### PR TITLE
LOOP-1167: play back delivered and pending alerts on re-launch

### DIFF
--- a/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
+++ b/Loop/Managers/DeviceAlert/DeviceAlertManager.swift
@@ -37,7 +37,7 @@ public final class DeviceAlertManager {
             [UserNotificationDeviceAlertPresenter(),
             InAppModalDeviceAlertPresenter(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
 
-        playBack()
+        playbackPersistedAlerts()
     }
 
     public func addAlertResponder(managerIdentifier: String, alertResponder: DeviceAlertResponder) {
@@ -63,6 +63,11 @@ extension DeviceAlertManager: DeviceAlertManagerResponder {
         if let responder = responders[identifier.managerIdentifier]?.value {
             responder.acknowledgeAlert(alertIdentifier: identifier.alertIdentifier)
         }
+        // Also clear the alert from the NotificationCenter
+        log.debug("Removing notification %@ from delivered & pending notifications", identifier.value)
+        let center = UNUserNotificationCenter.current()
+        center.removeDeliveredNotifications(withIdentifiers: [identifier.value])
+        center.removePendingNotificationRequests(withIdentifiers: [identifier.value])
     }
 }
 
@@ -139,23 +144,166 @@ extension URL {
 
 
 extension DeviceAlertManager {
-    private func playBack() {
+    
+    private func playbackPersistedAlerts() {
     
         let center = UNUserNotificationCenter.current()
         center.getDeliveredNotifications {
             $0.forEach { notification in
-                if let data = notification.request.content.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] as? Data,
-                    let savedAlert = try? DeviceAlert.decode(from: data) {
-                    print("Replaying Alert: \(savedAlert)")
-                    self.issueAlert(savedAlert)
-                }
+                self.log.debug("Delivered alert: %@", "\(notification)")
+                self.playbackDeliveredNotification(notification)
             }
         }
         
         center.getPendingNotificationRequests {
-            $0.forEach {
-                print("PENDING: \($0)")
+            $0.forEach { request in
+                self.log.debug("Pending alert: %@", "\(request)")
+                self.playbackPendingNotificationRequest(request)
             }
+        }
+    }
+
+    private func playbackDeliveredNotification(_ notification: UNNotification) {
+        guard let savedAlertString = notification.request.content.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] as? String else {
+            self.log.error("Could not find persistent alert in notification")
+            return
+        }
+         
+        do {
+            let savedAlert = try DeviceAlert.decode(from: savedAlertString)
+            // Assume if it was delivered, the trigger should be .immediate.
+            let newAlert = DeviceAlert(identifier: savedAlert.identifier,
+                                       foregroundContent: savedAlert.foregroundContent,
+                                       backgroundContent: savedAlert.backgroundContent,
+                                       trigger: .immediate,
+                                       sound: savedAlert.sound)
+            self.log.debug("Replaying Alert: %@", savedAlertString)
+            self.issueAlert(newAlert)
+        } catch {
+            self.log.error("Could not decode alert: error %@, from %@", error.localizedDescription, savedAlertString)
+        }
+    }
+
+    private func playbackPendingNotificationRequest(_ request: UNNotificationRequest) {
+        guard let savedAlertString = request.content.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] as? String else  {
+            self.log.error("Could not find persistent alert in notification")
+            return
+        }
+        do {
+            let savedAlert = try DeviceAlert.decode(from: savedAlertString)
+            let newTrigger = determineNewPendingTrigger(from: request) ?? savedAlert.trigger
+            let newAlert = DeviceAlert(identifier: savedAlert.identifier,
+                                       foregroundContent: savedAlert.foregroundContent,
+                                       backgroundContent: savedAlert.backgroundContent,
+                                       trigger: newTrigger,
+                                       sound: savedAlert.sound)
+            self.log.debug("Replaying Pending Alert: %@ with new trigger %@", savedAlertString, "\(newTrigger)")
+            self.issueAlert(newAlert)
+        } catch {
+            self.log.error("Could not decode alert: error %@, from %@", error.localizedDescription, savedAlertString)
+        }
+    }
+    
+    private func determineNewPendingTrigger(from request: UNNotificationRequest) -> DeviceAlert.Trigger? {
+        guard let requestTrigger = request.trigger else {
+            //Is immediate a good fallback?
+            return DeviceAlert.Trigger.immediate
+        }
+        // Strange case here: if it is a repeating trigger, we can't really play back exactly
+        // at the right "remaining time" and then repeat at the original period.  So, I think
+        // the best we can do is just use the original trigger
+        if requestTrigger.repeats {
+            return nil  // use saved trigger
+        } else if let delay = requestTrigger.getNextTriggerDate()?.timeIntervalSinceNow {
+            return .delayed(interval: delay)
+        } else {
+            //Is immediate a good fallback?
+            return .immediate
+        }
+    }
+
+}
+
+fileprivate extension UNNotificationTrigger {
+    func getNextTriggerDate() -> Date? {
+        //// <XXX!! -- Hm. this isn't doing what I thought it would.  I thought it would give me the "time remaining" on the notification.  It doesn't seem to be doing that.
+        if let timeIntervalTrigger = self as? UNTimeIntervalNotificationTrigger {
+            return timeIntervalTrigger.nextTriggerDate()
+        }
+        if let calendarTrigger = self as? UNCalendarNotificationTrigger {
+            return calendarTrigger.nextTriggerDate()
+        }
+        return nil
+    }
+}
+
+public extension DeviceAlert {
+    
+    enum Error: String, Swift.Error {
+        case noBackgroundContent
+    }
+    
+    func asUserNotificationRequest() throws -> UNNotificationRequest {
+        let uncontent = try getUserNotificationContent()
+        return UNNotificationRequest(identifier: identifier.value,
+                                     content: uncontent,
+                                     trigger: trigger.asUserNotificationTrigger())
+    }
+    
+    private func getUserNotificationContent() throws -> UNNotificationContent {
+        guard let content = backgroundContent else {
+            throw Error.noBackgroundContent
+        }
+        let userNotificationContent = UNMutableNotificationContent()
+        userNotificationContent.title = content.title
+        userNotificationContent.body = content.body
+        userNotificationContent.sound = getUserNotificationSound()
+        // TODO: Once we have a final design and approval for custom UserNotification buttons, we'll need to set categoryIdentifier
+//        userNotificationContent.categoryIdentifier = LoopNotificationCategory.alert.rawValue
+        userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
+        userNotificationContent.userInfo = [
+            LoopNotificationUserInfoKey.managerIDForAlert.rawValue: identifier.managerIdentifier,
+            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier,
+        ]
+        let encodedAlert = try encodeToString()
+        userNotificationContent.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] = encodedAlert
+        print("Alert: \(encodedAlert)")
+        return userNotificationContent
+    }
+    
+    private func getUserNotificationSound() -> UNNotificationSound? {
+        guard let content = backgroundContent else {
+            return nil
+        }
+        if let sound = sound {
+            switch sound {
+            case .vibrate:
+                // TODO: Not sure how to "force" UNNotificationSound to "vibrate only"...so for now we just do the default
+                break
+            case .silence:
+                // TODO: Not sure how to "force" UNNotificationSound to "silence"...so for now we just do the default
+                break
+            default:
+                if let actualFileName = DeviceAlertManager.soundURL(for: self)?.lastPathComponent {
+                    let unname = UNNotificationSoundName(rawValue: actualFileName)
+                    return content.isCritical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
+                }
+            }
+        }
+        
+        return content.isCritical ? .defaultCritical : .default
+    }
+}
+
+fileprivate extension DeviceAlert.Trigger {
+    func asUserNotificationTrigger() -> UNNotificationTrigger? {
+        switch self {
+        case .immediate:
+            return nil
+        case .delayed(let timeInterval):
+            return UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+        case .repeating(let repeatInterval):
+            return UNTimeIntervalNotificationTrigger(timeInterval: repeatInterval, repeats: true)
         }
     }
 }

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -7,29 +7,24 @@
 //
 
 import LoopKit
-import UserNotifications
-
-protocol UserNotificationCenter {
-    func add(_ request: UNNotificationRequest, withCompletionHandler: ((Error?) -> Void)?)
-    func removePendingNotificationRequests(withIdentifiers: [String])
-    func removeDeliveredNotifications(withIdentifiers: [String])
-}
-
-extension UNUserNotificationCenter: UserNotificationCenter {}
 
 class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     
     let userNotificationCenter: UserNotificationCenter
     let log = DiagnosticLog(category: "UserNotificationDeviceAlertPresenter")
     
-    init(userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current()) {
+    init(userNotificationCenter: UserNotificationCenter) {
         self.userNotificationCenter = userNotificationCenter
     }
-        
+    
     func issueAlert(_ alert: DeviceAlert) {
+        issueAlert(alert, timestamp: Date())
+    }
+
+    func issueAlert(_ alert: DeviceAlert, timestamp: Date) {
         DispatchQueue.main.async {
             do {
-                let request = try alert.asUserNotificationRequest()
+                let request = try UNNotificationRequest(from: alert, timestamp: timestamp)
                 self.userNotificationCenter.add(request) { error in
                     if let error = error {
                         self.log.error("Something went wrong posting the user notification: %@", error.localizedDescription)

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -28,13 +28,16 @@ class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
         
     func issueAlert(_ alert: DeviceAlert) {
         DispatchQueue.main.async {
-            if let request = alert.asUserNotificationRequest() {
+            do {
+                let request = try alert.asUserNotificationRequest()
                 self.userNotificationCenter.add(request) { error in
                     if let error = error {
                         self.log.error("Something went wrong posting the user notification: %@", error.localizedDescription)
                     }
                 }
                 // For now, UserNotifications do not not acknowledge...not yet at least
+            } catch {
+                self.log.error("Error issuing alert: %@", error.localizedDescription)
             }
         }
     }
@@ -48,76 +51,6 @@ class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
     func removeDeliveredAlert(identifier: DeviceAlert.Identifier) {
         DispatchQueue.main.async {
             self.userNotificationCenter.removeDeliveredNotifications(withIdentifiers: [identifier.value])
-        }
-    }
-}
-
-public extension DeviceAlert {
-    
-    fileprivate func asUserNotificationRequest() -> UNNotificationRequest? {
-        guard let uncontent = getUserNotificationContent() else {
-            return nil
-        }
-        return UNNotificationRequest(identifier: identifier.value,
-                                     content: uncontent,
-                                     trigger: trigger.asUserNotificationTrigger())
-    }
-    
-    private func getUserNotificationContent() -> UNNotificationContent? {
-        guard let content = backgroundContent else {
-            return nil
-        }
-        let userNotificationContent = UNMutableNotificationContent()
-        userNotificationContent.title = content.title
-        userNotificationContent.body = content.body
-        userNotificationContent.sound = getUserNotificationSound()
-        // TODO: Once we have a final design and approval for custom UserNotification buttons, we'll need to set categoryIdentifier
-//        userNotificationContent.categoryIdentifier = LoopNotificationCategory.alert.rawValue
-        userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
-        userNotificationContent.userInfo = [
-            LoopNotificationUserInfoKey.managerIDForAlert.rawValue: identifier.managerIdentifier,
-            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier,
-        ]
-        if let encodedAlert = try? encode() {
-            userNotificationContent.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] = encodedAlert
-            print("Alert: \(String(describing: String(data: encodedAlert, encoding: .utf8)))")
-        }
-        return userNotificationContent
-    }
-    
-    private func getUserNotificationSound() -> UNNotificationSound? {
-        guard let content = backgroundContent else {
-            return nil
-        }
-        if let sound = sound {
-            switch sound {
-            case .vibrate:
-                // TODO: Not sure how to "force" UNNotificationSound to "vibrate only"...so for now we just do the default
-                break
-            case .silence:
-                // TODO: Not sure how to "force" UNNotificationSound to "silence"...so for now we just do the default
-                break
-            default:
-                if let actualFileName = DeviceAlertManager.soundURL(for: self)?.lastPathComponent {
-                    let unname = UNNotificationSoundName(rawValue: actualFileName)
-                    return content.isCritical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
-                }
-            }
-        }
-        
-        return content.isCritical ? .defaultCritical : .default
-    }
-}
-
-public extension DeviceAlert.Trigger {
-    func asUserNotificationTrigger() -> UNNotificationTrigger? {
-        switch self {
-        case .immediate:
-            return nil
-        case .delayed(let timeInterval):
-            return UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
-        case .repeating(let repeatInterval):
-            return UNTimeIntervalNotificationTrigger(timeInterval: repeatInterval, repeats: true)
         }
     }
 }

--- a/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
+++ b/Loop/Managers/DeviceAlert/UserNotificationDeviceAlertPresenter.swift
@@ -76,8 +76,12 @@ public extension DeviceAlert {
         userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
         userNotificationContent.userInfo = [
             LoopNotificationUserInfoKey.managerIDForAlert.rawValue: identifier.managerIdentifier,
-            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier
+            LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier,
         ]
+        if let encodedAlert = try? encode() {
+            userNotificationContent.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] = encodedAlert
+            print("Alert: \(String(describing: String(data: encodedAlert, encoding: .utf8)))")
+        }
         return userNotificationContent
     }
     

--- a/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
+++ b/LoopTests/Managers/DeviceAlert/DeviceAlertManagerTests.swift
@@ -7,6 +7,7 @@
 //
 
 import LoopKit
+import UserNotifications
 import XCTest
 @testable import Loop
 
@@ -33,18 +34,71 @@ class DeviceAlertManagerTests: XCTestCase {
             acknowledged[alertIdentifier] = true
         }
     }
+
+    class MockFileManager: FileManager {
+        
+        var fileExists = true
+        let newer = Date()
+        let older = Date.distantPast
+        
+        var createdDirURL: URL?
+        override func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey : Any]? = nil) throws {
+            createdDirURL = url
+        }
+        override func fileExists(atPath path: String) -> Bool {
+            return !path.contains("doesntExist")
+        }
+        override func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
+            return path.contains("Sounds") ? path.contains("existsNewer") ? [.creationDate: newer] : [.creationDate: older] :
+                 [.creationDate: newer]
+        }
+        var removedURLs = [URL]()
+        override func removeItem(at URL: URL) throws {
+            removedURLs.append(URL)
+        }
+        var copiedSrcURLs = [URL]()
+        var copiedDstURLs = [URL]()
+        override func copyItem(at srcURL: URL, to dstURL: URL) throws {
+            copiedSrcURLs.append(srcURL)
+            copiedDstURLs.append(dstURL)
+        }
+    }
+
+    class MockSoundVendor: DeviceAlertSoundVendor {
+        func getSoundBaseURL() -> URL? {
+            // Hm.  It's not easy to make a "fake" URL, so we'll use this one:
+            return Bundle.main.resourceURL
+        }
+        
+        func getSounds() -> [DeviceAlert.Sound] {
+            return [.sound(name: "doesntExist"), .sound(name: "existsNewer"), .sound(name: "existsOlder")]
+        }
+    }
     
     static let mockManagerIdentifier = "mockManagerIdentifier"
     static let mockTypeIdentifier = "mockTypeIdentifier"
-    let mockDeviceAlert = DeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: mockManagerIdentifier, alertIdentifier: mockTypeIdentifier), foregroundContent: nil, backgroundContent: nil, trigger: .immediate)
+    static let mockIdentifier = DeviceAlert.Identifier(managerIdentifier: mockManagerIdentifier, alertIdentifier: mockTypeIdentifier)
+    let mockDeviceAlert = DeviceAlert(identifier: mockIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .immediate)
     
