### PR TITLE
LOOP-1200: alert persistence followups

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		1D05219B2469E9DF000EBBDE /* StoredAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05219A2469E9DF000EBBDE /* StoredAlert.swift */; };
 		1D05219D2469F1F5000EBBDE /* AlertStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05219C2469F1F5000EBBDE /* AlertStore.swift */; };
 		1D080CBD2473214A00356610 /* AlertStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */; };
+		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
+		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
 		1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D80313C24746274002810DF /* AlertStoreTests.swift */; };
 		1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */; };
 		1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */; };
@@ -619,6 +621,8 @@
 		1D05219A2469E9DF000EBBDE /* StoredAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredAlert.swift; sourceTree = "<group>"; };
 		1D05219C2469F1F5000EBBDE /* AlertStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStore.swift; sourceTree = "<group>"; };
 		1D080CBC2473214A00356610 /* AlertStore.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AlertStore.xcdatamodel; sourceTree = "<group>"; };
+		1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataClass.swift"; sourceTree = "<group>"; };
+		1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		1D80313C24746274002810DF /* AlertStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStoreTests.swift; sourceTree = "<group>"; };
 		1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertPresenter.swift; sourceTree = "<group>"; };
 		1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenter.swift; sourceTree = "<group>"; };
@@ -1257,6 +1261,8 @@
 		1DA6499D2441266400F61E75 /* Alerts */ = {
 			isa = PBXGroup;
 			children = (
+				1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */,
+				1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */,
 				1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */,
 				1D05219C2469F1F5000EBBDE /* AlertStore.swift */,
 				1DB1065024467E18005542BD /* DeviceAlertManager.swift */,
@@ -2790,6 +2796,7 @@
 				4346D1E71C77F5FE00ABAFE3 /* ChartTableViewCell.swift in Sources */,
 				437CEEE41CDE5C0A003C8C80 /* UIImage.swift in Sources */,
 				C1201E2C23ECDBD0002DA84A /* WatchContextRequestUserInfo.swift in Sources */,
+				1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */,
 				892ADE082446E1C2007CE08C /* SuspendThresholdEditor.swift in Sources */,
 				892D7C5123B54A15008A9656 /* CarbEntryViewController.swift in Sources */,
 				A999D40424663CE1004C89D4 /* DoseStore.swift in Sources */,
@@ -2815,6 +2822,7 @@
 				4F6663941E905FD2009E74FC /* ChartColorPalette+Loop.swift in Sources */,
 				4328E0351CFC0AE100E199AA /* WatchDataManager.swift in Sources */,
 				4345E3FC21F04911009E00E5 /* UIColor+HIG.swift in Sources */,
+				1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */,
 				43D381621EBD9759007F8C8F /* HeaderValuesTableViewCell.swift in Sources */,
 				A9C62D892331703100535612 /* LoggingServicesManager.swift in Sources */,
 				89E267FF229267DF00A3F2AF /* Optional.swift in Sources */,

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -21,8 +21,6 @@ public class AlertStore {
     private let persistentContainer: NSPersistentContainer
         
     private let log = DiagnosticLog(category: "AlertStore")
-
-    private let dataAccessQueue = DispatchQueue(label: "com.loop.AlertStore.dataAccessQueue", qos: .utility)
     
     public init(storageFileURL: URL? = nil) {
         managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
@@ -53,17 +51,15 @@ public class AlertStore {
 extension AlertStore {
     
     public func recordIssued(alert: DeviceAlert, at date: Date = Date(), completion: ((Result<Void, Error>) -> Void)? = nil) {
-        dataAccessQueue.async {
-            self.managedObjectContext.perform {
-                _ = StoredAlert(from: alert, context: self.managedObjectContext, issuedDate: date)
-                do {
-                    try self.managedObjectContext.save()
-                    self.log.default("Recorded alert: %{public}@", alert.identifier.value)
-                    completion?(.success)
-                } catch {
-                    self.log.error("Could not store alert: %{public}@, %{public}@", alert.identifier.value, String(describing: error))
-                    completion?(.failure(error))
-                }
+        self.managedObjectContext.perform {
+            _ = StoredAlert(from: alert, context: self.managedObjectContext, issuedDate: date)
+            do {
+                try self.managedObjectContext.save()
+                self.log.default("Recorded alert: %{public}@", alert.identifier.value)
+                completion?(.success)
+            } catch {
+                self.log.error("Could not store alert: %{public}@, %{public}@", alert.identifier.value, String(describing: error))
+                completion?(.failure(error))
             }
         }
     }
@@ -81,32 +77,31 @@ extension AlertStore {
     private func recordUpdateOfLatest(of identifier: DeviceAlert.Identifier,
                                       with block: @escaping (StoredAlert) -> Void,
                                       completion: ((Result<Void, Error>) -> Void)?) {
-        dataAccessQueue.async {
-            self.managedObjectContext.perform {
-                self.lookupLatest(identifier: identifier) {
-                    switch $0 {
-                    case .success(let object):
-                        if let object = object {
-                            block(object)
-                            do {
-                                try self.managedObjectContext.save()
-                                self.log.default("Recorded alert: %{public}@", identifier.value)
-                                completion?(.success)
-                            } catch {
-                                self.log.error("Could not store alert: %{public}@, %{public}@", identifier.value, String(describing: error))
-                                completion?(.failure(error))
-                            }
-                        } else {
-                            self.log.default("Alert not found for update: %{public}@", identifier.value)
-                            completion?(.failure(AlertStoreError.notFound))
+        self.managedObjectContext.perform {
+            self.lookupLatest(identifier: identifier) {
+                switch $0 {
+                case .success(let object):
+                    if let object = object {
+                        block(object)
+                        do {
+                            try self.managedObjectContext.save()
+                            self.log.default("Recorded alert: %{public}@", identifier.value)
+                            completion?(.success)
+                        } catch {
+                            self.log.error("Could not store alert: %{public}@, %{public}@", identifier.value, String(describing: error))
+                            completion?(.failure(error))
                         }
-                    case .failure(let error):
-                        completion?(.failure(error))
+                    } else {
+                        self.log.default("Alert not found for update: %{public}@", identifier.value)
+                        completion?(.failure(AlertStoreError.notFound))
                     }
+                case .failure(let error):
+                    completion?(.failure(error))
                 }
             }
         }
     }
+
     
     private func lookupLatest(identifier: DeviceAlert.Identifier, completion: @escaping (Result<StoredAlert?, Error>) -> Void) {
         managedObjectContext.perform {
@@ -126,15 +121,24 @@ extension AlertStore {
 
 }
 
+public protocol QueryFilter: Equatable {
+    var predicate: NSPredicate? { get }
+}
+
 // MARK: Query Support
 
 extension AlertStore {
-
-    public struct QueryAnchor: RawRepresentable, Equatable {
+    
+    public struct QueryAnchor<Filter: QueryFilter>: RawRepresentable, Equatable {
         public typealias RawValue = [String: Any]
         internal var modificationCounter: Int64
+        internal var filter: Filter?
         public init() {
             self.modificationCounter = 0
+        }
+        init(modificationCounter: Int64? = nil, filter: Filter?) {
+            self.modificationCounter = modificationCounter ?? 0
+            self.filter = filter
         }
         public init?(rawValue: RawValue) {
             guard let modificationCounter = rawValue["modificationCounter"] as? Int64 else {
@@ -148,65 +152,64 @@ extension AlertStore {
             return rawValue
         }
     }
-    typealias QueryResult = Result<(QueryAnchor, [StoredAlert]), Error>
+    typealias QueryResult<Filter: QueryFilter> = Result<(QueryAnchor<Filter>, [StoredAlert]), Error>
     
-    func executeAlertQuery(from queryAnchor: QueryAnchor? = nil, since date: Date? = nil, limit: Int, completion: @escaping (QueryResult) -> Void) {
-        dataAccessQueue.async {
-            var queryAnchor = queryAnchor ?? QueryAnchor()
-            var queryResult = [StoredAlert]()
-            var queryError: Error?
+    struct NoFilter: QueryFilter {
+        let predicate: NSPredicate?
+    }
+    struct SinceDateFilter: QueryFilter {
+        let date: Date
+        var predicate: NSPredicate? { NSPredicate(format: "issuedDate >= %@", date as NSDate) }
+    }
+    
+    func executeQuery(since date: Date, limit: Int, completion: @escaping (QueryResult<SinceDateFilter>) -> Void) {
+        executeAlertQuery(from: QueryAnchor(filter: SinceDateFilter(date: date)), limit: limit, completion: completion)
+    }
+    
+    func continueQuery<Filter: QueryFilter>(from anchor: QueryAnchor<Filter>, limit: Int, completion: @escaping (QueryResult<Filter>) -> Void) {
+        executeAlertQuery(from: anchor, limit: limit, completion: completion)
+    }
 
+    private func executeAlertQuery<Filter: QueryFilter>(from anchor: QueryAnchor<Filter>, limit: Int, completion: @escaping (QueryResult<Filter>) -> Void) {
+        self.managedObjectContext.perform {
             guard limit > 0 else {
-                completion(.success((queryAnchor, queryResult)))
+                completion(.success((anchor, [])))
                 return
             }
-
-            self.managedObjectContext.performAndWait {
-                let storedRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
-                if let date = date {
-                    storedRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
-                        NSPredicate(format: "modificationCounter > %d", queryAnchor.modificationCounter),
-                        NSPredicate(format: "issuedDate >= %@", date as NSDate)
-                    ])
-                } else {
-                    storedRequest.predicate = NSPredicate(format: "modificationCounter > %d", queryAnchor.modificationCounter)
-                }
-                storedRequest.sortDescriptors = [NSSortDescriptor(key: "modificationCounter", ascending: true)]
-                storedRequest.fetchLimit = limit
-
-                do {
-                    let stored = try self.managedObjectContext.fetch(storedRequest)
-                    if let modificationCounter = stored.max(by: { $0.modificationCounter < $1.modificationCounter })?.modificationCounter {
-                        queryAnchor.modificationCounter = modificationCounter
-                    }
-                    queryResult.append(contentsOf: stored)
-                } catch let error {
-                    queryError = error
-                    return
-                }
+            let storedRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
+            let anchorPredicate = NSPredicate(format: "modificationCounter > %d", anchor.modificationCounter)
+            if let filterPredicate = anchor.filter?.predicate {
+                storedRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    anchorPredicate,
+                    filterPredicate
+                ])
+            } else {
+                storedRequest.predicate = anchorPredicate
             }
-
-            if let queryError = queryError {
-                completion(.failure(queryError))
-                return
+            storedRequest.sortDescriptors = [NSSortDescriptor(key: "modificationCounter", ascending: true)]
+            storedRequest.fetchLimit = limit
+            
+            do {
+                let stored = try self.managedObjectContext.fetch(storedRequest)
+                let modificationCounter = stored.max(by: { $0.modificationCounter < $1.modificationCounter })?.modificationCounter
+                let newAnchor = QueryAnchor<Filter>(modificationCounter: modificationCounter, filter: anchor.filter)
+                completion(.success((newAnchor, stored)))
+            } catch let error {
+                completion(.failure(error))
             }
-
-            completion(.success((queryAnchor, queryResult)))
         }
     }
-        
+    
     // At the moment, this is only used for unit testing
     internal func fetch(identifier: DeviceAlert.Identifier, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
-        dataAccessQueue.async {
-            self.managedObjectContext.performAndWait {
-                let storedRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
-                storedRequest.predicate = NSPredicate(format: "identifier == %@", identifier.value)
-                do {
-                    let stored = try self.managedObjectContext.fetch(storedRequest)
-                    completion(.success(stored))
-                } catch {
-                    completion(.failure(error))
-                }
+        self.managedObjectContext.perform {
+            let storedRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
+            storedRequest.predicate = NSPredicate(format: "identifier == %@", identifier.value)
+            do {
+                let stored = try self.managedObjectContext.fetch(storedRequest)
+                completion(.success(stored))
+            } catch {
+                completion(.failure(error))
             }
         }
     }

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -150,7 +150,7 @@ extension AlertStore {
     }
     typealias QueryResult = Result<(QueryAnchor, [StoredAlert]), Error>
 
-    func executeAlertQuery(fromQueryAnchor queryAnchor: QueryAnchor? = nil, limit: Int = 100, completion: @escaping (QueryResult) -> Void) {
+    func executeAlertQuery(fromQueryAnchor queryAnchor: QueryAnchor? = nil, limit: Int, completion: @escaping (QueryResult) -> Void) {
         dataAccessQueue.async {
             var queryAnchor = queryAnchor ?? QueryAnchor()
             var queryResult = [StoredAlert]()

--- a/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
+++ b/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15702" systemVersion="19E287" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="StoredAlert" representedClassName=".StoredAlert" syncable="YES" codeGenerationType="class">
+    <entity name="StoredAlert" representedClassName=".StoredAlert" syncable="YES">
         <attribute name="acknowledgedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="alertIdentifier" attributeType="String"/>
         <attribute name="backgroundContent" optional="YES" attributeType="String"/>
         <attribute name="foregroundContent" optional="YES" attributeType="String"/>
-        <attribute name="identifier" attributeType="String"/>
         <attribute name="isCritical" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="issuedDate" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="managerIdentifier" attributeType="String"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="retractedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="sound" optional="YES" attributeType="String"/>
@@ -14,6 +15,6 @@
         <attribute name="triggerType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <elements>
-        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="28"/>
+        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="223"/>
     </elements>
 </model>

--- a/Loop/Managers/Alerts/DeviceAlertManager.swift
+++ b/Loop/Managers/Alerts/DeviceAlertManager.swift
@@ -234,23 +234,23 @@ extension DeviceAlertManager {
 extension DeviceAlertManager {
     
     func getStoredEntries(startDate: Date, completion: @escaping (_ report: String) -> Void) {
-        alertStore.executeAlertQuery(since: startDate, limit: 100) {
-            switch $0 {
+        alertStore.executeQuery(since: startDate, limit: 100) { result in
+            switch result {
             case .failure(let error): completion("Error: \(error)")
             case .success(let entries):
-                let report = "## Alerts\n" + entries.1.map {
+                let report = "## Alerts\n" + entries.1.map { storedAlert in
                     return """
-                    **\($0.title ?? "??")**
+                    **\(storedAlert.title ?? "??")**
                     
-                    * identifier: \($0.identifier!)
-                    * issued: \($0.issuedDate!)
-                    * acknowledged: \($0.acknowledgedDate?.description ?? "n/a")
-                    * retracted: \($0.retractedDate?.description ?? "n/a")
-                    * isCritical: \($0.isCritical)
-                    * trigger: \($0.trigger)
-                    * foregroundContent: \($0.foregroundContent ?? "n/a")
-                    * backgroundContent: \($0.backgroundContent ?? "n/a")
-                    * sound: \($0.sound ?? "n/a")
+                    * identifier: \(storedAlert.identifier!)
+                    * issued: \(storedAlert.issuedDate!)
+                    * acknowledged: \(storedAlert.acknowledgedDate?.description ?? "n/a")
+                    * retracted: \(storedAlert.retractedDate?.description ?? "n/a")
+                    * isCritical: \(storedAlert.isCritical)
+                    * trigger: \(storedAlert.trigger)
+                    * foregroundContent: \(storedAlert.foregroundContent ?? "n/a")
+                    * backgroundContent: \(storedAlert.backgroundContent ?? "n/a")
+                    * sound: \(storedAlert.sound ?? "n/a")
 
                     """
                 }.joined(separator: "\n")

--- a/Loop/Managers/Alerts/DeviceAlertManager.swift
+++ b/Loop/Managers/Alerts/DeviceAlertManager.swift
@@ -236,14 +236,16 @@ extension DeviceAlertManager {
     func getStoredEntries(startDate: Date, completion: @escaping (_ report: String) -> Void) {
         alertStore.executeQuery(since: startDate, limit: 100) { result in
             switch result {
-            case .failure(let error): completion("Error: \(error)")
+            case .failure(let error):
+                completion("Error: \(error)")
             case .success(let entries):
                 let report = "## Alerts\n" + entries.1.map { storedAlert in
                     return """
                     **\(storedAlert.title ?? "??")**
                     
-                    * identifier: \(storedAlert.identifier!)
-                    * issued: \(storedAlert.issuedDate!)
+                    * alertIdentifier: \(storedAlert.alertIdentifier)
+                    * managerIdentifier: \(storedAlert.managerIdentifier)
+                    * issued: \(storedAlert.issuedDate)
                     * acknowledged: \(storedAlert.acknowledgedDate?.description ?? "n/a")
                     * retracted: \(storedAlert.retractedDate?.description ?? "n/a")
                     * isCritical: \(storedAlert.isCritical)

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
@@ -1,0 +1,16 @@
+//
+//  StoredAlert+CoreDataClass.swift
+//  Loop
+//
+//  Created by Rick Pasetto on 5/22/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+public class StoredAlert: NSManagedObject {
+
+}

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -1,0 +1,33 @@
+//
+//  StoredAlert+CoreDataProperties.swift
+//  Loop
+//
+//  Created by Rick Pasetto on 5/22/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension StoredAlert {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<StoredAlert> {
+        return NSFetchRequest<StoredAlert>(entityName: "StoredAlert")
+    }
+
+    @NSManaged public var acknowledgedDate: Date?
+    @NSManaged public var alertIdentifier: String
+    @NSManaged public var backgroundContent: String?
+    @NSManaged public var foregroundContent: String?
+    @NSManaged public var isCritical: Bool
+    @NSManaged public var issuedDate: Date
+    @NSManaged public var managerIdentifier: String
+    @NSManaged public var modificationCounter: Int64
+    @NSManaged public var retractedDate: Date?
+    @NSManaged public var sound: String?
+    @NSManaged public var triggerInterval: NSNumber?
+    @NSManaged public var triggerType: Int16
+
+}

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -18,7 +18,8 @@ extension StoredAlert {
         do {
             self.init(context: context)
             self.issuedDate = issuedDate
-            identifier = deviceAlert.identifier.value
+            alertIdentifier = deviceAlert.identifier.alertIdentifier
+            managerIdentifier = deviceAlert.identifier.managerIdentifier
             triggerType = deviceAlert.trigger.storedType
             triggerInterval = deviceAlert.trigger.storedInterval
             isCritical = deviceAlert.foregroundContent?.isCritical ?? false || deviceAlert.backgroundContent?.isCritical ?? false
@@ -49,6 +50,10 @@ extension StoredAlert {
             return content.title
         }
         return nil
+    }
+    
+    public var identifier: DeviceAlert.Identifier {
+        return DeviceAlert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier)
     }
     
     public override func willSave() {

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -20,7 +20,7 @@ final class DeviceDataManager {
     private let log = DiagnosticLog(category: "DeviceDataManager")
 
     let pluginManager: PluginManager
-    weak var deviceAlertManager: DeviceAlertManager?
+    weak var deviceAlertManager: DeviceAlertManager!
 
     /// Remember the launch date of the app for diagnostic reporting
     private let launchDate = Date()
@@ -253,7 +253,7 @@ final class DeviceDataManager {
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
         self.loopManager.generateDiagnosticReport { (loopReport) in
             
-            self.deviceAlertManager?.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
+            self.deviceAlertManager.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
                 
                 self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
                     let deviceLogReport: String

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -252,46 +252,51 @@ final class DeviceDataManager {
     
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
         self.loopManager.generateDiagnosticReport { (loopReport) in
-            self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
-                let deviceLogReport: String
-                switch result {
-                case .failure(let error):
-                    deviceLogReport = "Error fetching entries: \(error)"
-                case .success(let entries):
-                    deviceLogReport = entries.map { "* \($0.timestamp) \($0.managerIdentifier) \($0.deviceIdentifier ?? "") \($0.type) \($0.message)" }.joined(separator: "\n")
+            
+            self.deviceAlertManager?.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
+                
+                self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
+                    let deviceLogReport: String
+                    switch result {
+                    case .failure(let error):
+                        deviceLogReport = "Error fetching entries: \(error)"
+                    case .success(let entries):
+                        deviceLogReport = entries.map { "* \($0.timestamp) \($0.managerIdentifier) \($0.deviceIdentifier ?? "") \($0.type) \($0.message)" }.joined(separator: "\n")
+                    }
+                    
+                    let report = [
+                        Bundle.main.localizedNameAndVersion,
+                        "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
+                        "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
+                        "* sourceRoot: \(Bundle.main.sourceRoot ?? "N/A")",
+                        "* buildDateString: \(Bundle.main.buildDateString ?? "N/A")",
+                        "* xcodeVersion: \(Bundle.main.xcodeVersion ?? "N/A")",
+                        "",
+                        "## FeatureFlags",
+                        "\(FeatureFlags)",
+                        "",
+                        "## DeviceDataManager",
+                        "* launchDate: \(self.launchDate)",
+                        "* lastError: \(String(describing: self.lastError))",
+                        "* lastBLEDrivenUpdate: \(self.lastBLEDrivenUpdate)",
+                        "",
+                        self.cgmManager != nil ? String(reflecting: self.cgmManager!) : "cgmManager: nil",
+                        "",
+                        self.pumpManager != nil ? String(reflecting: self.pumpManager!) : "pumpManager: nil",
+                        "",
+                        "## Device Communication Log",
+                        deviceLogReport,
+                        "",
+                        String(reflecting: self.watchManager!),
+                        "",
+                        String(reflecting: self.statusExtensionManager!),
+                        "",
+                        loopReport,
+                        alertReport
+                        ].joined(separator: "\n")
+                    
+                    completion(report)
                 }
-                
-                let report = [
-                    Bundle.main.localizedNameAndVersion,
-                    "* gitRevision: \(Bundle.main.gitRevision ?? "N/A")",
-                    "* gitBranch: \(Bundle.main.gitBranch ?? "N/A")",
-                    "* sourceRoot: \(Bundle.main.sourceRoot ?? "N/A")",
-                    "* buildDateString: \(Bundle.main.buildDateString ?? "N/A")",
-                    "* xcodeVersion: \(Bundle.main.xcodeVersion ?? "N/A")",
-                    "",
-                    "## FeatureFlags",
-                    "\(FeatureFlags)",
-                    "",
-                    "## DeviceDataManager",
-                    "* launchDate: \(self.launchDate)",
-                    "* lastError: \(String(describing: self.lastError))",
-                    "* lastBLEDrivenUpdate: \(self.lastBLEDrivenUpdate)",
-                    "",
-                    self.cgmManager != nil ? String(reflecting: self.cgmManager!) : "cgmManager: nil",
-                    "",
-                    self.pumpManager != nil ? String(reflecting: self.pumpManager!) : "pumpManager: nil",
-                    "",
-                    "## Device Communication Log",
-                    deviceLogReport,
-                    "",
-                    String(reflecting: self.watchManager!),
-                    "",
-                    String(reflecting: self.statusExtensionManager!),
-                    "",
-                    loopReport,
-                ].joined(separator: "\n")
-                
-                completion(report)
             }
         }
     }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -144,7 +144,7 @@ class AlertStoreTests: XCTestCase {
             switch $0 {
             case .failure(let error): XCTFail("Unexpected \(error)")
             case .success:
-                self.alertStore.executeAlertQuery {
+                self.alertStore.executeAlertQuery(limit: 100) {
                     switch $0 {
                     case .failure(let error): XCTFail("Unexpected \(error)")
                     case .success(let (anchor, storedAlerts)):
@@ -172,7 +172,7 @@ class AlertStoreTests: XCTestCase {
             switch $0 {
             case .failure(let error): XCTFail("Unexpected \(error)")
             case .success:
-                self.alertStore.executeAlertQuery {
+                self.alertStore.executeAlertQuery(limit: 100) {
                     switch $0 {
                     case .failure(let error): XCTFail("Unexpected \(error)")
                     case .success(let (anchor, storedAlerts)):
@@ -188,7 +188,7 @@ class AlertStoreTests: XCTestCase {
                             switch $0 {
                             case .failure(let error): XCTFail("Unexpected \(error)")
                             case .success:
-                                self.alertStore.executeAlertQuery(fromQueryAnchor: anchor) {
+                                self.alertStore.executeAlertQuery(fromQueryAnchor: anchor, limit: 100) {
                                     switch $0 {
                                     case .failure(let error): XCTFail("Unexpected \(error)")
                                     case .success(let (anchor, storedAlerts)):

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -45,7 +45,7 @@ class AlertStoreTests: XCTestCase {
         XCTAssertNil(object.retractedDate)
         XCTAssertEqual("{\"body\":\"body\",\"isCritical\":true,\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\"}", object.backgroundContent)
         XCTAssertEqual("{\"body\":\"body\",\"isCritical\":true,\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\"}", object.foregroundContent)
-        XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier)
+        XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier.value)
         XCTAssertEqual(true, object.isCritical)
         XCTAssertEqual(Date.distantPast, object.issuedDate)
         XCTAssertEqual(0, object.modificationCounter)
@@ -64,7 +64,7 @@ class AlertStoreTests: XCTestCase {
                         case .failure(let error): XCTFail("Unexpected \(error)")
                         case .success(let storedAlerts):
                             XCTAssertEqual(1, storedAlerts.count)
-                            XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                            XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                             XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
                             XCTAssertNil(storedAlerts[0].acknowledgedDate)
                             XCTAssertNil(storedAlerts[0].retractedDate)
@@ -93,7 +93,7 @@ class AlertStoreTests: XCTestCase {
                             case .failure(let error): XCTFail("Unexpected \(error)")
                             case .success(let storedAlerts):
                                 XCTAssertEqual(1, storedAlerts.count)
-                                XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                                XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                                 XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
                                 XCTAssertEqual(acknowledgedDate, storedAlerts[0].acknowledgedDate)
                                 XCTAssertNil(storedAlerts[0].retractedDate)
@@ -124,7 +124,7 @@ class AlertStoreTests: XCTestCase {
                             case .failure(let error): XCTFail("Unexpected \(error)")
                             case .success(let storedAlerts):
                                 XCTAssertEqual(1, storedAlerts.count)
-                                XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                                XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                                 XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
                                 XCTAssertEqual(retractedDate, storedAlerts[0].retractedDate)
                                 XCTAssertNil(storedAlerts[0].acknowledgedDate)
@@ -169,7 +169,7 @@ class AlertStoreTests: XCTestCase {
                     case .success(let (anchor, storedAlerts)):
                         XCTAssertEqual(1, anchor.modificationCounter)
                         XCTAssertEqual(1, storedAlerts.count)
-                        XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                        XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                         XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
                         XCTAssertNil(storedAlerts[0].acknowledgedDate)
                         XCTAssertNil(storedAlerts[0].retractedDate)
@@ -195,7 +195,7 @@ class AlertStoreTests: XCTestCase {
                     case .success(let (anchor, storedAlerts)):
                         XCTAssertEqual(1, anchor.modificationCounter)
                         XCTAssertEqual(1, storedAlerts.count)
-                        XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                        XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                         XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
                         XCTAssertNil(storedAlerts[0].acknowledgedDate)
                         XCTAssertNil(storedAlerts[0].retractedDate)
@@ -209,7 +209,7 @@ class AlertStoreTests: XCTestCase {
                                     case .success(let (anchor, storedAlerts)):
                                         XCTAssertEqual(2, anchor.modificationCounter)
                                         XCTAssertEqual(1, storedAlerts.count)
-                                        XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                                        XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                                         XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
                                         XCTAssertEqual(retractedDate, storedAlerts[0].retractedDate)
                                         XCTAssertNil(storedAlerts[0].acknowledgedDate)
@@ -242,7 +242,7 @@ class AlertStoreTests: XCTestCase {
                             case .success(let (anchor, storedAlerts)):
                                 XCTAssertEqual(2, anchor.modificationCounter)
                                 XCTAssertEqual(1, storedAlerts.count)
-                                XCTAssertEqual(Self.identifier2.value, storedAlerts[0].identifier)
+                                XCTAssertEqual(Self.identifier2, storedAlerts[0].identifier)
                                 XCTAssertEqual(now, storedAlerts[0].issuedDate)
                                 XCTAssertNil(storedAlerts[0].acknowledgedDate)
                                 XCTAssertNil(storedAlerts[0].retractedDate)
@@ -272,7 +272,7 @@ class AlertStoreTests: XCTestCase {
                             case .success(let (anchor, storedAlerts)):
                                 XCTAssertEqual(1, anchor.modificationCounter)
                                 XCTAssertEqual(1, storedAlerts.count)
-                                XCTAssertEqual(Self.identifier1.value, storedAlerts[0].identifier)
+                                XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                                 XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
                                 XCTAssertNil(storedAlerts[0].acknowledgedDate)
                                 XCTAssertNil(storedAlerts[0].retractedDate)
@@ -307,7 +307,7 @@ class AlertStoreTests: XCTestCase {
                                     case .success(let (anchor, storedAlerts)):
                                         XCTAssertEqual(2, anchor.modificationCounter)
                                         XCTAssertEqual(1, storedAlerts.count)
-                                        XCTAssertEqual(Self.identifier2.value, storedAlerts[0].identifier)
+                                        XCTAssertEqual(Self.identifier2, storedAlerts[0].identifier)
                                         XCTAssertEqual(now, storedAlerts[0].issuedDate)
                                         XCTAssertNil(storedAlerts[0].acknowledgedDate)
                                         XCTAssertNil(storedAlerts[0].retractedDate)


### PR DESCRIPTION
After speaking with Paul, it became clear to me that we are going to need to be able to either filter or group by device when querying alerts (possibly post-510K, but it is way easier to do this now).  So, I split out `alertIdentifier` and `managerIdentifier` again.

Also, by request, this PR changes from using auto-generated code to "manually generated" code for `StoredAlert`