### PR TITLE
Minor guardrails fixes

### DIFF
--- a/Loop/Views/CorrectionRangeOverridesEditor.swift
+++ b/Loop/Views/CorrectionRangeOverridesEditor.swift
@@ -123,8 +123,8 @@ struct CorrectionRangeOverridesEditor: View {
                                 }
                             }
                         ),
-                        unit: unit,
-                        minValue: minValue,
+                        unit: self.unit,
+                        minValue: self.minValue,
                         guardrail: self.guardrail(for: preset)
                     )
                 }

--- a/Loop/Views/SuspendThresholdEditor.swift
+++ b/Loop/Views/SuspendThresholdEditor.swift
@@ -77,11 +77,14 @@ struct SuspendThresholdEditor: View {
                             },
                             expandedContent: {
                                 GlucoseValuePicker(
-                                    value: $value.animation(),
-                                    unit: unit,
-                                    guardrail: guardrail,
-                                    bounds: guardrail.absoluteBounds.lowerBound...(maxValue ?? guardrail.absoluteBounds.upperBound)
+                                    value: self.$value.animation(),
+                                    unit: self.unit,
+                                    guardrail: self.guardrail,
+                                    bounds: self.guardrail.absoluteBounds.lowerBound...(self.maxValue ?? self.guardrail.absoluteBounds.upperBound)
                                 )
+                                // Prevent the picker from expanding the card's width on small devices
+                                .frame(maxWidth: UIScreen.main.bounds.width - 48)
+                                .clipped()
                             }
                         )
                     }


### PR DESCRIPTION
- Update callsites with required `self` for now-escaping closure as of https://github.com/tidepool-org/LoopKit/pull/105
- Prevent suspend threshold picker from expanding the card's width on iPhone SE (Gen 1)