+    var mockFileManager: MockFileManager!
     var mockPresenter: MockPresenter!
+    var mockUserNotificationCenter: MockUserNotificationCenter!
     var deviceAlertManager: DeviceAlertManager!
     var isInBackground = true
     
+    override class func setUp() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        UNUserNotificationCenter.current().removeAllDeliveredNotifications()
+    }
+    
     override func setUp() {
+        mockFileManager = MockFileManager()
         mockPresenter = MockPresenter()
-        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(), handlers: [mockPresenter])
+        mockUserNotificationCenter = MockUserNotificationCenter()
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
+                                                handlers: [mockPresenter],
+                                                userNotificationCenter: mockUserNotificationCenter,
+                                                fileManager: mockFileManager)
     }
     
     func testIssueAlertOnHandlerCalled() {
@@ -72,7 +126,7 @@ class DeviceAlertManagerTests: XCTestCase {
         let responder = MockResponder()
         deviceAlertManager.addAlertResponder(managerIdentifier: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: Self.mockIdentifier)
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
     }
     
@@ -88,12 +142,131 @@ class DeviceAlertManagerTests: XCTestCase {
         let responder = MockResponder()
         deviceAlertManager.addAlertResponder(managerIdentifier: Self.mockManagerIdentifier, alertResponder: responder)
         XCTAssertTrue(responder.acknowledged.isEmpty)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: Self.mockIdentifier)
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == true)
         
         responder.acknowledged[DeviceAlertManagerTests.mockTypeIdentifier] = false
         deviceAlertManager.removeAlertResponder(managerIdentifier: DeviceAlertManagerTests.mockManagerIdentifier)
