### PR TITLE
Fix copy-frameworks script; missing quotes around environment variable

### DIFF
--- a/Scripts/copy-frameworks.sh
+++ b/Scripts/copy-frameworks.sh
@@ -20,7 +20,7 @@ fi
 for COUNTER in $(seq 0 $(($SCRIPT_INPUT_FILE_COUNT - 1))); do
     SCRIPT_INPUT_VAR="SCRIPT_INPUT_FILE_${COUNTER}"
     echo "Stripping binary file from framework path for ${!SCRIPT_INPUT_VAR}"
-    export ${SCRIPT_INPUT_VAR}=$(dirname "${!SCRIPT_INPUT_VAR}")
+    export ${SCRIPT_INPUT_VAR}="$(dirname "${!SCRIPT_INPUT_VAR}")"
 
     CARTHAGE_BUILD_FILE="${!SCRIPT_INPUT_VAR/${BUILT_PRODUCTS_DIR}/${CARTHAGE_BUILD_DIR}}"
     if [ -e "${CARTHAGE_BUILD_FILE}" ]; then


### PR DESCRIPTION
The script fails when archiving "Loop (Workspace)" scheme due to the space in the scheme name. The additional double quotes fixes the issue.