### PR TITLE
Fix incorrect carb effect in bolus prediction

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -991,7 +991,7 @@ extension LoopDataManager {
                     let potentialCarbEffect = try carbStore.glucoseEffects(
                         of: [potentialCarbEntry],
                         startingAt: retrospectiveStart,
-                        effectVelocities: nil // ICE is irrelevant for future entries
+                        effectVelocities: settings.dynamicCarbAbsorptionEnabled ? insulinCounteractionEffects : nil
                     )
 
                     effects.append(potentialCarbEffect)


### PR DESCRIPTION
Fixes a bug where the prediction generated on the bolus screen fails to align with the actual prediction after the bolus is delivered.