-        deviceAlertManager.acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier(managerIdentifier: Self.mockManagerIdentifier, alertIdentifier: Self.mockTypeIdentifier))
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: Self.mockIdentifier)
         XCTAssert(responder.acknowledged[Self.mockTypeIdentifier] == false)
     }
+    
+    func testAcknowledgedAlertsRemovedFromUserNotificationCenter() {
+        deviceAlertManager.acknowledgeDeviceAlert(identifier: Self.mockIdentifier)
+    }
+    
+    func testSoundVendorInitialization() {
+        let soundVendor = MockSoundVendor()
+        deviceAlertManager.addAlertSoundVendor(managerIdentifier: Self.mockManagerIdentifier, soundVendor: soundVendor)
+        XCTAssertEqual("Sounds", mockFileManager.createdDirURL?.lastPathComponent)
+        XCTAssertEqual(["\(Self.mockManagerIdentifier)-existsOlder"], mockFileManager.removedURLs.map { $0.lastPathComponent })
+        XCTAssertEqual(["doesntExist", "existsOlder"], mockFileManager.copiedSrcURLs.map { $0.lastPathComponent })
+        XCTAssertEqual(["\(Self.mockManagerIdentifier)-doesntExist", "\(Self.mockManagerIdentifier)-existsOlder"], mockFileManager.copiedDstURLs.map { $0.lastPathComponent })
+    }
+    
+    // Unfortunately, it is not very easy to test playback of delivered notifications, because we
+    // can't construct UNNotifications.  Hopefully, the code footprint in `DeviceAlertManager.playbackDeliveredNotification` is small enough, because it calls common code under test.
+    
+    func testPlaybackPendingImmediateNotification() {
+        let date = Date()
+        let content = DeviceAlert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
+        let alert = DeviceAlert(identifier: Self.mockIdentifier,
+                                foregroundContent: content, backgroundContent: content, trigger: .immediate)
+
+        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
+                                                handlers: [mockPresenter],
+                                                userNotificationCenter: mockUserNotificationCenter,
+                                                fileManager: mockFileManager)
+        XCTAssertEqual(alert, mockPresenter.issuedAlert)
+    }
+    
+    func testPlaybackPendingExpiredDelayedNotification() {
+        let date = Date.distantPast
+        let content = DeviceAlert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
+        let alert = DeviceAlert(identifier: Self.mockIdentifier,
+                                foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
+
+        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
+                                                handlers: [mockPresenter],
+                                                userNotificationCenter: mockUserNotificationCenter,
+                                                fileManager: mockFileManager)
+        let expected = DeviceAlert(identifier: Self.mockIdentifier, foregroundContent: content, backgroundContent: content, trigger: .immediate)
+        XCTAssertEqual(expected, mockPresenter.issuedAlert)
+    }
+    
+    func testPlaybackPendingDelayedNotification() {
+        let date = Date().addingTimeInterval(-15.0) // Pretend the 30-second-delayed alert was issued 15 seconds ago
+        let content = DeviceAlert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
+        let alert = DeviceAlert(identifier: Self.mockIdentifier,
+                                foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
+
+        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
+                                                handlers: [mockPresenter],
+                                                userNotificationCenter: mockUserNotificationCenter,
+                                                fileManager: mockFileManager)
+        // The trigger for this should be `.delayed` by "something less than 15 seconds",
+        // but the exact value depends on the speed of executing this test.
+        // As long as it is <= 15 seconds, we call it good.
+        XCTAssertNotNil(mockPresenter.issuedAlert)
+        switch mockPresenter.issuedAlert?.trigger {
+        case .some(.delayed(let interval)):
+            XCTAssertLessThanOrEqual(interval, 15.0)
+        default:
+            XCTFail("Wrong trigger \(String(describing: mockPresenter.issuedAlert?.trigger))")
+        }
+    }
+    
+    func testPlaybackPendingRepeatingNotification() {
+        let date = Date.distantPast
+        let content = DeviceAlert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
+        let alert = DeviceAlert(identifier: Self.mockIdentifier,
+                                foregroundContent: content, backgroundContent: content, trigger: .repeating(repeatInterval: 60.0))
+
+        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        deviceAlertManager = DeviceAlertManager(rootViewController: UIViewController(),
+                                                handlers: [mockPresenter],
+                                                userNotificationCenter: mockUserNotificationCenter,
+                                                fileManager: mockFileManager)
+        XCTAssertEqual(alert, mockPresenter.issuedAlert)
+    }
 }
