### PR TITLE
LOOP-1006: Make 60- and 120-minute "Loop not Looping" alert critical

### DIFF
--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -145,7 +145,11 @@ struct NotificationManager {
             }
 
             notification.title = NSLocalizedString("Loop Failure", comment: "The notification title for a loop failure")
-            notification.sound = isCritical ? .defaultCritical : .default
+            if isCritical, FeatureFlags.criticalAlertsEnabled, #available(iOS 12.0, *) {
+                notification.sound = .defaultCritical
+            } else {
+                notification.sound = .default
+            }
             notification.categoryIdentifier = LoopNotificationCategory.loopNotRunning.rawValue
             notification.threadIdentifier = LoopNotificationCategory.loopNotRunning.rawValue
 

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -131,7 +131,7 @@ struct NotificationManager {
         // Give a little extra time for a loop-in-progress to complete
         let gracePeriod = TimeInterval(minutes: 0.5)
 
-        for (minutes, isCritical): (Double, Bool) in [(20, false), (40, false), (60, true), (120, true)] {
+        for (minutes, isCritical) in [(20.0, false), (40.0, false), (60.0, true), (120.0, true)] {
             let notification = UNMutableNotificationContent()
             let failureInterval = TimeInterval(minutes: minutes)
 

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -131,7 +131,7 @@ struct NotificationManager {
         // Give a little extra time for a loop-in-progress to complete
         let gracePeriod = TimeInterval(minutes: 0.5)
 
-        for minutes: Double in [20, 40, 60, 120] {
+        for (minutes, isCritical): (Double, Bool) in [(20, false), (40, false), (60, true), (120, true)] {
             let notification = UNMutableNotificationContent()
             let failureInterval = TimeInterval(minutes: minutes)
 
@@ -145,7 +145,7 @@ struct NotificationManager {
             }
 
             notification.title = NSLocalizedString("Loop Failure", comment: "The notification title for a loop failure")
-            notification.sound = .default
+            notification.sound = isCritical ? .defaultCritical : .default
             notification.categoryIdentifier = LoopNotificationCategory.loopNotRunning.rawValue
             notification.threadIdentifier = LoopNotificationCategory.loopNotRunning.rawValue
 


### PR DESCRIPTION
Note: I tested this by:
1. "forcing" (via a code change, not included here) scheduling the loop-not-looping notification
2. Force-quitting the app
3. waiting 60 minutes, observing three notifications, 2 not critical, 1 critical.

[LOOP-1006](https://tidepool.atlassian.net/browse/LOOP-1006)