### PR TITLE
LOOP-1197: Ensure bolus goes through when BG data is missing

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -540,14 +540,7 @@ extension LoopDataManager {
 
                     self.carbEffect = nil
                     self.carbsOnBoard = nil
-
-                    do {
-                        try self.update()
-
-                        completion(.success(()))
-                    } catch let error {
-                        completion(.failure(error))
-                    }
+                    completion(.success(()))
                 case .failure(let error):
                     completion(.failure(error))
                 }

--- a/WatchApp Extension/Controllers/CarbAndBolusFlowController.swift
+++ b/WatchApp Extension/Controllers/CarbAndBolusFlowController.swift
@@ -17,7 +17,8 @@ final class CarbAndBolusFlowController: WKHostingController<CarbAndBolusFlow>, I
     private lazy var viewModel = {
         CarbAndBolusFlowViewModel(
             configuration: configuration,
-            dismiss: { [unowned self] in
+            dismiss: { [weak self] in
+                guard let self = self else { return }
                 self.willDeactivateObserver = nil
                 self.dismiss()
             }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1197

- `addCarbEntry` was failing if `update` failed (e.g. glucose data unavailable), causing the bolus not to go through (as designed when storing the carb entry fails)
- `update` doesn't need to be called here at all, as observers of LDM data changing go through `getLoopState`, which already triggers `update`

- separately, for some reason CarbAndBolusFlowViewModel sometimes outlives its hosting controller, so I changed the reference from `unowned` to `weak`