### PR TITLE
Clear pending "loop not looping" notification requests

### DIFF
--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -127,11 +127,6 @@ struct NotificationManager {
         UNUserNotificationCenter.current().add(request)
     }
 
-    // Cancel any previous scheduled notifications in the Loop Not Running category
-    static func clearPendingNotificationRequests() {
-        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
-    }
-
     static func scheduleLoopNotRunningNotifications() {
         // Give a little extra time for a loop-in-progress to complete
         let gracePeriod = TimeInterval(minutes: 0.5)
@@ -168,15 +163,25 @@ struct NotificationManager {
     }
 
     static func clearLoopNotRunningNotifications() {
+        let notificationCenter = UNUserNotificationCenter.current()
+        // Cancel any previous scheduled notifications in the Loop Not Running category
+        notificationCenter.getPendingNotificationRequests { notificationRequests in
+            let loopNotRunningIdentifiers = notificationRequests.filter({
+                $0.content.categoryIdentifier == LoopNotificationCategory.loopNotRunning.rawValue
+            }).map({
+                $0.identifier
+            })
+            notificationCenter.removePendingNotificationRequests(withIdentifiers: loopNotRunningIdentifiers)
+        }
         // Clear out any existing not-running notifications
-        UNUserNotificationCenter.current().getDeliveredNotifications { (notifications) in
+        notificationCenter.getDeliveredNotifications { notifications in
             let loopNotRunningIdentifiers = notifications.filter({
                 $0.request.content.categoryIdentifier == LoopNotificationCategory.loopNotRunning.rawValue
             }).map({
                 $0.request.identifier
             })
 
-            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: loopNotRunningIdentifiers)
+            notificationCenter.removeDeliveredNotifications(withIdentifiers: loopNotRunningIdentifiers)
         }
     }
 

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -163,25 +163,15 @@ struct NotificationManager {
     }
 
     static func clearLoopNotRunningNotifications() {
-        let notificationCenter = UNUserNotificationCenter.current()
-        // Cancel any previous scheduled notifications in the Loop Not Running category
-        notificationCenter.getPendingNotificationRequests { notificationRequests in
-            let loopNotRunningIdentifiers = notificationRequests.filter({
-                $0.content.categoryIdentifier == LoopNotificationCategory.loopNotRunning.rawValue
-            }).map({
-                $0.identifier
-            })
-            notificationCenter.removePendingNotificationRequests(withIdentifiers: loopNotRunningIdentifiers)
-        }
         // Clear out any existing not-running notifications
-        notificationCenter.getDeliveredNotifications { notifications in
+        UNUserNotificationCenter.current().getDeliveredNotifications { (notifications) in
             let loopNotRunningIdentifiers = notifications.filter({
                 $0.request.content.categoryIdentifier == LoopNotificationCategory.loopNotRunning.rawValue
             }).map({
                 $0.request.identifier
             })
 
-            notificationCenter.removeDeliveredNotifications(withIdentifiers: loopNotRunningIdentifiers)
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: loopNotRunningIdentifiers)
         }
     }
 


### PR DESCRIPTION
Opening this draft PR as a means of asking @ps2 a question: Pete, shouldn't the future pending loop-not-looping notification requests be cleared on every loop iteration as well as delivered ones.  Otherwise...isn't there a race condition where a UserNotification is delivered, then cleared when a loop iteration happens?  Also, isn't this just loading up UserNotificationCenter's future pending alerts?  Note: `clearPendingNotificationRequests()` does not seem to ever be called anywhere.  (Also: it is implemented incorrectly...)