### PR TITLE
Make sure copying plugins to their destination doesn't fail

### DIFF
--- a/Scripts/copy-plugins.sh
+++ b/Scripts/copy-plugins.sh
@@ -28,7 +28,7 @@ function copy_plugins {
       for framework_path in "${f}"/Frameworks/*.framework; do
         framework=$(basename "$framework_path")
         echo "Copying plugin's framework $framework_path to ${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
-        cp -a "$framework_path" "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
+        cp -avf "$framework_path" "${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/."
         plugin_path="$(readlink "$f" || echo "$f")"
         if [ "$EXPANDED_CODE_SIGN_IDENTITY" != "-" ] && [ "$EXPANDED_CODE_SIGN_IDENTITY" != "" ]; then
           echo "Signing $framework for $plugin with $EXPANDED_CODE_SIGN_IDENTITY_NAME"


### PR DESCRIPTION
Sometimes I see incremental build failures on my machine like this:
```
Copying plugin's framework /Users/rick/Library/Developer/Xcode/DerivedData/Tidepool-cxihkevfmvnrqggmramyzqmhlmll/Build/Products/Debug-iphonesimulator/DexcomCGMKitPlugin.loopplugin/Frameworks/Alerts.framework to /Users/rick/Library/Developer/Xcode/DerivedData/Tidepool-cxihkevfmvnrqggmramyzqmhlmll/Build/Products/Debug-iphonesimulator/Loop.app/Frameworks/.
cp: symlink: rick@Ricks-MacBook-Pro.local.31788: File exists
cp: symlink: rick@Ricks-MacBook-Pro.local.31788: File exists
```
I think this fixes that.