+
+class MockUserNotificationCenter: UserNotificationCenter {
+        
+    var pendingRequests = [UNNotificationRequest]()
+    var deliveredRequests = [UNNotificationRequest]()
+            
+    func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)? = nil) {
+        pendingRequests.append(request)
+    }
+    
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        identifiers.forEach { identifier in
+            pendingRequests.removeAll { $0.identifier == identifier }
+        }
+    }
+
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+        identifiers.forEach { identifier in
+            deliveredRequests.removeAll { $0.identifier == identifier }
+        }
+    }
+    
+    func deliverAll() {
+        deliveredRequests = pendingRequests
+        pendingRequests = []
+    }
+    
+    func getDeliveredNotifications(completionHandler: @escaping ([UNNotification]) -> Void) {
+        // Sadly, we can't create UNNotifications.
+        completionHandler([])
+    }
+    
+    func getPendingNotificationRequests(completionHandler: @escaping ([UNNotificationRequest]) -> Void) {
+        completionHandler(pendingRequests)
+    }
+}
+

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -11,33 +11,6 @@ import XCTest
 @testable import Loop
 
 class UserNotificationDeviceAlertPresenterTests: XCTestCase {
-
-    class MockUserNotificationCenter: UserNotificationCenter {
-        
-        var pendingRequests = [UNNotificationRequest]()
-        var deliveredRequests = [UNNotificationRequest]()
-                
-        func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)? = nil) {
-            pendingRequests.append(request)
-        }
-        
-        func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
-            identifiers.forEach { identifier in
-                pendingRequests.removeAll { $0.identifier == identifier }
-            }
-        }
-
-        func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
-            identifiers.forEach { identifier in
-                deliveredRequests.removeAll { $0.identifier == identifier }
-            }
-        }
-        
-        func deliverAll() {
-            deliveredRequests = pendingRequests
-            pendingRequests = []
-        }
-    }
     
     var userNotificationDeviceAlertPresenter: UserNotificationDeviceAlertPresenter!
     
