### PR TITLE
Add query using modification counter

### DIFF
--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -150,7 +150,7 @@ extension AlertStore {
     }
     typealias QueryResult = Result<(QueryAnchor, [StoredAlert]), Error>
 
-    func executeAlertQuery(fromQueryAnchor queryAnchor: QueryAnchor? = nil, limit: Int = 100, completion: @escaping (QueryResult) -> Void) {
+    func executeAlertQuery(fromQueryAnchor queryAnchor: QueryAnchor? = nil, limit: Int, completion: @escaping (QueryResult) -> Void) {
         dataAccessQueue.async {
             var queryAnchor = queryAnchor ?? QueryAnchor()
             var queryResult = [StoredAlert]()

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -20,7 +20,7 @@ final class DeviceDataManager {
     private let log = DiagnosticLog(category: "DeviceDataManager")
 
     let pluginManager: PluginManager
-    weak var deviceAlertManager: DeviceAlertManager?
+    weak var deviceAlertManager: DeviceAlertManager!
 
     /// Remember the launch date of the app for diagnostic reporting
     private let launchDate = Date()
@@ -252,46 +252,51 @@ final class DeviceDataManager {
     
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
         self.loopManager.generateDiagnosticReport { (loopReport) in
-            self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
-                let deviceLogReport: String
-                switch result {
-                case .failure(let error):
-                    deviceLogReport = "Error fetching entries: \(error)"
-                case .success(let entries):
-                    deviceLogReport = entries.map { "* \($0.timestamp) \($0.managerIdentifier) \($0.deviceIdentifier ?? "") \($0.type) \($0.message)" }.joined(separator: "\n")
+            
+            self.deviceAlertManager.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
+                
+                self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
+                    let deviceLogReport: String
+                    switch result {
+                    case .failure(let error):
+                        deviceLogReport = "Error fetching entries: \(error)"
+                    case .success(let entries):
+                        deviceLogReport = entries.map { "* \($0.timestamp) \($0.managerIdentifier) \($0.deviceIdentifier ?? "") \($0.type) \($0.message)" }.joined(separator: "\n")
+                    }
+                    
+                    let report = [
+                        Bundle.main.localizedNameAndVersion,
+                        "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
+                        "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
+                        "* sourceRoot: \(Bundle.main.sourceRoot ?? "N/A")",
+                        "* buildDateString: \(Bundle.main.buildDateString ?? "N/A")",
+                        "* xcodeVersion: \(Bundle.main.xcodeVersion ?? "N/A")",
+                        "",
+                        "## FeatureFlags",
+                        "\(FeatureFlags)",
+                        "",
+                        "## DeviceDataManager",
+                        "* launchDate: \(self.launchDate)",
+                        "* lastError: \(String(describing: self.lastError))",
+                        "* lastBLEDrivenUpdate: \(self.lastBLEDrivenUpdate)",
+                        "",
+                        self.cgmManager != nil ? String(reflecting: self.cgmManager!) : "cgmManager: nil",
+                        "",
+                        self.pumpManager != nil ? String(reflecting: self.pumpManager!) : "pumpManager: nil",
+                        "",
+                        "## Device Communication Log",
+                        deviceLogReport,
+                        "",
+                        String(reflecting: self.watchManager!),
+                        "",
+                        String(reflecting: self.statusExtensionManager!),
+                        "",
+                        loopReport,
+                        alertReport
+                        ].joined(separator: "\n")
+                    
+                    completion(report)
                 }
-                
-                let report = [
-                    Bundle.main.localizedNameAndVersion,
-                    "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
-                    "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
-                    "* sourceRoot: \(Bundle.main.sourceRoot ?? "N/A")",
-                    "* buildDateString: \(Bundle.main.buildDateString ?? "N/A")",
-                    "* xcodeVersion: \(Bundle.main.xcodeVersion ?? "N/A")",
-                    "",
-                    "## FeatureFlags",
-                    "\(FeatureFlags)",
-                    "",
-                    "## DeviceDataManager",
-                    "* launchDate: \(self.launchDate)",
-                    "* lastError: \(String(describing: self.lastError))",
-                    "* lastBLEDrivenUpdate: \(self.lastBLEDrivenUpdate)",
-                    "",
-                    self.cgmManager != nil ? String(reflecting: self.cgmManager!) : "cgmManager: nil",
-                    "",
-                    self.pumpManager != nil ? String(reflecting: self.pumpManager!) : "pumpManager: nil",
-                    "",
-                    "## Device Communication Log",
-                    deviceLogReport,
-                    "",
-                    String(reflecting: self.watchManager!),
-                    "",
-                    String(reflecting: self.statusExtensionManager!),
-                    "",
-                    loopReport,
-                ].joined(separator: "\n")
-                
-                completion(report)
             }
         }
     }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -144,7 +144,7 @@ class AlertStoreTests: XCTestCase {
             switch $0 {
             case .failure(let error): XCTFail("Unexpected \(error)")
             case .success:
-                self.alertStore.executeAlertQuery {
+                self.alertStore.executeAlertQuery(limit: 100) {
                     switch $0 {
                     case .failure(let error): XCTFail("Unexpected \(error)")
                     case .success(let (anchor, storedAlerts)):
@@ -172,7 +172,7 @@ class AlertStoreTests: XCTestCase {
             switch $0 {
             case .failure(let error): XCTFail("Unexpected \(error)")
             case .success:
-                self.alertStore.executeAlertQuery {
+                self.alertStore.executeAlertQuery(limit: 100) {
                     switch $0 {
                     case .failure(let error): XCTFail("Unexpected \(error)")
                     case .success(let (anchor, storedAlerts)):
@@ -188,7 +188,7 @@ class AlertStoreTests: XCTestCase {
                             switch $0 {
                             case .failure(let error): XCTFail("Unexpected \(error)")
                             case .success:
-                                self.alertStore.executeAlertQuery(fromQueryAnchor: anchor) {
+                                self.alertStore.executeAlertQuery(fromQueryAnchor: anchor, limit: 100) {
                                     switch $0 {
                                     case .failure(let error): XCTFail("Unexpected \(error)")
                                     case .success(let (anchor, storedAlerts)):

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -138,19 +138,36 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: 1)
     }
     
+    func testEmptyQuery() {
+        let expect = self.expectation(description: #function)
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast) {
+            switch $0 {
+            case .failure(let error): XCTFail("Unexpected \(error)")
+            case .success:
+                self.alertStore.executeQuery(since: Date.distantPast, limit: 0) {
+                    switch $0 {
+                    case .failure(let error): XCTFail("Unexpected \(error)")
+                    case .success(let (_, storedAlerts)):
+                        XCTAssertTrue(storedAlerts.isEmpty)
+                        expect.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [expect], timeout: 1)
+    }
+    
     func testSimpleQuery() {
         let expect = self.expectation(description: #function)
         alertStore.recordIssued(alert: alert1, at: Date.distantPast) {
             switch $0 {
             case .failure(let error): XCTFail("Unexpected \(error)")
             case .success:
-                self.alertStore.executeAlertQuery(limit: 100) {
+                self.alertStore.executeQuery(since: Date.distantPast, limit: 100) {
                     switch $0 {
                     case .failure(let error): XCTFail("Unexpected \(error)")
                     case .success(let (anchor, storedAlerts)):
-                        var expectedAnchor = AlertStore.QueryAnchor()
-                        expectedAnchor.modificationCounter = 1
-                        XCTAssertEqual(expectedAnchor, anchor)
+                        XCTAssertEqual(1, anchor.modificationCounter)
                         XCTAssertEqual(1, storedAlerts.count)
                         XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
                         XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
@@ -172,13 +189,11 @@ class AlertStoreTests: XCTestCase {
             switch $0 {
             case .failure(let error): XCTFail("Unexpected \(error)")
             case .success:
-                self.alertStore.executeAlertQuery(limit: 100) {
+                self.alertStore.executeQuery(since: Date.distantPast, limit: 100) {
                     switch $0 {
                     case .failure(let error): XCTFail("Unexpected \(error)")
                     case .success(let (anchor, storedAlerts)):
-                        var expectedAnchor = AlertStore.QueryAnchor()
-                        expectedAnchor.modificationCounter = 1
-                        XCTAssertEqual(expectedAnchor, anchor)
+                        XCTAssertEqual(1, anchor.modificationCounter)
                         XCTAssertEqual(1, storedAlerts.count)
                         XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
                         XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
@@ -188,13 +203,11 @@ class AlertStoreTests: XCTestCase {
                             switch $0 {
                             case .failure(let error): XCTFail("Unexpected \(error)")
                             case .success:
-                                self.alertStore.executeAlertQuery(fromQueryAnchor: anchor, limit: 100) {
+                                self.alertStore.executeQuery(since: Date.distantPast, limit: 100) {
                                     switch $0 {
                                     case .failure(let error): XCTFail("Unexpected \(error)")
                                     case .success(let (anchor, storedAlerts)):
-                                        var expectedAnchor = AlertStore.QueryAnchor()
-                                        expectedAnchor.modificationCounter = 2
-                                        XCTAssertEqual(expectedAnchor, anchor)
+                                        XCTAssertEqual(2, anchor.modificationCounter)
                                         XCTAssertEqual(1, storedAlerts.count)
                                         XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
                                         XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
@@ -211,4 +224,103 @@ class AlertStoreTests: XCTestCase {
         }
         wait(for: [expect], timeout: 1)
     }
+    
+    func testQueryByDate() {
+        let expect = self.expectation(description: #function)
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast) {
+            switch $0 {
+            case .failure(let error): XCTFail("Unexpected \(error)")
+            case .success:
+                let now = Date()
+                self.alertStore.recordIssued(alert: self.alert2, at: now) {
+                    switch $0 {
+                    case .failure(let error): XCTFail("Unexpected \(error)")
+                    case .success:
+                        self.alertStore.executeQuery(since: now, limit: 100) {
+                            switch $0 {
+                            case .failure(let error): XCTFail("Unexpected \(error)")
+                            case .success(let (anchor, storedAlerts)):
+                                XCTAssertEqual(2, anchor.modificationCounter)
+                                XCTAssertEqual(1, storedAlerts.count)
+                                XCTAssertEqual(Self.identifier2.value, storedAlerts[0].identifier)
+                                XCTAssertEqual(now, storedAlerts[0].issuedDate)
+                                XCTAssertNil(storedAlerts[0].acknowledgedDate)
+                                XCTAssertNil(storedAlerts[0].retractedDate)
+                                expect.fulfill()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expect], timeout: 1)
+    }
+    
+    func testQueryWithLimit() {
+        let expect = self.expectation(description: #function)
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast) {
+            switch $0 {
+            case .failure(let error): XCTFail("Unexpected \(error)")
+            case .success:
+                self.alertStore.recordIssued(alert: self.alert2, at: Date()) {
+                    switch $0 {
+                    case .failure(let error): XCTFail("Unexpected \(error)")
+                    case .success:
+                        self.alertStore.executeQuery(since: Date.distantPast, limit: 1) {
+                            switch $0 {
+                            case .failure(let error): XCTFail("Unexpected \(error)")
+                            case .success(let (anchor, storedAlerts)):
+                                XCTAssertEqual(1, anchor.modificationCounter)
+                                XCTAssertEqual(1, storedAlerts.count)
+                                XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                                XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
+                                XCTAssertNil(storedAlerts[0].acknowledgedDate)
+                                XCTAssertNil(storedAlerts[0].retractedDate)
+                                expect.fulfill()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expect], timeout: 1)
+    }
+    
+    func testQueryThenContinue() {
+        let expect = self.expectation(description: #function)
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast) {
+            switch $0 {
+            case .failure(let error): XCTFail("Unexpected \(error)")
+            case .success:
+                let now = Date()
+                self.alertStore.recordIssued(alert: self.alert2, at: now) {
+                    switch $0 {
+                    case .failure(let error): XCTFail("Unexpected \(error)")
+                    case .success:
+                        self.alertStore.executeQuery(since: Date.distantPast, limit: 1) {
+                            switch $0 {
+                            case .failure(let error): XCTFail("Unexpected \(error)")
+                            case .success(let (anchor, _)):
+                                self.alertStore.continueQuery(from: anchor, limit: 1) {
+                                    switch $0 {
+                                    case .failure(let error): XCTFail("Unexpected \(error)")
+                                    case .success(let (anchor, storedAlerts)):
+                                        XCTAssertEqual(2, anchor.modificationCounter)
+                                        XCTAssertEqual(1, storedAlerts.count)
+                                        XCTAssertEqual(Self.identifier2.value, storedAlerts[0].identifier)
+                                        XCTAssertEqual(now, storedAlerts[0].issuedDate)
+                                        XCTAssertNil(storedAlerts[0].acknowledgedDate)
+                                        XCTAssertNil(storedAlerts[0].retractedDate)
+                                        expect.fulfill()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        wait(for: [expect], timeout: 1)
+    }
+
 }


### PR DESCRIPTION
This is a follow-up to #89 to add a query using the `modificationCounter`.  Hopefully this will help @darinkrauss with uploading to Tidepool Service.