### PR TITLE
LOOP-1179: introducing alert sounds

### DIFF
--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -7,6 +7,7 @@
 //
 
 import LoopKit
+import os.log
 
 protocol DeviceAlertManagerResponder: class {
     /// Method for our Handlers to call to kick off alert response.  Differs from DeviceAlertResponder because here we need the whole `Identifier`.
@@ -19,24 +20,38 @@ protocol DeviceAlertManagerResponder: class {
 /// - serializing alerts to storage
 /// - etc.
 public final class DeviceAlertManager {
+    static let soundsDirectory = "\(NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.libraryDirectory, .userDomainMask, true).last!)/Sounds"
+
+    private let log = OSLog(category: "DeviceAlertManager")
 
     var handlers: [DeviceAlertPresenter] = []
     var responders: [String: Weak<DeviceAlertResponder>] = [:]
-    
+    var soundVendors: [String: Weak<DeviceAlertSoundVendor>] = [:]
+
     public init(rootViewController: UIViewController,
                 isAppInBackgroundFunc: @escaping () -> Bool,
                 handlers: [DeviceAlertPresenter]? = nil) {
         self.handlers = handlers ??
             [UserNotificationDeviceAlertPresenter(isAppInBackgroundFunc: isAppInBackgroundFunc),
-             InAppModalDeviceAlertPresenter(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
+             InAppModalDeviceAlertPresenter(rootViewController: rootViewController,
+                                            deviceAlertManagerResponder: self)]
     }
     
-    public func addAlertResponder(key: String, alertResponder: DeviceAlertResponder) {
-        responders[key] = Weak(alertResponder)
+    public func addAlertResponder(managerIdentifier: String, alertResponder: DeviceAlertResponder) {
+        responders[managerIdentifier] = Weak(alertResponder)
     }
     
-    public func removeAlertResponder(key: String) {
-        responders.removeValue(forKey: key)
+    public func removeAlertResponder(managerIdentifier: String) {
+        responders.removeValue(forKey: managerIdentifier)
+    }
+    
+    public func addAlertSoundVendor(managerIdentifier: String, soundVendor: DeviceAlertSoundVendor) {
+        soundVendors[managerIdentifier] = Weak(soundVendor)
+        initializeSoundVendor(managerIdentifier, soundVendor)
+    }
+    
+    public func removeAlertSoundVendor(managerIdentifier: String) {
+        soundVendors.removeValue(forKey: managerIdentifier)
     }
 }
 
@@ -61,4 +76,59 @@ extension DeviceAlertManager: DeviceAlertPresenter {
     }
 }
 
+extension DeviceAlertManager {
+    
+    public static func soundURL(for alert: DeviceAlert) -> URL? {
+        guard let soundName = alert.soundName else { return nil }
+        return soundURL(managerIdentifier: alert.identifier.managerIdentifier, soundName: soundName)
+    }
+    
+    private static func soundURL(managerIdentifier: String, soundName: DeviceAlert.SoundName) -> URL? {
+        guard soundName != .vibrate && soundName != .silence else { return nil }
+        
+        // Seems all the sound files need to be in the sounds directory, so we namespace the filenames
+        return URL(fileURLWithPath: soundsDirectory).appendingPathComponent("\(managerIdentifier)-\(soundName)")
+    }
+    
+    private func initializeSoundVendor(_ managerIdentifier: String, _ soundVendor: DeviceAlertSoundVendor) {
+        let soundFileNames = soundVendor.getSoundNames()
+        guard let baseURL = soundVendor.getSoundBaseURL(), !soundFileNames.isEmpty else {
+            return
+        }
+        do {
+            let fileManager = FileManager.default
+            try fileManager.createDirectory(atPath: DeviceAlertManager.soundsDirectory, withIntermediateDirectories: true, attributes: nil)
+            for soundName in soundFileNames where soundName != .vibrate && soundName != .silence {
+                if let toURL = DeviceAlertManager.soundURL(managerIdentifier: managerIdentifier, soundName: soundName) {
+                    try fileManager.copyIfNewer(from: baseURL.appendingPathComponent(soundName), to: toURL)
+                }
+            }
+        } catch {
+            log.error("Unable to copy sound files from soundVendor %@: %@", managerIdentifier, String(describing: error))
+        }
+    }
+    
+}
 
+extension FileManager {
+    func copyIfNewer(from fromURL: URL, to toURL: URL) throws {
+        if fileExists(atPath: toURL.path) {
+            // If the source file is newer, remove the old one, otherwise skip it.
+            let toCreationDate = try toURL.fileCreationDate()
+            let fromCreationDate = try fromURL.fileCreationDate()
+            if fromCreationDate > toCreationDate {
+                try removeItem(at: toURL)
+            } else {
+                return
+            }
+        }
+        try copyItem(at: fromURL, to: toURL)
+    }
+}
+
+extension URL {
+    
+    func fileCreationDate() throws -> Date {
+        return try FileManager.default.attributesOfItem(atPath: self.path)[.creationDate] as! Date
+    }
+}

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -87,7 +87,7 @@ extension DeviceAlertManager {
         guard soundName != .vibrate && soundName != .silence else { return nil }
         
         // Seems all the sound files need to be in the sounds directory, so we namespace the filenames
-        return URL(fileURLWithPath: soundsDirectory).appendingPathComponent("\(managerIdentifier)-\(soundName)")
+        return URL(fileURLWithPath: soundsDirectory).appendingPathComponent("\(managerIdentifier)-\(soundName.rawValue)")
     }
     
     private func initializeSoundVendor(_ managerIdentifier: String, _ soundVendor: DeviceAlertSoundVendor) {
@@ -100,7 +100,7 @@ extension DeviceAlertManager {
             try fileManager.createDirectory(atPath: DeviceAlertManager.soundsDirectory, withIntermediateDirectories: true, attributes: nil)
             for soundName in soundFileNames where soundName != .vibrate && soundName != .silence {
                 if let toURL = DeviceAlertManager.soundURL(managerIdentifier: managerIdentifier, soundName: soundName) {
-                    try fileManager.copyIfNewer(from: baseURL.appendingPathComponent(soundName), to: toURL)
+                    try fileManager.copyIfNewer(from: baseURL.appendingPathComponent(soundName.rawValue), to: toURL)
                 }
             }
         } catch {

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -76,11 +76,12 @@ extension DeviceAlertManager: DeviceAlertPresenter {
 extension DeviceAlertManager {
     
     public static func soundURL(for alert: DeviceAlert) -> URL? {
-        return soundURL(managerIdentifier: alert.identifier.managerIdentifier, sound: alert.sound)
+        guard let sound = alert.sound else { return nil }
+        return soundURL(managerIdentifier: alert.identifier.managerIdentifier, sound: sound)
     }
     
-    private static func soundURL(managerIdentifier: String, sound: DeviceAlert.Sound?) -> URL? {
-        guard let soundFileName = sound?.filename else { return nil }
+    private static func soundURL(managerIdentifier: String, sound: DeviceAlert.Sound) -> URL? {
+        guard let soundFileName = sound.filename else { return nil }
         
         // Seems all the sound files need to be in the sounds directory, so we namespace the filenames
         return soundsDirectoryURL.appendingPathComponent("\(managerIdentifier)-\(soundFileName)")

--- a/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
@@ -8,6 +8,15 @@
 
 import Foundation
 import LoopKit
+import AudioToolbox
+import AVFoundation
+import os.log
+
+
+public protocol AlertSoundPlayer {
+    func vibrate()
+    func play(url: URL)
+}
 
 public class InAppModalDeviceAlertPresenter: DeviceAlertPresenter {
 
@@ -23,12 +32,16 @@ public class InAppModalDeviceAlertPresenter: DeviceAlertPresenter {
     typealias TimerFactoryFunction = (TimeInterval, Bool, (() -> Void)?) -> Timer
     private let newTimerFunc: TimerFactoryFunction
 
+    private let soundPlayer: AlertSoundPlayer
+
     init(rootViewController: UIViewController,
          deviceAlertManagerResponder: DeviceAlertManagerResponder,
+         soundPlayer: AlertSoundPlayer = AVSoundPlayer(),
          newActionFunc: @escaping ActionFactoryFunction = UIAlertAction.init,
          newTimerFunc: TimerFactoryFunction? = nil) {
         self.rootViewController = rootViewController
         self.deviceAlertManagerResponder = deviceAlertManagerResponder
+        self.soundPlayer = soundPlayer
         self.newActionFunc = newActionFunc
         self.newTimerFunc = newTimerFunc ?? { timeInterval, repeats, block in
             return Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: repeats) { _ in block?() }
@@ -95,6 +108,7 @@ extension InAppModalDeviceAlertPresenter {
             if self.isAlertShowing(identifier: alert.identifier) {
                 return
             }
+            self.playSound(for: alert)
             let alertController = self.presentAlert(title: content.title, message: content.body, action: content.acknowledgeActionButtonLabel) { [weak self] in
                 self?.clearDeliveredAlert(identifier: alert.identifier)
                 self?.deviceAlertManagerResponder?.acknowledgeDeviceAlert(identifier: alert.identifier)
@@ -156,4 +170,48 @@ extension InAppModalDeviceAlertPresenter {
         return controller
     }
     
+    private func playSound(for alert: DeviceAlert) {
+        guard let soundName = alert.soundName else { return }
+        switch soundName {
+        case .vibrate:
+            soundPlayer.vibrate()
+        case .silence:
+            break
+        default:
+            // Assuming in-app alerts should also vibrate.  That way, if the user has "silent mode" on, they still get
+            // some kind of haptic feedback
+            soundPlayer.vibrate()
+            guard let url = DeviceAlertManager.soundURL(for: alert) else { return }
+            soundPlayer.play(url: url)
+        }
+    }
+}
+
+private class AVSoundPlayer: AlertSoundPlayer {
+    private var soundEffect: AVAudioPlayer?
+    private let log = OSLog(category: "AVSoundPlayer")
+    
+    enum Error: Swift.Error {
+        case playFailed
+    }
+    
+    func vibrate() {
+        AudioServicesPlayAlertSound(SystemSoundID(kSystemSoundID_Vibrate))
+    }
+    
+    func play(url: URL) {
+        DispatchQueue.main.async {
+            do {
+                // The AVAudioPlayer has to remain around until the sound completes playing.  A cleaner way might be
+                // to wait until that completes, then delete it, but seems overkill.
+                let soundEffect = try AVAudioPlayer(contentsOf: url)
+                self.soundEffect = soundEffect
+                if !soundEffect.play() {
+                    self.log.error("couldn't play sound %@", url.absoluteString)
+                }
+            } catch {
+                self.log.error("couldn't play sound %@: %@", url.absoluteString, String(describing: error))
+            }
+        }
+    }
 }

--- a/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
@@ -170,8 +170,8 @@ extension InAppModalDeviceAlertPresenter {
     }
     
     private func playSound(for alert: DeviceAlert) {
-        guard let soundName = alert.soundName else { return }
-        switch soundName {
+        guard let sound = alert.sound else { return }
+        switch sound {
         case .vibrate:
             soundPlayer.vibrate()
         case .silence:
@@ -202,7 +202,7 @@ private class AVSoundPlayer: AlertSoundPlayer {
                 let soundEffect = try AVAudioPlayer(contentsOf: url)
                 self.soundEffect = soundEffect
                 if !soundEffect.play() {
-                    self.log.error("couldn't play sound %@", url.absoluteString)
+                    self.log.default("couldn't play sound (app may be in the background): %@", url.absoluteString)
                 }
             } catch {
                 self.log.error("couldn't play sound %@: %@", url.absoluteString, String(describing: error))

--- a/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/InAppModalDeviceAlertPresenter.swift
@@ -10,7 +10,6 @@ import Foundation
 import LoopKit
 import AudioToolbox
 import AVFoundation
-import os.log
 
 
 public protocol AlertSoundPlayer {
@@ -189,11 +188,7 @@ extension InAppModalDeviceAlertPresenter {
 
 private class AVSoundPlayer: AlertSoundPlayer {
     private var soundEffect: AVAudioPlayer?
-    private let log = OSLog(category: "AVSoundPlayer")
-    
-    enum Error: Swift.Error {
-        case playFailed
-    }
+    private let log = DiagnosticLog(category: "AVSoundPlayer")
     
     func vibrate() {
         AudioServicesPlayAlertSound(SystemSoundID(kSystemSoundID_Vibrate))

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -31,7 +31,8 @@ class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
         
     func issueAlert(_ alert: DeviceAlert) {
         DispatchQueue.main.async {
-            if self.alertInBackgroundOnly && self.isAppInBackgroundFunc() || !self.alertInBackgroundOnly {
+            let shouldAlert = self.alertInBackgroundOnly && self.isAppInBackgroundFunc() || !self.alertInBackgroundOnly
+            if shouldAlert || alert.trigger != .immediate {
                 if let request = alert.asUserNotificationRequest() {
                     self.userNotificationCenter.add(request) { error in
                         if let error = error {
@@ -75,7 +76,7 @@ public extension DeviceAlert {
         let userNotificationContent = UNMutableNotificationContent()
         userNotificationContent.title = content.title
         userNotificationContent.body = content.body
-        userNotificationContent.sound = content.isCritical ? .defaultCritical : .default
+        userNotificationContent.sound = getUserNotificationSound()
         // TODO: Once we have a final design and approval for custom UserNotification buttons, we'll need to set categoryIdentifier
 //        userNotificationContent.categoryIdentifier = LoopNotificationCategory.alert.rawValue
         userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
@@ -84,6 +85,29 @@ public extension DeviceAlert {
             LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier
         ]
         return userNotificationContent
+    }
+    
+    private func getUserNotificationSound() -> UNNotificationSound? {
+        guard let content = backgroundContent else {
+            return nil
+        }
+        if let soundName = soundName {
+            switch soundName {
+            case .vibrate:
+                // TODO: Not sure how to "force" UNNotificationSound to "vibrate only"...so for now we just do the default
+                break
+            case .silence:
+                // TODO: Not sure how to "force" UNNotificationSound to "silence"...so for now we just do the default
+                break
+            default:
+                if let actualFileName = DeviceAlertManager.soundURL(for: self)?.lastPathComponent {
+                    let unname = UNNotificationSoundName(rawValue: actualFileName)
+                    return content.isCritical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
+                }
+            }
+        }
+        
+        return content.isCritical ? .defaultCritical : .default
     }
 }
 
@@ -99,4 +123,3 @@ public extension DeviceAlert.Trigger {
         }
     }
 }
-

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -85,8 +85,8 @@ public extension DeviceAlert {
         guard let content = backgroundContent else {
             return nil
         }
-        if let soundName = soundName {
-            switch soundName {
+        if let sound = sound {
+            switch sound {
             case .vibrate:
                 // TODO: Not sure how to "force" UNNotificationSound to "vibrate only"...so for now we just do the default
                 break

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -296,8 +296,10 @@ private extension DeviceDataManager {
 
         updatePumpManagerBLEHeartbeatPreference()
         if let cgmManager = cgmManager {
-            deviceAlertManager?.addAlertResponder(key: cgmManager.managerIdentifier,
+            deviceAlertManager?.addAlertResponder(managerIdentifier: cgmManager.managerIdentifier,
                                                   alertResponder: cgmManager)
+            deviceAlertManager?.addAlertSoundVendor(managerIdentifier: cgmManager.managerIdentifier,
+                                                    soundVendor: cgmManager)
         }
     }
 
@@ -315,8 +317,10 @@ private extension DeviceDataManager {
             loopManager?.doseStore.pumpRecordsBasalProfileStartEvents = pumpRecordsBasalProfileStartEvents
         }
         if let pumpManager = pumpManager {
-            deviceAlertManager?.addAlertResponder(key: pumpManager.managerIdentifier,
+            deviceAlertManager?.addAlertResponder(managerIdentifier: pumpManager.managerIdentifier,
                                                   alertResponder: pumpManager)
+            deviceAlertManager?.addAlertSoundVendor(managerIdentifier: pumpManager.managerIdentifier,
+                                                    soundVendor: pumpManager)
         }
     }
 

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -72,7 +72,7 @@ class DeviceAlertManagerTests: XCTestCase {
 
     func testAlertResponderAcknowledged() {
         let responder = MockResponder()
-        deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
+        deviceAlertManager.addAlertResponder(managerIdentifier: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
         deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
@@ -80,7 +80,7 @@ class DeviceAlertManagerTests: XCTestCase {
     
     func testAlertResponderNotAcknowledgedIfWrongManagerIdentifier() {
         let responder = MockResponder()
-        deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
+        deviceAlertManager.addAlertResponder(managerIdentifier: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
         deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: "foo", alertIdentifier: Self.mockTypeIdentifier))
         XCTAssertTrue(responder.acknowledged.isEmpty)
@@ -88,13 +88,13 @@ class DeviceAlertManagerTests: XCTestCase {
     
     func testRemovedAlertResponderDoesntAcknowledge() {
         let responder = MockResponder()
-        deviceAlertManager.addAlertResponder(key: Self.mockManagerIdentifier, alertResponder: responder)
+        deviceAlertManager.addAlertResponder(managerIdentifier: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
         deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
         
         responder.acknowledged[DeviceAlertManagerTests.mockTypeIdentifier] = false
-        deviceAlertManager.removeAlertResponder(key: DeviceAlertManagerTests.mockManagerIdentifier)
+        deviceAlertManager.removeAlertResponder(managerIdentifier: DeviceAlertManagerTests.mockManagerIdentifier)
         deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == false)
     }

--- a/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
@@ -119,7 +119,7 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
-                                soundName: DeviceAlert.SoundName(rawValue: soundName))
+                                sound: .sound(name: soundName))
         inAppModalDeviceAlertPresenter.issueAlert(alert)
 
         waitOnMain()
@@ -135,7 +135,7 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
-                                soundName: .vibrate)
+                                sound: .vibrate)
         inAppModalDeviceAlertPresenter.issueAlert(alert)
 
         waitOnMain()
@@ -151,7 +151,7 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
-                                soundName: .silence)
+                                sound: .silence)
         inAppModalDeviceAlertPresenter.issueAlert(alert)
 
         waitOnMain()

--- a/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/InAppModalDeviceAlertPresenterTests.swift
@@ -114,18 +114,19 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueImmediateAlertWithSound() {
+        let soundName = "soundName"
         let alert = DeviceAlert(identifier: alertIdentifier,
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
-                                soundName: "soundName")
+                                soundName: DeviceAlert.SoundName(rawValue: soundName))
         inAppModalDeviceAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
         XCTAssertNotNil(alertController)
         XCTAssertEqual("FOREGROUND", alertController?.title)
-        XCTAssertEqual("\(InAppModalDeviceAlertPresenterTests.managerIdentifier)-soundName", mockSoundPlayer.urlPlayed?.lastPathComponent)
+        XCTAssertEqual("\(InAppModalDeviceAlertPresenterTests.managerIdentifier)-\(soundName)", mockSoundPlayer.urlPlayed?.lastPathComponent)
         XCTAssertTrue(mockSoundPlayer.vibrateCalled)
     }
     


### PR DESCRIPTION
After a few more complicated passes at this, I decided to keep it super-simple for now: just add a sound "name" to `DeviceAlert`, and request that all plugins vend their sound names to Loop so that it can copy them to a directory from whence it can play them.

See the corresponding [LoopKit PR](https://github.com/tidepool-org/LoopKit/pull/80) for more info.

LW PR: https://github.com/tidepool-org/LoopWorkspace/pull/76