@@ -55,7 +28,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
 
     func testIssueImmediateAlert() {
         let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -68,7 +41,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -77,7 +51,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     func testIssueImmediateCriticalAlert() {
         let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", isCritical: true)
         let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -90,7 +64,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":true,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":true,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -98,7 +73,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     
     func testIssueDelayedAlert() {
         let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -111,7 +86,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"delayed\":{\"delayInterval\":0.10000000000000001}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"delayed\":{\"delayInterval\":0.10000000000000001}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(0.1, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(false, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
@@ -120,7 +96,7 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     
     func testIssueRepeatingAlert() {
         let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 100))
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -133,7 +109,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"repeating\":{\"repeatInterval\":100}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"repeating\":{\"repeatInterval\":100}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(100, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(true, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)

--- a/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
+++ b/LoopTests/Managers/DeviceAlert/UserNotificationDeviceAlertPresenterTests.swift
@@ -67,7 +67,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -88,7 +89,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":true,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
@@ -108,7 +110,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"delayed\":{\"delayInterval\":0.10000000000000001}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(0.1, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(false, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
@@ -129,7 +132,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual(alertIdentifier.value, request.content.threadIdentifier)
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
-                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier
+                LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
+                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"repeating\":{\"repeatInterval\":100}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}"
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(100, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(true, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)


### PR DESCRIPTION
Here's the use case:  
- User gets an alert while the app is in the background.
- Alert shows in NotificationCenter, but the user does nothing about it (doesn't clear it, doesn't tap it... pretty normal for a busy person to do)
- At some point, the app is quit (i.e. ejected from memory) on iOS.  So any alerts "showing" in the UI are no longer in memory.
- The user re-launches the app (either by tapping the UserNotification or launching the app normally).  The alert modal should still be shown.

The idea here is: Let NotificationCenter keep track of those alerts.  So all I do is, upon launch, "re-play" those alerts that are in the "delivered" or "pending" lists in NotificationCenter.

However, there was a catch: the alerts delivered to NotificationCenter are not necessarily the same copy (body text) as the ones delivered in the modal.  Thus, I went ahead and implemented serializability to the DeviceAlert, which I then used to stuff into the `userInfo` on the `UNNotificationRequest` itself.  When the app launches, I deserialize it and play back. 
