### PR TITLE
LOOP-1163: Unit tests for the alert facility

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* Begin PBXBuildFile section */
 		1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift */; };
 		1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift */; };
+		1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */; };
 		1DB1065124467E18005542BD /* DeviceAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* DeviceAlertManager.swift */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */; };
@@ -566,6 +567,7 @@
 /* Begin PBXFileReference section */
 		1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertHandler.swift; sourceTree = "<group>"; };
 		1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertHandler.swift; sourceTree = "<group>"; };
+		1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertManagerTests.swift; sourceTree = "<group>"; };
 		1DB1065024467E18005542BD /* DeviceAlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertManager.swift; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryTableViewController.swift; sourceTree = "<group>"; };
@@ -1161,6 +1163,22 @@
 			path = DeviceAlert;
 			sourceTree = "<group>";
 		};
+		1DA7A83F24476E8C008257F0 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				1DA7A84024476E98008257F0 /* DeviceAlert */,
+			);
+			path = Managers;
+			sourceTree = "<group>";
+		};
+		1DA7A84024476E98008257F0 /* DeviceAlert */ = {
+			isa = PBXGroup;
+			children = (
+				1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */,
+			);
+			path = DeviceAlert;
+			sourceTree = "<group>";
+		};
 		4328E0121CFBE1B700E199AA /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1580,6 +1598,7 @@
 		43F78D2C1C8FC58F002152D1 /* LoopTests */ = {
 			isa = PBXGroup;
 			children = (
+				1DA7A83F24476E8C008257F0 /* Managers */,
 				43E2D90F1D20C581004DA55F /* Info.plist */,
 				7D2366E421250E0A0028B67D /* InfoPlist.strings */,
 				A9DAE7CF2332D77F006AE942 /* LoopTests.swift */,
@@ -2777,6 +2796,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8968B114240C55F10074BB48 /* LoopSettingsTests.swift in Sources */,
+				1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */,
 				A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */; };
 		1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */; };
 		1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */; };
+		1DA7A84424477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */; };
 		1DB1065124467E18005542BD /* DeviceAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* DeviceAlertManager.swift */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */; };
@@ -568,6 +569,7 @@
 		1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertPresenter.swift; sourceTree = "<group>"; };
 		1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenter.swift; sourceTree = "<group>"; };
 		1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertManagerTests.swift; sourceTree = "<group>"; };
+		1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenterTests.swift; sourceTree = "<group>"; };
 		1DB1065024467E18005542BD /* DeviceAlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertManager.swift; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryTableViewController.swift; sourceTree = "<group>"; };
@@ -1175,6 +1177,7 @@
 			isa = PBXGroup;
 			children = (
 				1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */,
+				1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */,
 			);
 			path = DeviceAlert;
 			sourceTree = "<group>";
@@ -2795,6 +2798,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1DA7A84424477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift in Sources */,
 				8968B114240C55F10074BB48 /* LoopSettingsTests.swift in Sources */,
 				1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */,
 				A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */,

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */; };
 		1DA7A84424477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */; };
 		1DB1065124467E18005542BD /* DeviceAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* DeviceAlertManager.swift */; };
+		1DFE9E172447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE9E162447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */; };
 		4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */; };
@@ -571,6 +572,7 @@
 		1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertManagerTests.swift; sourceTree = "<group>"; };
 		1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenterTests.swift; sourceTree = "<group>"; };
 		1DB1065024467E18005542BD /* DeviceAlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertManager.swift; sourceTree = "<group>"; };
+		1DFE9E162447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertPresenterTests.swift; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryTableViewController.swift; sourceTree = "<group>"; };
 		430B29892041F54A00BA9F93 /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
@@ -1178,6 +1180,7 @@
 			children = (
 				1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */,
 				1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */,
+				1DFE9E162447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift */,
 			);
 			path = DeviceAlert;
 			sourceTree = "<group>";
@@ -2802,6 +2805,7 @@
 				8968B114240C55F10074BB48 /* LoopSettingsTests.swift in Sources */,
 				1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */,
 				A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */,
+				1DFE9E172447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -22,8 +22,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift */; };
-		1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift */; };
+		1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */; };
+		1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */; };
 		1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */; };
 		1DB1065124467E18005542BD /* DeviceAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* DeviceAlertManager.swift */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
@@ -565,8 +565,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertHandler.swift; sourceTree = "<group>"; };
-		1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertHandler.swift; sourceTree = "<group>"; };
+		1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertPresenter.swift; sourceTree = "<group>"; };
+		1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenter.swift; sourceTree = "<group>"; };
 		1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertManagerTests.swift; sourceTree = "<group>"; };
 		1DB1065024467E18005542BD /* DeviceAlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertManager.swift; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
@@ -1157,8 +1157,8 @@
 			isa = PBXGroup;
 			children = (
 				1DB1065024467E18005542BD /* DeviceAlertManager.swift */,
-				1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift */,
-				1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift */,
+				1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */,
+				1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */,
 			);
 			path = DeviceAlert;
 			sourceTree = "<group>";
@@ -2551,13 +2551,13 @@
 				C1F8B243223E73FD00DD66CF /* BolusProgressTableViewCell.swift in Sources */,
 				89D6953E23B6DF8A002B3066 /* PotentialCarbEntryTableViewCell.swift in Sources */,
 				89CA2B30226C0161004D9350 /* DirectoryObserver.swift in Sources */,
-				1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertHandler.swift in Sources */,
+				1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift in Sources */,
 				439A7942211F631C0041B75F /* RootNavigationController.swift in Sources */,
 				4F11D3C020DCBEEC006E072C /* GlucoseBackfillRequestUserInfo.swift in Sources */,
 				43F5C2DB1B92A5E1003EB13D /* SettingsTableViewController.swift in Sources */,
 				89E267FC2292456700A3F2AF /* FeatureFlags.swift in Sources */,
 				43A567691C94880B00334FAC /* LoopDataManager.swift in Sources */,
