### PR TITLE
Fix preventing UserNotifications from displaying in the foreground.

### DIFF
--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -29,8 +29,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        deviceAlertManager = DeviceAlertManager(rootViewController: rootViewController,
-                                                isAppInBackgroundFunc: isInBackground)
+        deviceAlertManager = DeviceAlertManager(rootViewController: rootViewController)
         deviceDataManager = DeviceDataManager(pluginManager: pluginManager, deviceAlertManager: deviceAlertManager)
 
         SharedLogging.instance = deviceDataManager.loggingServicesManager
@@ -105,8 +104,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication,
                      didReceiveRemoteNotification userInfo: [AnyHashable : Any],
-                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
-    ) {
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         guard let notification = userInfo as? [String: AnyObject] else {
             completionHandler(.failed)
             return
@@ -114,10 +112,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
       
         deviceDataManager.handleRemoteNotification(notification)
         completionHandler(.noData)
-    }
-
-    private func isInBackground() -> Bool {
-        return UIApplication.shared.applicationState == .background
     }
 }
 

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -152,7 +152,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([.badge, .sound, .alert])
+        // UserNotifications are not to be displayed while in the foreground
+        completionHandler([])
     }
     
 }

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -27,7 +27,7 @@ public final class DeviceAlertManager {
                 isAppInBackgroundFunc: @escaping () -> Bool,
                 handlers: [DeviceAlertPresenter]? = nil) {
         self.handlers = handlers ??
-            [UserNotificationDeviceAlertPresenter(isAppInBackgroundFunc: isAppInBackgroundFunc),
+            [UserNotificationDeviceAlertPresenter(),
              InAppModalDeviceAlertPresenter(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
     }
     

--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -24,7 +24,6 @@ public final class DeviceAlertManager {
     var responders: [String: Weak<DeviceAlertResponder>] = [:]
     
     public init(rootViewController: UIViewController,
-                isAppInBackgroundFunc: @escaping () -> Bool,
                 handlers: [DeviceAlertPresenter]? = nil) {
         self.handlers = handlers ??
             [UserNotificationDeviceAlertPresenter(),

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -19,27 +19,21 @@ extension UNUserNotificationCenter: UserNotificationCenter {}
 
 class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     
-    let alertInBackgroundOnly = true
-    let isAppInBackgroundFunc: () -> Bool
     let userNotificationCenter: UserNotificationCenter
     
-    init(isAppInBackgroundFunc: @escaping () -> Bool,
-         userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()) {
-        self.isAppInBackgroundFunc = isAppInBackgroundFunc
+    init(userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()) {
         self.userNotificationCenter = userNotificationCenter
     }
         
     func issueAlert(_ alert: DeviceAlert) {
         DispatchQueue.main.async {
-            if self.alertInBackgroundOnly && self.isAppInBackgroundFunc() || !self.alertInBackgroundOnly {
-                if let request = alert.asUserNotificationRequest() {
-                    self.userNotificationCenter.add(request) { error in
-                        if let error = error {
-                            print("Something went wrong posting the user notification: \(error)")
-                        }
+            if let request = alert.asUserNotificationRequest() {
+                self.userNotificationCenter.add(request) { error in
+                    if let error = error {
+                        print("Something went wrong posting the user notification: \(error)")
                     }
-                    // For now, UserNotifications do not not acknowledge...not yet at least
                 }
+                // For now, UserNotifications do not not acknowledge...not yet at least
             }
         }
     }

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -20,6 +20,7 @@ extension UNUserNotificationCenter: UserNotificationCenter {}
 class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     
     let userNotificationCenter: UserNotificationCenter
+    let log = DiagnosticLog(category: "UserNotificationDeviceAlertPresenter")
     
     init(userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()) {
         self.userNotificationCenter = userNotificationCenter
@@ -30,7 +31,7 @@ class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
             if let request = alert.asUserNotificationRequest() {
                 self.userNotificationCenter.add(request) { error in
                     if let error = error {
-                        print("Something went wrong posting the user notification: \(error)")
+                        self.log.error("Something went wrong posting the user notification: %@", error.localizedDescription)
                     }
                 }
                 // For now, UserNotifications do not not acknowledge...not yet at least

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -44,9 +44,7 @@ class DeviceAlertManagerTests: XCTestCase {
     
     override func setUp() {
         mockPresenter = MockPresenter()
-        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
-                                                isAppInBackgroundFunc: { return self.isInBackground },
-                                                handlers: [mockPresenter])
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(), handlers: [mockPresenter])
     }
     
     func testIssueAlertOnHandlerCalled() {

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -40,7 +40,6 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     }
     
     var userNotificationDeviceAlertPresenter: UserNotificationDeviceAlertPresenter!
-    var isInBackground = true
     
     let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
     let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
@@ -50,11 +49,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     
     override func setUp() {
         mockUserNotificationCenter = MockUserNotificationCenter()
-        
-        isInBackground = true
         userNotificationDeviceAlertPresenter =
-            UserNotificationDeviceAlertPresenter(isAppInBackgroundFunc: { return self.isInBackground },
-                                                 userNotificationCenter: mockUserNotificationCenter)
+            UserNotificationDeviceAlertPresenter(userNotificationCenter: mockUserNotificationCenter)
     }
 
     func testIssueImmediateAlert() {
@@ -170,16 +166,6 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
         let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: nil, trigger: .immediate)
         userNotificationDeviceAlertPresenter.issueAlert(alert)
 
-        waitOnMain()
-        
-        XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
-    }
-    
-    func testDoesNotShowInForeground() {
-        isInBackground = false
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
-        
         waitOnMain()
         
         XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)


### PR DESCRIPTION
Background-only UserNotifications was implemented wrong.  It should have been prevented by an AppDelegate callback, not at the time of posting it.
This fixes that.

LW PR: https://github.com/tidepool-org/LoopWorkspace/pull/75