### PR TITLE
Watch carb+bolus flow fixes

### DIFF
--- a/Loop/Managers/WatchDataManager.swift
+++ b/Loop/Managers/WatchDataManager.swift
@@ -48,13 +48,11 @@ final class WatchDataManager: NSObject {
             return
         }
 
-        switch updateContext {
-        case .glucose, .tempBasal:
-            sendWatchContextIfNeeded()
-        case .preferences:
+        // Any update context should trigger a watch update
+        sendWatchContextIfNeeded()
+
+        if case .preferences = updateContext {
             sendSettingsIfNeeded()
-        default:
-            break
         }
     }
 


### PR DESCRIPTION
1. Any iOS-side data update should trigger the send of an updated WatchContext. This ensures that if e.g. the user is looking at a bolus recommendation in the watch app, then adds new carbs via iOS, they will receive a 'Bolus Recommendation Updated' alert.

2. With fast comms, it was possible for a bolus initiated via watch to hit the phone and trigger a new update sent _back_ to the watch _before_ the initial interface had even dismissed. This would result in a confusing 'Bolus Recommendation Updated' alert in an interface whose interaction had already been completed.