### PR TITLE
[LOOP-918] Remove user-visible mentions of 'overrides'

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -823,22 +823,22 @@ final class StatusTableViewController: ChartsTableViewController {
                     case .preMeal, .legacyWorkout:
                         assertionFailure("Pre-meal and legacy workout modes should not produce status rows")
                     case .preset(let preset):
-                        cell.titleLabel.text = String(format: NSLocalizedString("%@ %@", comment: "The format for an active override preset. (1: preset symbol)(2: preset name)"), preset.symbol, preset.name)
+                        cell.titleLabel.text = String(format: NSLocalizedString("%@ %@", comment: "The format for an active custom preset. (1: preset symbol)(2: preset name)"), preset.symbol, preset.name)
                     case .custom:
-                        cell.titleLabel.text = NSLocalizedString("Custom Override", comment: "The title of the cell indicating a generic temporary override is enabled")
+                        cell.titleLabel.text = NSLocalizedString("Custom Preset", comment: "The title of the cell indicating a generic custom preset is enabled")
                     }
 
                     if override.isActive() {
                         switch override.duration {
                         case .finite:
                             let endTimeText = DateFormatter.localizedString(from: override.activeInterval.end, dateStyle: .none, timeStyle: .short)
-                            cell.subtitleLabel.text = String(format: NSLocalizedString("until %@", comment: "The format for the description of a temporary override end date"), endTimeText)
+                            cell.subtitleLabel.text = String(format: NSLocalizedString("until %@", comment: "The format for the description of a custom preset end date"), endTimeText)
                         case .indefinite:
                             cell.subtitleLabel.text = nil
                         }
                     } else {
                         let startTimeText = DateFormatter.localizedString(from: override.startDate, dateStyle: .none, timeStyle: .short)
-                        cell.subtitleLabel.text = String(format: NSLocalizedString("starting at %@", comment: "The format for the description of a temporary override start date"), startTimeText)
+                        cell.subtitleLabel.text = String(format: NSLocalizedString("starting at %@", comment: "The format for the description of a custom preset start date"), startTimeText)
                     }
 
                     cell.accessoryView = nil

--- a/WatchApp Extension/Controllers/ActionHUDController.swift
+++ b/WatchApp Extension/Controllers/ActionHUDController.swift
@@ -27,7 +27,7 @@ final class ActionHUDController: HUDInterfaceController {
     @IBOutlet var overrideButtonLabel: WKInterfaceLabel! {
         didSet {
             if FeatureFlags.sensitivityOverridesEnabled {
-                overrideButtonLabel.setText(NSLocalizedString("Override", comment: "The text for the Watch button for enabling a temporary override"))
+                overrideButtonLabel.setText(NSLocalizedString("Preset", comment: "The text for the Watch button for enabling a custom preset"))
             } else {
                 overrideButtonLabel.setText(NSLocalizedString("Workout", comment: "The text for the Watch button for enabling workout mode"))
             }


### PR DESCRIPTION
And update comments for localization. Overrides are not renamed at the code level.