-				1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertHandler.swift in Sources */,
+				1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift in Sources */,
 				43B260491ED248FB008CAA77 /* CarbEntryTableViewCell.swift in Sources */,
 				4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */,
 				43F64DD91D9C92C900D24DC6 /* TitleSubtitleTableViewCell.swift in Sources */,

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -139,7 +139,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             }
         case NotificationManager.Action.acknowledgeDeviceAlert.rawValue:
             let userInfo = response.notification.request.content.userInfo
-            if let alertTypeIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeId.rawValue] as? DeviceAlert.TypeIdentifier,
+            if let alertTypeIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeID.rawValue] as? DeviceAlert.TypeIdentifier,
                 let managerIdentifier = userInfo[LoopNotificationUserInfoKey.managerIDForAlert.rawValue] as? String {
                 deviceAlertManager.acknowledgeDeviceAlert(identifier:
                     DeviceAlert.Identifier(managerIdentifier: managerIdentifier, typeIdentifier: alertTypeIdentifier))

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -139,10 +139,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             }
         case NotificationManager.Action.acknowledgeDeviceAlert.rawValue:
             let userInfo = response.notification.request.content.userInfo
-            if let alertTypeIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeID.rawValue] as? DeviceAlert.TypeIdentifier,
+            if let alertIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeID.rawValue] as? DeviceAlert.AlertIdentifier,
                 let managerIdentifier = userInfo[LoopNotificationUserInfoKey.managerIDForAlert.rawValue] as? String {
                 deviceAlertManager.acknowledgeDeviceAlert(identifier:
-                    DeviceAlert.Identifier(managerIdentifier: managerIdentifier, typeIdentifier: alertTypeIdentifier))
+                    DeviceAlert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier))
             }
         default:
             break

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -137,7 +137,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 }
                 return
             }
