### PR TITLE
Added missing enum values for user notifiation info keys

### DIFF
--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -100,8 +100,8 @@ struct NotificationManager {
         }
 
         notification.userInfo = [
-            LoopNotificationUserInfoKey.rawValue: units,
-            LoopNotificationUserInfoKey.rawValue: startDate
+            LoopNotificationUserInfoKey.bolusAmount.rawValue: units,
+            LoopNotificationUserInfoKey.bolusStartDate.rawValue: startDate
         ]
 
         let request = UNNotificationRequest(


### PR DESCRIPTION
My last update to Loop was missing the actual enum values for the user notification info keys. This corrects that.