-        case NotificationManager.Action.acknowledgeAlert.rawValue:
+        case NotificationManager.Action.acknowledgeDeviceAlert.rawValue:
             let userInfo = response.notification.request.content.userInfo
             if let alertTypeIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeId.rawValue] as? DeviceAlert.TypeIdentifier,
                 let managerIdentifier = userInfo[LoopNotificationUserInfoKey.managerIDForAlert.rawValue] as? String {

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -24,9 +24,11 @@ public final class DeviceAlertManager {
     var responders: [String: Weak<DeviceAlertResponder>] = [:]
     
     public init(rootViewController: UIViewController,
-                isAppInBackgroundFunc: @escaping () -> Bool) {
-        handlers = [UserNotificationDeviceAlertHandler(isAppInBackgroundFunc: isAppInBackgroundFunc),
-                    InAppModalDeviceAlertHandler(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
+                isAppInBackgroundFunc: @escaping () -> Bool,
+                handlers: [DeviceAlertHandler]? = nil) {
+        self.handlers = handlers ??
+            [UserNotificationDeviceAlertHandler(isAppInBackgroundFunc: isAppInBackgroundFunc),
+             InAppModalDeviceAlertHandler(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
     }
     
     public func addAlertResponder(key: String, alertResponder: DeviceAlertResponder) {

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -43,7 +43,7 @@ public final class DeviceAlertManager {
 extension DeviceAlertManager: DeviceAlertManagerResponder {
     func acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier) {
         if let responder = responders[identifier.managerIdentifier]?.value {
-            responder.acknowledgeAlert(typeIdentifier: identifier.typeIdentifier)
+            responder.acknowledgeAlert(alertIdentifier: identifier.alertIdentifier)
         }
     }
 }

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -20,15 +20,15 @@ protocol DeviceAlertManagerResponder: class {
 /// - etc.
 public final class DeviceAlertManager {
 
-    var handlers: [DeviceAlertHandler] = []
+    var handlers: [DeviceAlertPresenter] = []
     var responders: [String: Weak<DeviceAlertResponder>] = [:]
     
     public init(rootViewController: UIViewController,
                 isAppInBackgroundFunc: @escaping () -> Bool,
-                handlers: [DeviceAlertHandler]? = nil) {
+                handlers: [DeviceAlertPresenter]? = nil) {
         self.handlers = handlers ??
-            [UserNotificationDeviceAlertHandler(isAppInBackgroundFunc: isAppInBackgroundFunc),
-             InAppModalDeviceAlertHandler(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
+            [UserNotificationDeviceAlertPresenter(isAppInBackgroundFunc: isAppInBackgroundFunc),
+             InAppModalDeviceAlertPresenter(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
     }
     
     public func addAlertResponder(key: String, alertResponder: DeviceAlertResponder) {
@@ -48,7 +48,7 @@ extension DeviceAlertManager: DeviceAlertManagerResponder {
     }
 }
 
-extension DeviceAlertManager: DeviceAlertHandler {
+extension DeviceAlertManager: DeviceAlertPresenter {
 
     public func issueAlert(_ alert: DeviceAlert) {
         handlers.forEach { $0.issueAlert(alert) }

--- a/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
@@ -10,16 +10,29 @@ import Foundation
 import LoopKit
 
 public class InAppModalDeviceAlertPresenter: DeviceAlertPresenter {
-    
+
     private weak var rootViewController: UIViewController?
     private weak var deviceAlertManagerResponder: DeviceAlertManagerResponder?
-    
+
     private var alertsShowing: [DeviceAlert.Identifier: (UIAlertController, DeviceAlert)] = [:]
     private var alertsPending: [DeviceAlert.Identifier: (Timer, DeviceAlert)] = [:]
+
+    typealias ActionFactoryFunction = (String?, UIAlertAction.Style, ((UIAlertAction) -> Void)?) -> UIAlertAction
+    private let newActionFunc: ActionFactoryFunction
     
-    init(rootViewController: UIViewController, deviceAlertManagerResponder: DeviceAlertManagerResponder) {
+    typealias TimerFactoryFunction = (TimeInterval, Bool, (() -> Void)?) -> Timer
+    private let newTimerFunc: TimerFactoryFunction
+
+    init(rootViewController: UIViewController,
+         deviceAlertManagerResponder: DeviceAlertManagerResponder,
+         newActionFunc: @escaping ActionFactoryFunction = UIAlertAction.init,
+         newTimerFunc: TimerFactoryFunction? = nil) {
         self.rootViewController = rootViewController
         self.deviceAlertManagerResponder = deviceAlertManagerResponder
+        self.newActionFunc = newActionFunc
+        self.newTimerFunc = newTimerFunc ?? { timeInterval, repeats, block in
+            return Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: repeats) { _ in block?() }
+        }
     }
         
     public func issueAlert(_ alert: DeviceAlert) {
@@ -41,8 +54,13 @@ public class InAppModalDeviceAlertPresenter: DeviceAlertPresenter {
     }
     
     public func removeDeliveredAlert(identifier: DeviceAlert.Identifier) {
+        removeDeliveredAlert(identifier: identifier, completion: nil)
+    }
+    
+    // For tests only
+    func removeDeliveredAlert(identifier: DeviceAlert.Identifier, completion: (() -> Void)?) {
         DispatchQueue.main.async {
-            self.alertsShowing[identifier]?.0.dismiss(animated: true)
+            self.alertsShowing[identifier]?.0.dismiss(animated: true, completion: completion)
             self.clearDeliveredAlert(identifier: identifier)
         }
     }
@@ -59,7 +77,7 @@ extension InAppModalDeviceAlertPresenter {
             if self.isAlertPending(identifier: alert.identifier) {
                 return
             }
-            let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: repeats) { [weak self] timer in
+            let timer = self.newTimerFunc(interval, repeats) { [weak self] in
                 self?.show(alert: alert)
                 if !repeats {
                     self?.clearPendingAlert(identifier: alert.identifier)
@@ -119,7 +137,7 @@ extension InAppModalDeviceAlertPresenter {
         dispatchPrecondition(condition: .onQueue(.main))
         // For now, this is a simple alert with an "OK" button
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: action, style: .default, handler: { _ in completion() }))
+        alertController.addAction(newActionFunc(action, .default, { _ in completion() }))
         topViewController(controller: rootViewController)?.present(alertController, animated: true)
         return alertController
     }

--- a/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
@@ -1,5 +1,5 @@
 //
-//  InAppUserAlertHandler.swift
+//  InAppModalDeviceAlertPresenter.swift
 //  LoopKit
 //
 //  Created by Rick Pasetto on 4/9/20.
@@ -9,7 +9,7 @@
 import Foundation
 import LoopKit
 
-public class InAppModalDeviceAlertHandler: DeviceAlertHandler {
+public class InAppModalDeviceAlertPresenter: DeviceAlertPresenter {
     
     private weak var rootViewController: UIViewController?
     private weak var deviceAlertManagerResponder: DeviceAlertManagerResponder?
@@ -49,7 +49,7 @@ public class InAppModalDeviceAlertHandler: DeviceAlertHandler {
 }
 
 /// Private functions
-extension InAppModalDeviceAlertHandler {
+extension InAppModalDeviceAlertPresenter {
         
     private func schedule(alert: DeviceAlert, interval: TimeInterval, repeats: Bool) {
         guard alert.foregroundContent != nil else {

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -81,7 +81,7 @@ public extension DeviceAlert {
         userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
         userNotificationContent.userInfo = [
             LoopNotificationUserInfoKey.managerIDForAlert.rawValue: identifier.managerIdentifier,
-            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.typeIdentifier
+            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier
         ]
         return userNotificationContent
     }

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -81,7 +81,7 @@ public extension DeviceAlert {
         userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
         userNotificationContent.userInfo = [
             LoopNotificationUserInfoKey.managerIDForAlert.rawValue: identifier.managerIdentifier,
-            LoopNotificationUserInfoKey.alertTypeId.rawValue: identifier.typeIdentifier
+            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.typeIdentifier
         ]
         return userNotificationContent
     }

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -9,7 +9,7 @@
 import LoopKit
 import UserNotifications
 
-class UserNotificationDeviceAlertHandler: DeviceAlertHandler {
+class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     
     let alertInBackgroundOnly: Bool
     let isAppInBackgroundFunc: () -> Bool

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -9,22 +9,35 @@
 import LoopKit
 import UserNotifications
 
+protocol UserNotificationCenter {
+    func add(_ request: UNNotificationRequest, withCompletionHandler: ((Error?) -> Void)?)
+    func removePendingNotificationRequests(withIdentifiers: [String])
+    func removeDeliveredNotifications(withIdentifiers: [String])
+}
+
+extension UNUserNotificationCenter: UserNotificationCenter {}
+
 class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     
-    let alertInBackgroundOnly: Bool
+    let alertInBackgroundOnly = true
     let isAppInBackgroundFunc: () -> Bool
-    let userNotificationCenter: UNUserNotificationCenter = UNUserNotificationCenter.current()
+    let userNotificationCenter: UserNotificationCenter
     
-    init(alertInBackgroundOnly: Bool = true, isAppInBackgroundFunc: @escaping () -> Bool) {
-        self.alertInBackgroundOnly = alertInBackgroundOnly
+    init(isAppInBackgroundFunc: @escaping () -> Bool,
+         userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()) {
         self.isAppInBackgroundFunc = isAppInBackgroundFunc
+        self.userNotificationCenter = userNotificationCenter
     }
         
     func issueAlert(_ alert: DeviceAlert) {
         DispatchQueue.main.async {
             if self.alertInBackgroundOnly && self.isAppInBackgroundFunc() || !self.alertInBackgroundOnly {
                 if let request = alert.asUserNotificationRequest() {
-                    self.userNotificationCenter.add(request)
+                    self.userNotificationCenter.add(request) { error in
+                        if let error = error {
+                            print("Something went wrong posting the user notification: \(error)")
+                        }
+                    }
                     // For now, UserNotifications do not not acknowledge...not yet at least
                 }
             }
@@ -32,11 +45,15 @@ class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     }
     
     func removePendingAlert(identifier: DeviceAlert.Identifier) {
-        userNotificationCenter.removePendingNotificationRequests(withIdentifiers: [identifier.value])
+        DispatchQueue.main.async {
+            self.userNotificationCenter.removePendingNotificationRequests(withIdentifiers: [identifier.value])
+        }
     }
     
     func removeDeliveredAlert(identifier: DeviceAlert.Identifier) {
-        userNotificationCenter.removeDeliveredNotifications(withIdentifiers: [identifier.value])
+        DispatchQueue.main.async {
+            self.userNotificationCenter.removeDeliveredNotifications(withIdentifiers: [identifier.value])
+        }
     }
 }
 

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -1,5 +1,5 @@
 //
-//  UserNotificationAlertHandler.swift
+//  UserNotificationDeviceAlertPresenter.swift
 //  LoopKit
 //
 //  Created by Rick Pasetto on 4/9/20.

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -369,7 +369,7 @@ extension DeviceDataManager {
 
 // MARK: - DeviceManagerDelegate
 extension DeviceDataManager: DeviceManagerDelegate {
-//    #if !USE_NEW_ALERT_FACILITY
+//    #if TO BE REMOVED
     func scheduleNotification(for manager: DeviceManager,
                               identifier: String,
                               content: UNNotificationContent,

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -398,7 +398,7 @@ extension DeviceDataManager: DeviceManagerDelegate {
 }
 
 // MARK: - UserAlertHandler
-extension DeviceDataManager: DeviceAlertHandler {
+extension DeviceDataManager: DeviceAlertPresenter {
 
     func issueAlert(_ alert: DeviceAlert) {
         deviceAlertManager?.issueAlert(alert)

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -369,7 +369,7 @@ extension DeviceDataManager {
 
 // MARK: - DeviceManagerDelegate
 extension DeviceDataManager: DeviceManagerDelegate {
-    #if !USE_NEW_ALERT_FACILITY
+//    #if !USE_NEW_ALERT_FACILITY
     func scheduleNotification(for manager: DeviceManager,
                               identifier: String,
                               content: UNNotificationContent,
@@ -390,7 +390,7 @@ extension DeviceDataManager: DeviceManagerDelegate {
     func removeNotificationRequests(for manager: DeviceManager, identifiers: [String]) {
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: identifiers)
     }
-    #endif
+//    #endif
     
     func deviceManager(_ manager: DeviceManager, logEventForDeviceIdentifier deviceIdentifier: String?, type: DeviceLogEntryType, message: String, completion: ((Error?) -> Void)?) {
         deviceLog.log(managerIdentifier: Swift.type(of: manager).managerIdentifier, deviceIdentifier: deviceIdentifier, type: type, message: message, completion: completion)

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -14,7 +14,7 @@ struct NotificationManager {
 
     enum Action: String {
         case retryBolus
-        case acknowledgeAlert
+        case acknowledgeDeviceAlert
     }
 
     private static var notificationCategories: Set<UNNotificationCategory> {
@@ -33,15 +33,15 @@ struct NotificationManager {
             options: []
         ))
         
-        let acknowledgeAlertAction = UNNotificationAction(
-            identifier: Action.acknowledgeAlert.rawValue,
+        let acknowledgeDeviceAlertAction = UNNotificationAction(
+            identifier: Action.acknowledgeDeviceAlert.rawValue,
             title: NSLocalizedString("OK", comment: "The title of the notification action to acknowledge a device alert"),
             options: [.foreground]
         )
         
         categories.append(UNNotificationCategory(
             identifier: LoopNotificationCategory.alert.rawValue,
-            actions: [acknowledgeAlertAction],
+            actions: [acknowledgeDeviceAlertAction],
             intentIdentifiers: [],
             options: [.customDismissAction]
         ))

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -36,14 +36,14 @@ struct NotificationManager {
         let acknowledgeDeviceAlertAction = UNNotificationAction(
             identifier: Action.acknowledgeDeviceAlert.rawValue,
             title: NSLocalizedString("OK", comment: "The title of the notification action to acknowledge a device alert"),
-            options: [.foreground]
+            options: .foreground
         )
         
         categories.append(UNNotificationCategory(
             identifier: LoopNotificationCategory.alert.rawValue,
             actions: [acknowledgeDeviceAlertAction],
             intentIdentifiers: [],
-            options: [.customDismissAction]
+            options: .customDismissAction
         ))
 
         return Set(categories)

--- a/LoopTests/LoopTests.swift
+++ b/LoopTests/LoopTests.swift
@@ -11,3 +11,15 @@ import XCTest
 @testable import Loop
 
 class LoopTests: XCTestCase {}
+
+extension XCTestCase {
+    
+    func waitOnMain() {
+        let exp = expectation(description: "waitOnMain")
+        DispatchQueue.main.async {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+}

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -1,0 +1,100 @@
+//
+//  DeviceAlertManagerTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 4/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+import XCTest
+@testable import Loop
+
+class DeviceAlertManagerTests: XCTestCase {
+    
+    class MockHandler: DeviceAlertHandler {
+        var issuedAlert: DeviceAlert?
+        func issueAlert(_ alert: DeviceAlert) {
+            issuedAlert = alert
+        }
+        var removedPendingAlertIdentifier: DeviceAlert.Identifier?
+        func removePendingAlert(identifier: DeviceAlert.Identifier) {
+            removedPendingAlertIdentifier = identifier
+        }
+        var removeDeliveredAlertIdentifier: DeviceAlert.Identifier?
+        func removeDeliveredAlert(identifier: DeviceAlert.Identifier) {
+            removeDeliveredAlertIdentifier = identifier
+        }
+    }
+    
+    class MockResponder: DeviceAlertResponder {
+        var acknowledged: [DeviceAlert.TypeIdentifier: Bool] = [:]
+        func acknowledgeAlert(typeIdentifier: DeviceAlert.TypeIdentifier) {
+            acknowledged[typeIdentifier] = true
+        }
+    }
+    
+    static let mockManagerIdentifier = "mockManagerIdentifier"
+    static let mockTypeIdentifier = "mockTypeIdentifier"
+    let mockDeviceAlert = DeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: mockManagerIdentifier, typeIdentifier: mockTypeIdentifier), foregroundContent: nil, backgroundContent: nil, trigger: .immediate)
+    
+    var mockHandler: MockHandler!
+    var deviceAlertManager: DeviceAlertManager!
+    var isInBackground = true
+    
+    override func setUp() {
+        mockHandler = MockHandler()
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),                                              isAppInBackgroundFunc: { return self.isInBackground },
+                                                handlers: [mockHandler])
+    }
+    
+    func testIssueAlertOnHandlerCalled() {
+        deviceAlertManager.issueAlert(mockDeviceAlert)
+        XCTAssertEqual(mockDeviceAlert.identifier, mockHandler.issuedAlert?.identifier)
+        XCTAssertNil(mockHandler.removeDeliveredAlertIdentifier)
+        XCTAssertNil(mockHandler.removedPendingAlertIdentifier)
+    }
+    
+    func testRemovePendingAlertOnHandlerCalled() {
+        deviceAlertManager.removePendingAlert(identifier: mockDeviceAlert.identifier)
+        XCTAssertNil(mockHandler.issuedAlert)
+        XCTAssertEqual(mockDeviceAlert.identifier, mockHandler.removedPendingAlertIdentifier)
+        XCTAssertNil(mockHandler.removeDeliveredAlertIdentifier)
+    }
+    
+    func testRemoveDeliveredAlertOnHandlerCalled() {
+        deviceAlertManager.removeDeliveredAlert(identifier: mockDeviceAlert.identifier)
+        XCTAssertNil(mockHandler.issuedAlert)
+        XCTAssertNil(mockHandler.removedPendingAlertIdentifier)
+        XCTAssertEqual(mockDeviceAlert.identifier, mockHandler.removeDeliveredAlertIdentifier)
+    }
+
+    func testAlertResponderAcknowledged() {
+        let responder = MockResponder()
+        deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
+        XCTAssertTrue(responder.acknowledged.isEmpty)
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, typeIdentifier: Self.mockTypeIdentifier))
+        XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
+    }
+    
+    func testAlertResponderNotAcknowledgedIfWrongManagerIdentifier() {
+        let responder = MockResponder()
+        deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
+        XCTAssertTrue(responder.acknowledged.isEmpty)
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: Self.mockTypeIdentifier))
+        XCTAssertTrue(responder.acknowledged.isEmpty)
+    }
+    
+    func testRemovedAlertResponderDoesntAcknowledge() {
+        let responder = MockResponder()
+        deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
+        XCTAssertTrue(responder.acknowledged.isEmpty)
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, typeIdentifier: Self.mockTypeIdentifier))
+        XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
+        
+        responder.acknowledged[DeviceAlertManagerTests.mockTypeIdentifier] = false
+        deviceAlertManager.removeAlertResponder(key: DeviceAlertManagerTests.mockManagerIdentifier)
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, typeIdentifier: Self.mockTypeIdentifier))
+        XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == false)
+    }
+}

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class DeviceAlertManagerTests: XCTestCase {
     
-    class MockHandler: DeviceAlertPresenter {
+    class MockPresenter: DeviceAlertPresenter {
         var issuedAlert: DeviceAlert?
         func issueAlert(_ alert: DeviceAlert) {
             issuedAlert = alert
@@ -38,36 +38,36 @@ class DeviceAlertManagerTests: XCTestCase {
     static let mockTypeIdentifier = "mockTypeIdentifier"
     let mockDeviceAlert = DeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: mockManagerIdentifier, alertIdentifier: mockTypeIdentifier), foregroundContent: nil, backgroundContent: nil, trigger: .immediate)
     
-    var mockHandler: MockHandler!
+    var mockPresenter: MockPresenter!
     var deviceAlertManager: DeviceAlertManager!
     var isInBackground = true
     
     override func setUp() {
-        mockHandler = MockHandler()
+        mockPresenter = MockPresenter()
         deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
                                                 isAppInBackgroundFunc: { return self.isInBackground },
-                                                handlers: [mockHandler])
+                                                handlers: [mockPresenter])
     }
     
     func testIssueAlertOnHandlerCalled() {
         deviceAlertManager.issueAlert(mockDeviceAlert)
-        XCTAssertEqual(mockDeviceAlert.identifier, mockHandler.issuedAlert?.identifier)
-        XCTAssertNil(mockHandler.removeDeliveredAlertIdentifier)
-        XCTAssertNil(mockHandler.removedPendingAlertIdentifier)
+        XCTAssertEqual(mockDeviceAlert.identifier, mockPresenter.issuedAlert?.identifier)
+        XCTAssertNil(mockPresenter.removeDeliveredAlertIdentifier)
+        XCTAssertNil(mockPresenter.removedPendingAlertIdentifier)
     }
     
     func testRemovePendingAlertOnHandlerCalled() {
         deviceAlertManager.removePendingAlert(identifier: mockDeviceAlert.identifier)
-        XCTAssertNil(mockHandler.issuedAlert)
-        XCTAssertEqual(mockDeviceAlert.identifier, mockHandler.removedPendingAlertIdentifier)
-        XCTAssertNil(mockHandler.removeDeliveredAlertIdentifier)
+        XCTAssertNil(mockPresenter.issuedAlert)
+        XCTAssertEqual(mockDeviceAlert.identifier, mockPresenter.removedPendingAlertIdentifier)
+        XCTAssertNil(mockPresenter.removeDeliveredAlertIdentifier)
     }
     
     func testRemoveDeliveredAlertOnHandlerCalled() {
         deviceAlertManager.removeDeliveredAlert(identifier: mockDeviceAlert.identifier)
-        XCTAssertNil(mockHandler.issuedAlert)
-        XCTAssertNil(mockHandler.removedPendingAlertIdentifier)
-        XCTAssertEqual(mockDeviceAlert.identifier, mockHandler.removeDeliveredAlertIdentifier)
+        XCTAssertNil(mockPresenter.issuedAlert)
+        XCTAssertNil(mockPresenter.removedPendingAlertIdentifier)
+        XCTAssertEqual(mockDeviceAlert.identifier, mockPresenter.removeDeliveredAlertIdentifier)
     }
 
     func testAlertResponderAcknowledged() {

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -28,15 +28,15 @@ class DeviceAlertManagerTests: XCTestCase {
     }
     
     class MockResponder: DeviceAlertResponder {
-        var acknowledged: [DeviceAlert.TypeIdentifier: Bool] = [:]
-        func acknowledgeAlert(typeIdentifier: DeviceAlert.TypeIdentifier) {
-            acknowledged[typeIdentifier] = true
+        var acknowledged: [DeviceAlert.AlertIdentifier: Bool] = [:]
+        func acknowledgeAlert(alertIdentifier: DeviceAlert.AlertIdentifier) {
+            acknowledged[alertIdentifier] = true
         }
     }
     
     static let mockManagerIdentifier = "mockManagerIdentifier"
     static let mockTypeIdentifier = "mockTypeIdentifier"
-    let mockDeviceAlert = DeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: mockManagerIdentifier, typeIdentifier: mockTypeIdentifier), foregroundContent: nil, backgroundContent: nil, trigger: .immediate)
+    let mockDeviceAlert = DeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: mockManagerIdentifier, alertIdentifier: mockTypeIdentifier), foregroundContent: nil, backgroundContent: nil, trigger: .immediate)
     
     var mockHandler: MockHandler!
     var deviceAlertManager: DeviceAlertManager!
@@ -74,7 +74,7 @@ class DeviceAlertManagerTests: XCTestCase {
         let responder = MockResponder()
         deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, typeIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
     }
     
@@ -82,7 +82,7 @@ class DeviceAlertManagerTests: XCTestCase {
         let responder = MockResponder()
         deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: "foo", alertIdentifier: Self.mockTypeIdentifier))
         XCTAssertTrue(responder.acknowledged.isEmpty)
     }
     
@@ -90,12 +90,12 @@ class DeviceAlertManagerTests: XCTestCase {
         let responder = MockResponder()
         deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, typeIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
         
         responder.acknowledged[DeviceAlertManagerTests.mockTypeIdentifier] = false
         deviceAlertManager.removeAlertResponder(key: DeviceAlertManagerTests.mockManagerIdentifier)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, typeIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == false)
     }
 }

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class DeviceAlertManagerTests: XCTestCase {
     
-    class MockHandler: DeviceAlertHandler {
+    class MockHandler: DeviceAlertPresenter {
         var issuedAlert: DeviceAlert?
         func issueAlert(_ alert: DeviceAlert) {
             issuedAlert = alert
@@ -44,7 +44,8 @@ class DeviceAlertManagerTests: XCTestCase {
     
     override func setUp() {
         mockHandler = MockHandler()
-        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),                                              isAppInBackgroundFunc: { return self.isInBackground },
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
+                                                isAppInBackgroundFunc: { return self.isInBackground },
                                                 handlers: [mockHandler])
     }
     

--- a/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
@@ -11,7 +11,28 @@ import XCTest
 @testable import Loop
 
 class InAppModalDeviceAlertPresenterTests: XCTestCase {
-
+    
+    class MockAlertAction: UIAlertAction {
+        typealias Handler = ((UIAlertAction) -> Void)
+        var handler: Handler?
+        var mockTitle: String?
+        var mockStyle: Style
+        convenience init(title: String?, style: Style, handler: Handler?) {
+            self.init()
+            
+            mockTitle = title
+            mockStyle = style
+            self.handler = handler
+        }
+        override init() {
+          mockStyle = .default
+          super.init()
+        }
+        func callHandler() {
+            handler?(self)
+        }
+    }
+    
     class MockAlertManagerResponder: DeviceAlertManagerResponder {
         var identifierAcknowledged: DeviceAlert.Identifier?
         func acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier) {
@@ -21,15 +42,28 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     
     class MockViewController: UIViewController {
         var viewControllerPresented: UIViewController?
+        var autoComplete = true
+        var completion: (() -> Void)?
         override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
             viewControllerPresented = viewControllerToPresent
+            if autoComplete {
+                completion?()
+            } else {
+                self.completion = completion
+            }
+        }
+        func callCompletion() {
             completion?()
         }
     }
-
-    let mockIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: "bar")
-    let mockForegroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
-    let mockBackgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+    
+    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: "bar")
+    let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
+    let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+    
+    var mockTimer: Timer?
+    var mockTimerTimeInterval: TimeInterval?
+    var mockTimerRepeats: Bool?
     var mockAlertManagerResponder: MockAlertManagerResponder!
     var mockViewController: MockViewController!
     var inAppModalDeviceAlertPresenter: InAppModalDeviceAlertPresenter!
@@ -37,25 +71,162 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     override func setUp() {
         mockAlertManagerResponder = MockAlertManagerResponder()
         mockViewController = MockViewController()
-        inAppModalDeviceAlertPresenter = InAppModalDeviceAlertPresenter(rootViewController: mockViewController, deviceAlertManagerResponder: mockAlertManagerResponder)
-    }
-
-    func testIssueImmediateAlert() {
-        let alert = DeviceAlert(identifier: mockIdentifier, foregroundContent: mockForegroundContent, backgroundContent: mockBackgroundContent, trigger: .immediate)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
-        waitOnMain {
-            let alertController = mockViewController.viewControllerPresented as? UIAlertController
-            XCTAssertNotNil(alertController)
-            XCTAssertEqual("FOREGROUND", alertController?.title)
+        
+        let newTimerFunc: InAppModalDeviceAlertPresenter.TimerFactoryFunction = { timeInterval, repeats, block in
+            let timer = Timer(timeInterval: timeInterval, repeats: repeats) { _ in block?() }
+            self.mockTimer = timer
+            self.mockTimerTimeInterval = timeInterval
+            self.mockTimerRepeats = repeats
+            return timer
         }
+        inAppModalDeviceAlertPresenter =
+            InAppModalDeviceAlertPresenter(rootViewController: mockViewController,
+                                           deviceAlertManagerResponder: mockAlertManagerResponder,
+                                           newActionFunc: MockAlertAction.init,
+                                           newTimerFunc: newTimerFunc)
     }
     
-    func waitOnMain(completion: ()->Void) {
+    func testIssueImmediateAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        let alertController = mockViewController.viewControllerPresented as? UIAlertController
+        XCTAssertNotNil(alertController)
+        XCTAssertEqual("FOREGROUND", alertController?.title)
+    }
+    
+    func testRemoveImmediateAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        var dismissed = false
+        inAppModalDeviceAlertPresenter.removeDeliveredAlert(identifier: alert.identifier) {
+            dismissed = true
+        }
+        
+        waitOnMain()
+        let alertController = mockViewController.viewControllerPresented as? UIAlertController
+        XCTAssertNotNil(alertController)
+        XCTAssertTrue(dismissed)
+    }
+    
+    func testIssueImmediateAlertTwiceOnlyOneShows() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger:
+            .immediate)
+        mockViewController.autoComplete = false
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        mockViewController.viewControllerPresented = nil
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        XCTAssertNil(mockViewController.viewControllerPresented)
+    }
+    
+    func testIssueImmediateAlertWithoutForegroundContentDoesNothing() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        XCTAssertNil(mockViewController.viewControllerPresented)
+    }
+    
+    func testIssueImmediateAlertAcknowledgement() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        waitOnMain()
+        let action = (mockViewController.viewControllerPresented as? UIAlertController)?.actions[0] as? MockAlertAction
+        XCTAssertNotNil(action)
+        XCTAssertNil(mockAlertManagerResponder.identifierAcknowledged)
+        action?.callHandler()
+        XCTAssertEqual(alertIdentifier, mockAlertManagerResponder.identifierAcknowledged)
+    }
+    
+    func testIssueDelayedAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        mockViewController.autoComplete = false
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+            
+        waitOnMain()
+        // Timer should be created but won't fire yet
+        XCTAssertNil(mockViewController.viewControllerPresented)
+        XCTAssertNotNil(mockTimer)
+        XCTAssertEqual(0.1, mockTimerTimeInterval)
+        XCTAssert(mockTimerRepeats == false)
+        mockTimer?.fire()
+        
+        waitOnMain()
+        let alertController = mockViewController.viewControllerPresented as? UIAlertController
+        XCTAssertNotNil(alertController)
+        XCTAssertEqual("FOREGROUND", alertController?.title)
+    }
+    
+    func testIssueDelayedAlertTwiceOnlyOneWorks() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        mockViewController.autoComplete = false
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+            
+        waitOnMain()
+        guard let firstTimer = mockTimer else { XCTFail(); return }
+        mockTimer = nil
+        // This should not schedule another timer
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        
+        waitOnMain()
+        XCTAssertNil(mockTimer)
+        XCTAssertNil(mockViewController.viewControllerPresented)
+        firstTimer.fire()
+        
+        waitOnMain()
+        XCTAssertNil(mockTimer)
+        XCTAssertNotNil(mockViewController.viewControllerPresented)
+    }
+    
+    func testIssueDelayedAlertWithoutForegroundContentDoesNothing() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        XCTAssertNil(mockViewController.viewControllerPresented)
+    }
+
+    func testRemovePendingAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        
+        waitOnMain()
+        XCTAssert(mockTimer?.isValid == true)
+        inAppModalDeviceAlertPresenter.removePendingAlert(identifier: alert.identifier)
+        
+        waitOnMain()
+        XCTAssert(mockTimer?.isValid == false)
+    }
+
+    func testIssueRepeatingAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 0.1))
+        mockViewController.autoComplete = false
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+            
+        waitOnMain()
+        // Timer should be created but won't fire yet
+        XCTAssertNil(mockViewController.viewControllerPresented)
+        XCTAssertNotNil(mockTimer)
+        XCTAssertEqual(0.1, mockTimerTimeInterval)
+        XCTAssert(mockTimerRepeats == true)
+        mockTimer?.fire()
+        
+        waitOnMain()
+        let alertController = mockViewController.viewControllerPresented as? UIAlertController
+        XCTAssertNotNil(alertController)
+        XCTAssertEqual("FOREGROUND", alertController?.title)
+    }
+    
+    func waitOnMain() {
         let exp = expectation(description: "waitOnMain")
         DispatchQueue.main.async {
             exp.fulfill()
         }
         wait(for: [exp], timeout: 1.0)
-        completion()
     }
 }

--- a/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
@@ -57,7 +57,7 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
         }
     }
     
-    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: "bar")
+    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
     let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
     let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
     

--- a/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
@@ -221,12 +221,4 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
         XCTAssertNotNil(alertController)
         XCTAssertEqual("FOREGROUND", alertController?.title)
     }
-    
-    func waitOnMain() {
-        let exp = expectation(description: "waitOnMain")
-        DispatchQueue.main.async {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
-    }
 }

--- a/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
@@ -1,0 +1,61 @@
+//
+//  InAppModalDeviceAlertPresenterTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 4/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+import XCTest
+@testable import Loop
+
+class InAppModalDeviceAlertPresenterTests: XCTestCase {
+
+    class MockAlertManagerResponder: DeviceAlertManagerResponder {
+        var identifierAcknowledged: DeviceAlert.Identifier?
+        func acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier) {
+            identifierAcknowledged = identifier
+        }
+    }
+    
+    class MockViewController: UIViewController {
+        var viewControllerPresented: UIViewController?
+        override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+            viewControllerPresented = viewControllerToPresent
+            completion?()
+        }
+    }
+
+    let mockIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: "bar")
+    let mockForegroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
+    let mockBackgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+    var mockAlertManagerResponder: MockAlertManagerResponder!
+    var mockViewController: MockViewController!
+    var inAppModalDeviceAlertPresenter: InAppModalDeviceAlertPresenter!
+    
+    override func setUp() {
+        mockAlertManagerResponder = MockAlertManagerResponder()
+        mockViewController = MockViewController()
+        inAppModalDeviceAlertPresenter = InAppModalDeviceAlertPresenter(rootViewController: mockViewController, deviceAlertManagerResponder: mockAlertManagerResponder)
+    }
+
+    func testIssueImmediateAlert() {
+        let alert = DeviceAlert(identifier: mockIdentifier, foregroundContent: mockForegroundContent, backgroundContent: mockBackgroundContent, trigger: .immediate)
+        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        waitOnMain {
+            let alertController = mockViewController.viewControllerPresented as? UIAlertController
+            XCTAssertNotNil(alertController)
+            XCTAssertEqual("FOREGROUND", alertController?.title)
+        }
+    }
+    
+    func waitOnMain(completion: ()->Void) {
+        let exp = expectation(description: "waitOnMain")
+        DispatchQueue.main.async {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+        completion()
+    }
+}

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -1,0 +1,196 @@
+//
+//  UserNotificationDeviceAlertPresenterTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 4/15/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+import XCTest
+@testable import Loop
+
+class UserNotificationDeviceAlertPresenterTests: XCTestCase {
+
+    class MockUserNotificationCenter: UserNotificationCenter {
+        
+        var pendingRequests = [UNNotificationRequest]()
+        var deliveredRequests = [UNNotificationRequest]()
+                
+        func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)? = nil) {
+            pendingRequests.append(request)
+        }
+        
+        func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+            identifiers.forEach { identifier in
+                pendingRequests.removeAll { $0.identifier == identifier }
+            }
+        }
+
+        func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+            identifiers.forEach { identifier in
+                deliveredRequests.removeAll { $0.identifier == identifier }
+            }
+        }
+        
+        func deliverAll() {
+            deliveredRequests = pendingRequests
+            pendingRequests = []
+        }
+    }
+    
+    var userNotificationDeviceAlertPresenter: UserNotificationDeviceAlertPresenter!
+    var isInBackground = true
+    
+    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: "bar")
+    let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
+    let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+
+    var mockUserNotificationCenter: MockUserNotificationCenter!
+    
+    override func setUp() {
+        mockUserNotificationCenter = MockUserNotificationCenter()
+        
+        isInBackground = true
+        userNotificationDeviceAlertPresenter =
+            UserNotificationDeviceAlertPresenter(isAppInBackgroundFunc: { return self.isInBackground },
+                                                 userNotificationCenter: mockUserNotificationCenter)
+    }
+
+    func testIssueImmediateAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        
+        XCTAssertEqual(1, mockUserNotificationCenter.pendingRequests.count)
+        if let request = mockUserNotificationCenter.pendingRequests.first {
+            XCTAssertEqual(self.backgroundContent.title, request.content.title)
+            XCTAssertEqual(self.backgroundContent.body, request.content.body)
+            XCTAssertEqual(UNNotificationSound.default, request.content.sound)
+            XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
+            XCTAssertEqual([
+                LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
+                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+            ], request.content.userInfo as? [String: String])
+            XCTAssertNil(request.trigger)
+        }
+    }
+    
+    func testIssueImmediateCriticalAlert() {
+        let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", isCritical: true)
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        
+        XCTAssertEqual(1, mockUserNotificationCenter.pendingRequests.count)
+        if let request = mockUserNotificationCenter.pendingRequests.first {
+            XCTAssertEqual(self.backgroundContent.title, request.content.title)
+            XCTAssertEqual(self.backgroundContent.body, request.content.body)
+            XCTAssertEqual(UNNotificationSound.defaultCritical, request.content.sound)
+            XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
+            XCTAssertEqual([
+                LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
+                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+            ], request.content.userInfo as? [String: String])
+            XCTAssertNil(request.trigger)
+        }
+    }
+    
+    func testIssueDelayedAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        
+        XCTAssertEqual(1, mockUserNotificationCenter.pendingRequests.count)
+        if let request = mockUserNotificationCenter.pendingRequests.first {
+            XCTAssertEqual(self.backgroundContent.title, request.content.title)
+            XCTAssertEqual(self.backgroundContent.body, request.content.body)
+            XCTAssertEqual(UNNotificationSound.default, request.content.sound)
+            XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
+            XCTAssertEqual([
+                LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
+                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+            ], request.content.userInfo as? [String: String])
+            XCTAssertEqual(0.1, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
+            XCTAssertEqual(false, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
+        }
+    }
+    
+    func testIssueRepeatingAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 100))
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        
+        XCTAssertEqual(1, mockUserNotificationCenter.pendingRequests.count)
+        if let request = mockUserNotificationCenter.pendingRequests.first {
+            XCTAssertEqual(self.backgroundContent.title, request.content.title)
+            XCTAssertEqual(self.backgroundContent.body, request.content.body)
+            XCTAssertEqual(UNNotificationSound.default, request.content.sound)
+            XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
+            XCTAssertEqual([
+                LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
+                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+            ], request.content.userInfo as? [String: String])
+            XCTAssertEqual(100, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
+            XCTAssertEqual(true, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
+        }
+    }
+    
+    func testRemovePendingAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        userNotificationDeviceAlertPresenter.removePendingAlert(identifier: alert.identifier)
+        
+        waitOnMain()
+        XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
+    }
+    
+    func testRemoveDeliveredAlert() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        mockUserNotificationCenter.deliverAll()
+        
+        userNotificationDeviceAlertPresenter.removeDeliveredAlert(identifier: alert.identifier)
+        
+        waitOnMain()
+        XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
+        XCTAssertTrue(mockUserNotificationCenter.deliveredRequests.isEmpty)
+    }
+
+    
+    func testDoesNotShowIfNoBackgroundContent() {
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: nil, trigger: .immediate)
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+
+        waitOnMain()
+        
+        XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
+    }
+    
+    func testDoesNotShowInForeground() {
+        isInBackground = false
+        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        
+        waitOnMain()
+        
+        XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
+    }
+    
+    func waitOnMain() {
+        let exp = expectation(description: "waitOnMain")
+        DispatchQueue.main.async {
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+    }
+
+}

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -42,7 +42,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     var userNotificationDeviceAlertPresenter: UserNotificationDeviceAlertPresenter!
     var isInBackground = true
     
-    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", typeIdentifier: "bar")
+    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
     let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
     let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
 
@@ -71,7 +71,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -92,7 +92,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -112,7 +112,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(0.1, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(false, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
@@ -133,7 +133,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(100, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(true, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -184,13 +184,4 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
         
         XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
     }
-    
-    func waitOnMain() {
-        let exp = expectation(description: "waitOnMain")
-        DispatchQueue.main.async {
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: 1.0)
-    }
-
 }

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -71,7 +71,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -92,7 +92,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -112,7 +112,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(0.1, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(false, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
@@ -133,7 +133,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeId.rawValue: alertIdentifier.typeIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.typeIdentifier
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(100, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(true, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)


### PR DESCRIPTION
This is actually subtask [LOOP-1163](https://tidepool.atlassian.net/browse/LOOP-1163).

Note: also includes renaming DeviceAlertHandler -> DeviceAlertPresenter, suggested by @ps2 .  So, this PR is dependent on https://github.com/tidepool-org/LoopKit/pull/70. 