### PR TITLE
Rename DeviceAlert -> Alert

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -28,12 +28,12 @@
 		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
 		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
 		1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D80313C24746274002810DF /* AlertStoreTests.swift */; };
-		1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */; };
-		1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */; };
-		1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */; };
-		1DA7A84424477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */; };
-		1DB1065124467E18005542BD /* DeviceAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* DeviceAlertManager.swift */; };
-		1DFE9E172447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE9E162447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift */; };
+		1DA649A7244126CD00F61E75 /* UserNotificationAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationAlertPresenter.swift */; };
+		1DA649A9244126DA00F61E75 /* InAppModalAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalAlertPresenter.swift */; };
+		1DA7A84224476EAD008257F0 /* AlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* AlertManagerTests.swift */; };
+		1DA7A84424477698008257F0 /* InAppModalAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84324477698008257F0 /* InAppModalAlertPresenterTests.swift */; };
+		1DB1065124467E18005542BD /* AlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* AlertManager.swift */; };
+		1DFE9E172447B6270082C280 /* UserNotificationAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE9E162447B6270082C280 /* UserNotificationAlertPresenterTests.swift */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */; };
 		4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */; };
@@ -626,12 +626,12 @@
 		1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataClass.swift"; sourceTree = "<group>"; };
 		1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		1D80313C24746274002810DF /* AlertStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStoreTests.swift; sourceTree = "<group>"; };
-		1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertPresenter.swift; sourceTree = "<group>"; };
-		1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenter.swift; sourceTree = "<group>"; };
-		1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceAlertManagerTests.swift; sourceTree = "<group>"; };
-		1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppModalDeviceAlertPresenterTests.swift; sourceTree = "<group>"; };
-		1DB1065024467E18005542BD /* DeviceAlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceAlertManager.swift; sourceTree = "<group>"; };
-		1DFE9E162447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationDeviceAlertPresenterTests.swift; sourceTree = "<group>"; };
+		1DA649A6244126CD00F61E75 /* UserNotificationAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationAlertPresenter.swift; sourceTree = "<group>"; };
+		1DA649A8244126DA00F61E75 /* InAppModalAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalAlertPresenter.swift; sourceTree = "<group>"; };
+		1DA7A84124476EAD008257F0 /* AlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManagerTests.swift; sourceTree = "<group>"; };
+		1DA7A84324477698008257F0 /* InAppModalAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppModalAlertPresenterTests.swift; sourceTree = "<group>"; };
+		1DB1065024467E18005542BD /* AlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertManager.swift; sourceTree = "<group>"; };
+		1DFE9E162447B6270082C280 /* UserNotificationAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationAlertPresenterTests.swift; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryTableViewController.swift; sourceTree = "<group>"; };
 		430B29892041F54A00BA9F93 /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
@@ -1265,14 +1265,14 @@
 		1DA6499D2441266400F61E75 /* Alerts */ = {
 			isa = PBXGroup;
 			children = (
+				1DB1065024467E18005542BD /* AlertManager.swift */,
+				1D05219C2469F1F5000EBBDE /* AlertStore.swift */,
+				1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */,
+				1DA649A8244126DA00F61E75 /* InAppModalAlertPresenter.swift */,
+				1D05219A2469E9DF000EBBDE /* StoredAlert.swift */,
 				1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */,
 				1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */,
-				1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */,
-				1D05219C2469F1F5000EBBDE /* AlertStore.swift */,
-				1DB1065024467E18005542BD /* DeviceAlertManager.swift */,
-				1DA649A8244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift */,
-				1D05219A2469E9DF000EBBDE /* StoredAlert.swift */,
-				1DA649A6244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift */,
+				1DA649A6244126CD00F61E75 /* UserNotificationAlertPresenter.swift */,
 			);
 			path = Alerts;
 			sourceTree = "<group>";
@@ -1289,9 +1289,9 @@
 			isa = PBXGroup;
 			children = (
 				1D80313C24746274002810DF /* AlertStoreTests.swift */,
-				1DA7A84124476EAD008257F0 /* DeviceAlertManagerTests.swift */,
-				1DA7A84324477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift */,
-				1DFE9E162447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift */,
+				1DA7A84124476EAD008257F0 /* AlertManagerTests.swift */,
+				1DA7A84324477698008257F0 /* InAppModalAlertPresenterTests.swift */,
+				1DFE9E162447B6270082C280 /* UserNotificationAlertPresenterTests.swift */,
 			);
 			path = Alerts;
 			sourceTree = "<group>";
@@ -2780,14 +2780,14 @@
 				C1F8B243223E73FD00DD66CF /* BolusProgressTableViewCell.swift in Sources */,
 				89D6953E23B6DF8A002B3066 /* PotentialCarbEntryTableViewCell.swift in Sources */,
 				89CA2B30226C0161004D9350 /* DirectoryObserver.swift in Sources */,
-				1DA649A7244126CD00F61E75 /* UserNotificationDeviceAlertPresenter.swift in Sources */,
+				1DA649A7244126CD00F61E75 /* UserNotificationAlertPresenter.swift in Sources */,
 				439A7942211F631C0041B75F /* RootNavigationController.swift in Sources */,
 				4F11D3C020DCBEEC006E072C /* GlucoseBackfillRequestUserInfo.swift in Sources */,
 				892ADE0A2446E9C3007CE08C /* ExplicitlyDismissibleModal.swift in Sources */,
 				43F5C2DB1B92A5E1003EB13D /* SettingsTableViewController.swift in Sources */,
 				89E267FC2292456700A3F2AF /* FeatureFlags.swift in Sources */,
 				43A567691C94880B00334FAC /* LoopDataManager.swift in Sources */,
-				1DA649A9244126DA00F61E75 /* InAppModalDeviceAlertPresenter.swift in Sources */,
+				1DA649A9244126DA00F61E75 /* InAppModalAlertPresenter.swift in Sources */,
 				43B260491ED248FB008CAA77 /* CarbEntryTableViewCell.swift in Sources */,
 				4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */,
 				43F64DD91D9C92C900D24DC6 /* TitleSubtitleTableViewCell.swift in Sources */,
@@ -2810,7 +2810,7 @@
 				89CA2B32226C18B8004D9350 /* TestingScenariosTableViewController.swift in Sources */,
 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
 				43C05CAF21EB2C24006FB252 /* NSBundle.swift in Sources */,
-				1DB1065124467E18005542BD /* DeviceAlertManager.swift in Sources */,
+				1DB1065124467E18005542BD /* AlertManager.swift in Sources */,
 				43BFF0BC1E45C80600FF19A9 /* UIColor+Loop.swift in Sources */,
 				43C0944A1CACCC73001F6403 /* NotificationManager.swift in Sources */,
 				43D9003321EB258C00AF44BF /* InsulinModelSettings+Loop.swift in Sources */,
@@ -3072,13 +3072,13 @@
 				A9A63F8D246B261100588D5B /* DosingDecisionStoreTests.swift in Sources */,
 				A9E6DFEF246A0474005B1A1C /* LoopErrorTests.swift in Sources */,
 				A9E6DFEA246A0448005B1A1C /* PumpManagerErrorTests.swift in Sources */,
-				1DA7A84424477698008257F0 /* InAppModalDeviceAlertPresenterTests.swift in Sources */,
+				1DA7A84424477698008257F0 /* InAppModalAlertPresenterTests.swift in Sources */,
 				8968B114240C55F10074BB48 /* LoopSettingsTests.swift in Sources */,
-				1DA7A84224476EAD008257F0 /* DeviceAlertManagerTests.swift in Sources */,
+				1DA7A84224476EAD008257F0 /* AlertManagerTests.swift in Sources */,
 				A9E6DFE6246A042E005B1A1C /* CarbStoreTests.swift in Sources */,
 				A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */,
 				A9E6DFEC246A0453005B1A1C /* SetBolusErrorTests.swift in Sources */,
-				1DFE9E172447B6270082C280 /* UserNotificationDeviceAlertPresenterTests.swift in Sources */,
+				1DFE9E172447B6270082C280 /* UserNotificationAlertPresenterTests.swift in Sources */,
 				A9E6DFE8246A043D005B1A1C /* DoseStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -20,7 +20,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     private lazy var pluginManager = PluginManager()
 
     private var deviceDataManager: DeviceDataManager!
-    private var deviceAlertManager: DeviceAlertManager!
+    private var alertManager: AlertManager!
     
     var window: UIWindow?
 
@@ -31,8 +31,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UIDevice.current.isBatteryMonitoringEnabled = true
 
-        deviceAlertManager = DeviceAlertManager(rootViewController: rootViewController)
-        deviceDataManager = DeviceDataManager(pluginManager: pluginManager, deviceAlertManager: deviceAlertManager)
+        alertManager = AlertManager(rootViewController: rootViewController)
+        deviceDataManager = DeviceDataManager(pluginManager: pluginManager, alertManager: alertManager)
 
         SharedLogging.instance = deviceDataManager.loggingServicesManager
 
@@ -133,12 +133,12 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                 }
                 return
             }
-        case NotificationManager.Action.acknowledgeDeviceAlert.rawValue:
+        case NotificationManager.Action.acknowledgeAlert.rawValue:
             let userInfo = response.notification.request.content.userInfo
-            if let alertIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeID.rawValue] as? DeviceAlert.AlertIdentifier,
+            if let alertIdentifier = userInfo[LoopNotificationUserInfoKey.alertTypeID.rawValue] as? Alert.AlertIdentifier,
                 let managerIdentifier = userInfo[LoopNotificationUserInfoKey.managerIDForAlert.rawValue] as? String {
-                deviceAlertManager.acknowledgeDeviceAlert(identifier:
-                    DeviceAlert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier))
+                alertManager.acknowledgeAlert(identifier:
+                    Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier))
             }
         default:
             break

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -1,5 +1,5 @@
 //
-//  DeviceAlertManager.swift
+//  AlertManager.swift
 //  Loop
 //
 //  Created by Rick Pasetto on 4/9/20.
@@ -8,9 +8,9 @@
 
 import LoopKit
 
-protocol DeviceAlertManagerResponder: class {
-    /// Method for our Handlers to call to kick off alert response.  Differs from DeviceAlertResponder because here we need the whole `Identifier`.
-    func acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier)
+protocol AlertManagerResponder: class {
+    /// Method for our Handlers to call to kick off alert response.  Differs from AlertResponder because here we need the whole `Identifier`.
+    func acknowledgeAlert(identifier: Alert.Identifier)
 }
 
 public protocol UserNotificationCenter {
@@ -22,8 +22,8 @@ public protocol UserNotificationCenter {
 }
 extension UNUserNotificationCenter: UserNotificationCenter {}
 
-public enum DeviceAlertUserNotificationUserInfoKey: String {
-    case deviceAlert, deviceAlertTimestamp
+public enum AlertUserNotificationUserInfoKey: String {
+    case alert, alertTimestamp
 }
 
 /// Main (singleton-ish) class that is responsible for:
@@ -31,16 +31,16 @@ public enum DeviceAlertUserNotificationUserInfoKey: String {
 /// - managing the different responders that might acknowledge the alert
 /// - serializing alerts to storage
 /// - etc.
-public final class DeviceAlertManager {
+public final class AlertManager {
     static let soundsDirectoryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).last!.appendingPathComponent("Sounds")
     
     static let timestampFormatter = ISO8601DateFormatter()
     
-    private let log = DiagnosticLog(category: "DeviceAlertManager")
+    private let log = DiagnosticLog(category: "AlertManager")
 
-    var handlers: [DeviceAlertPresenter] = []
-    var responders: [String: Weak<DeviceAlertResponder>] = [:]
-    var soundVendors: [String: Weak<DeviceAlertSoundVendor>] = [:]
+    var handlers: [AlertPresenter] = []
+    var responders: [String: Weak<AlertResponder>] = [:]
+    var soundVendors: [String: Weak<AlertSoundVendor>] = [:]
     
     let userNotificationCenter: UserNotificationCenter
     let fileManager: FileManager
@@ -48,7 +48,7 @@ public final class DeviceAlertManager {
     let alertStore: AlertStore
 
     public init(rootViewController: UIViewController,
-                handlers: [DeviceAlertPresenter]? = nil,
+                handlers: [AlertPresenter]? = nil,
                 userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current(),
                 fileManager: FileManager = FileManager.default) {
         self.userNotificationCenter = userNotificationCenter
@@ -58,13 +58,13 @@ public final class DeviceAlertManager {
             .appendingPathComponent("AlertStore")
             .appendingPathComponent("AlertStore.sqlite"))
         self.handlers = handlers ??
-            [UserNotificationDeviceAlertPresenter(userNotificationCenter: userNotificationCenter),
-            InAppModalDeviceAlertPresenter(rootViewController: rootViewController, deviceAlertManagerResponder: self)]
+            [UserNotificationAlertPresenter(userNotificationCenter: userNotificationCenter),
+            InAppModalAlertPresenter(rootViewController: rootViewController, alertManagerResponder: self)]
             
         playbackAlertsFromUserNotificationCenter()
     }
 
-    public func addAlertResponder(managerIdentifier: String, alertResponder: DeviceAlertResponder) {
+    public func addAlertResponder(managerIdentifier: String, alertResponder: AlertResponder) {
         responders[managerIdentifier] = Weak(alertResponder)
     }
     
@@ -72,7 +72,7 @@ public final class DeviceAlertManager {
         responders.removeValue(forKey: managerIdentifier)
     }
     
-    public func addAlertSoundVendor(managerIdentifier: String, soundVendor: DeviceAlertSoundVendor) {
+    public func addAlertSoundVendor(managerIdentifier: String, soundVendor: AlertSoundVendor) {
         soundVendors[managerIdentifier] = Weak(soundVendor)
         initializeSoundVendor(managerIdentifier, soundVendor)
     }
@@ -82,10 +82,10 @@ public final class DeviceAlertManager {
     }
 }
 
-// MARK: DeviceAlertManagerResponder implementation
+// MARK: AlertManagerResponder implementation
 
-extension DeviceAlertManager: DeviceAlertManagerResponder {
-    func acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier) {
+extension AlertManager: AlertManagerResponder {
+    func acknowledgeAlert(identifier: Alert.Identifier) {
         if let responder = responders[identifier.managerIdentifier]?.value {
             responder.acknowledgeAlert(alertIdentifier: identifier.alertIdentifier)
         }
@@ -97,51 +97,51 @@ extension DeviceAlertManager: DeviceAlertManagerResponder {
     }
 }
 
-// MARK: DeviceAlertPresenter implementation
+// MARK: AlertPresenter implementation
 
-extension DeviceAlertManager: DeviceAlertPresenter {
+extension AlertManager: AlertPresenter {
 
-    public func issueAlert(_ alert: DeviceAlert) {
+    public func issueAlert(_ alert: Alert) {
         handlers.forEach { $0.issueAlert(alert) }
         alertStore.recordIssued(alert: alert)
     }
     
-    public func retractAlert(identifier: DeviceAlert.Identifier) {
+    public func retractAlert(identifier: Alert.Identifier) {
         handlers.forEach { $0.retractAlert(identifier: identifier) }
         alertStore.recordRetraction(of: identifier)
     }
     
-    private func replayAlert(_ alert: DeviceAlert) {
+    private func replayAlert(_ alert: Alert) {
         handlers.forEach { $0.issueAlert(alert) }
     }
 }
 
 // MARK: Sound Support
 
-extension DeviceAlertManager {
+extension AlertManager {
     
-    public static func soundURL(for alert: DeviceAlert) -> URL? {
+    public static func soundURL(for alert: Alert) -> URL? {
         guard let sound = alert.sound else { return nil }
         return soundURL(managerIdentifier: alert.identifier.managerIdentifier, sound: sound)
     }
     
-    private static func soundURL(managerIdentifier: String, sound: DeviceAlert.Sound) -> URL? {
+    private static func soundURL(managerIdentifier: String, sound: Alert.Sound) -> URL? {
         guard let soundFileName = sound.filename else { return nil }
         
         // Seems all the sound files need to be in the sounds directory, so we namespace the filenames
         return soundsDirectoryURL.appendingPathComponent("\(managerIdentifier)-\(soundFileName)")
     }
     
-    private func initializeSoundVendor(_ managerIdentifier: String, _ soundVendor: DeviceAlertSoundVendor) {
+    private func initializeSoundVendor(_ managerIdentifier: String, _ soundVendor: AlertSoundVendor) {
         let sounds = soundVendor.getSounds()
         guard let baseURL = soundVendor.getSoundBaseURL(), !sounds.isEmpty else {
             return
         }
         do {
-            try fileManager.createDirectory(at: DeviceAlertManager.soundsDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+            try fileManager.createDirectory(at: AlertManager.soundsDirectoryURL, withIntermediateDirectories: true, attributes: nil)
             for sound in sounds {
                 if let fromFilename = sound.filename,
-                    let toURL = DeviceAlertManager.soundURL(managerIdentifier: managerIdentifier, sound: sound) {
+                    let toURL = AlertManager.soundURL(managerIdentifier: managerIdentifier, sound: sound) {
                     try fileManager.copyIfNewer(from: baseURL.appendingPathComponent(fromFilename), to: toURL)
                 }
             }
@@ -154,7 +154,7 @@ extension DeviceAlertManager {
 
 // MARK: Alert Playback
 
-extension DeviceAlertManager {
+extension AlertManager {
     
     private func playbackAlertsFromUserNotificationCenter() {
     
@@ -182,17 +182,17 @@ extension DeviceAlertManager {
         playbackAnyNotificationRequest(request)
     }
     
-    private func playbackAnyNotificationRequest(_ request: UNNotificationRequest, usingTrigger trigger: DeviceAlert.Trigger? = nil) {
-        guard let savedAlertString = request.content.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] as? String,
-            let savedAlertTimestampString = request.content.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue] as? String,
-            let savedAlertTimestamp = DeviceAlertManager.timestampFormatter.date(from: savedAlertTimestampString) else  {
+    private func playbackAnyNotificationRequest(_ request: UNNotificationRequest, usingTrigger trigger: Alert.Trigger? = nil) {
+        guard let savedAlertString = request.content.userInfo[AlertUserNotificationUserInfoKey.alert.rawValue] as? String,
+            let savedAlertTimestampString = request.content.userInfo[AlertUserNotificationUserInfoKey.alertTimestamp.rawValue] as? String,
+            let savedAlertTimestamp = AlertManager.timestampFormatter.date(from: savedAlertTimestampString) else  {
             self.log.error("Could not find persistent alert in notification")
             return
         }
         do {
-            let savedAlert = try DeviceAlert.decode(from: savedAlertString)
+            let savedAlert = try Alert.decode(from: savedAlertString)
             let newTrigger = trigger ?? determineNewTrigger(from: savedAlert, timestamp: savedAlertTimestamp)
-            let newAlert = DeviceAlert(identifier: savedAlert.identifier,
+            let newAlert = Alert(identifier: savedAlert.identifier,
                                        foregroundContent: savedAlert.foregroundContent,
                                        backgroundContent: savedAlert.backgroundContent,
                                        trigger: newTrigger,
@@ -207,7 +207,7 @@ extension DeviceAlertManager {
         }
     }
     
-    private func determineNewTrigger(from alert: DeviceAlert, timestamp: Date) -> DeviceAlert.Trigger {
+    private func determineNewTrigger(from alert: Alert, timestamp: Date) -> Alert.Trigger {
         switch alert.trigger {
         case .immediate:
             return alert.trigger
@@ -231,7 +231,7 @@ extension DeviceAlertManager {
 }
 
 // MARK: Alert storage access
-extension DeviceAlertManager {
+extension AlertManager {
     
     func getStoredEntries(startDate: Date, completion: @escaping (_ report: String) -> Void) {
         alertStore.executeQuery(since: startDate, limit: 100) { result in
@@ -287,7 +287,7 @@ extension URL {
     }
 }
 
-public extension DeviceAlert {
+public extension Alert {
     
     enum Error: String, Swift.Error {
         case noBackgroundContent
@@ -309,9 +309,9 @@ public extension DeviceAlert {
             LoopNotificationUserInfoKey.alertTypeID.rawValue: identifier.alertIdentifier,
         ]
         let encodedAlert = try encodeToString()
-        userNotificationContent.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue] = encodedAlert
-        userNotificationContent.userInfo[DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue] =
-            DeviceAlertManager.timestampFormatter.string(from: timestamp)
+        userNotificationContent.userInfo[AlertUserNotificationUserInfoKey.alert.rawValue] = encodedAlert
+        userNotificationContent.userInfo[AlertUserNotificationUserInfoKey.alertTimestamp.rawValue] =
+            AlertManager.timestampFormatter.string(from: timestamp)
         return userNotificationContent
     }
     
@@ -328,7 +328,7 @@ public extension DeviceAlert {
                 // TODO: Not sure how to "force" UNNotificationSound to "silence"...so for now we just do the default
                 break
             default:
-                if let actualFileName = DeviceAlertManager.soundURL(for: self)?.lastPathComponent {
+                if let actualFileName = AlertManager.soundURL(for: self)?.lastPathComponent {
                     let unname = UNNotificationSoundName(rawValue: actualFileName)
                     return content.isCritical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
                 }
@@ -340,17 +340,17 @@ public extension DeviceAlert {
 }
 
 public extension UNNotificationRequest {
-    convenience init(from deviceAlert: DeviceAlert, timestamp: Date) throws {
-        let uncontent = try deviceAlert.getUserNotificationContent(timestamp: timestamp)
-        self.init(identifier: deviceAlert.identifier.value,
+    convenience init(from alert: Alert, timestamp: Date) throws {
+        let uncontent = try alert.getUserNotificationContent(timestamp: timestamp)
+        self.init(identifier: alert.identifier.value,
                   content: uncontent,
-                  trigger: UNTimeIntervalNotificationTrigger(from: deviceAlert.trigger))
+                  trigger: UNTimeIntervalNotificationTrigger(from: alert.trigger))
     }
 }
 
 fileprivate extension UNTimeIntervalNotificationTrigger {
-    convenience init?(from deviceAlertTrigger: DeviceAlert.Trigger) {
-        switch deviceAlertTrigger {
+    convenience init?(from alertTrigger: Alert.Trigger) {
+        switch alertTrigger {
         case .immediate:
             return nil
         case .delayed(let timeInterval):

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -193,10 +193,10 @@ extension AlertManager {
             let savedAlert = try Alert.decode(from: savedAlertString)
             let newTrigger = trigger ?? determineNewTrigger(from: savedAlert, timestamp: savedAlertTimestamp)
             let newAlert = Alert(identifier: savedAlert.identifier,
-                                       foregroundContent: savedAlert.foregroundContent,
-                                       backgroundContent: savedAlert.backgroundContent,
-                                       trigger: newTrigger,
-                                       sound: savedAlert.sound)
+                                 foregroundContent: savedAlert.foregroundContent,
+                                 backgroundContent: savedAlert.backgroundContent,
+                                 trigger: newTrigger,
+                                 sound: savedAlert.sound)
             self.log.debug("Replaying %@Alert: %@ with %@trigger %@",
                            trigger != nil ? "" : "Pending ",
                            trigger != nil ? "" : "new ",

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -50,7 +50,7 @@ public class AlertStore {
 
 extension AlertStore {
     
-    public func recordIssued(alert: DeviceAlert, at date: Date = Date(), completion: ((Result<Void, Error>) -> Void)? = nil) {
+    public func recordIssued(alert: Alert, at date: Date = Date(), completion: ((Result<Void, Error>) -> Void)? = nil) {
         self.managedObjectContext.perform {
             _ = StoredAlert(from: alert, context: self.managedObjectContext, issuedDate: date)
             do {
@@ -64,17 +64,17 @@ extension AlertStore {
         }
     }
     
-    public func recordAcknowledgement(of identifier: DeviceAlert.Identifier, at date: Date = Date(),
+    public func recordAcknowledgement(of identifier: Alert.Identifier, at date: Date = Date(),
                                       completion: ((Result<Void, Error>) -> Void)? = nil) {
         recordUpdateOfLatest(of: identifier, with: { $0.acknowledgedDate = date }, completion: completion)
     }
     
-    public func recordRetraction(of identifier: DeviceAlert.Identifier, at date: Date = Date(),
+    public func recordRetraction(of identifier: Alert.Identifier, at date: Date = Date(),
                                  completion: ((Result<Void, Error>) -> Void)? = nil) {
         recordUpdateOfLatest(of: identifier, with: { $0.retractedDate = date }, completion: completion)
     }
     
-    private func recordUpdateOfLatest(of identifier: DeviceAlert.Identifier,
+    private func recordUpdateOfLatest(of identifier: Alert.Identifier,
                                       with block: @escaping (StoredAlert) -> Void,
                                       completion: ((Result<Void, Error>) -> Void)?) {
         self.managedObjectContext.perform {
@@ -102,7 +102,7 @@ extension AlertStore {
         }
     }
 
-    private func lookupLatest(identifier: DeviceAlert.Identifier, completion: @escaping (Result<StoredAlert?, Error>) -> Void) {
+    private func lookupLatest(identifier: Alert.Identifier, completion: @escaping (Result<StoredAlert?, Error>) -> Void) {
         managedObjectContext.perform {
             do {
                 let fetchRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
@@ -199,7 +199,7 @@ extension AlertStore {
     }
     
     // At the moment, this is only used for unit testing
-    internal func fetch(identifier: DeviceAlert.Identifier, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+    internal func fetch(identifier: Alert.Identifier, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
         self.managedObjectContext.perform {
             let storedRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
             storedRequest.predicate = identifier.equalsPredicate
@@ -213,7 +213,7 @@ extension AlertStore {
     }
 }
 
-extension DeviceAlert.Identifier {
+extension Alert.Identifier {
     var equalsPredicate: NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(format: "managerIdentifier == %@", managerIdentifier),

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -14,29 +14,29 @@ extension StoredAlert {
     static var encoder = JSONEncoder()
     static var decoder = JSONDecoder()
           
-    convenience init(from deviceAlert: DeviceAlert, context: NSManagedObjectContext, issuedDate: Date = Date()) {
+    convenience init(from alert: Alert, context: NSManagedObjectContext, issuedDate: Date = Date()) {
         do {
             self.init(context: context)
             self.issuedDate = issuedDate
-            alertIdentifier = deviceAlert.identifier.alertIdentifier
-            managerIdentifier = deviceAlert.identifier.managerIdentifier
-            triggerType = deviceAlert.trigger.storedType
-            triggerInterval = deviceAlert.trigger.storedInterval
-            isCritical = deviceAlert.foregroundContent?.isCritical ?? false || deviceAlert.backgroundContent?.isCritical ?? false
+            alertIdentifier = alert.identifier.alertIdentifier
+            managerIdentifier = alert.identifier.managerIdentifier
+            triggerType = alert.trigger.storedType
+            triggerInterval = alert.trigger.storedInterval
+            isCritical = alert.foregroundContent?.isCritical ?? false || alert.backgroundContent?.isCritical ?? false
             // Encode as JSON strings
             let encoder = StoredAlert.encoder
-            sound = try encoder.encodeToStringIfPresent(deviceAlert.sound)
-            foregroundContent = try encoder.encodeToStringIfPresent(deviceAlert.foregroundContent)
-            backgroundContent = try encoder.encodeToStringIfPresent(deviceAlert.backgroundContent)
+            sound = try encoder.encodeToStringIfPresent(alert.sound)
+            foregroundContent = try encoder.encodeToStringIfPresent(alert.foregroundContent)
+            backgroundContent = try encoder.encodeToStringIfPresent(alert.backgroundContent)
         } catch {
             fatalError("Failed to encode: \(error)")
         }
     }
 
-    public var trigger: DeviceAlert.Trigger {
+    public var trigger: Alert.Trigger {
         get {
             do {
-                return try DeviceAlert.Trigger(storedType: triggerType, storedInterval: triggerInterval)
+                return try Alert.Trigger(storedType: triggerType, storedInterval: triggerInterval)
             } catch {
                 fatalError("\(error): \(triggerType) \(String(describing: triggerInterval))")
             }
@@ -46,14 +46,14 @@ extension StoredAlert {
     public var title: String? {
         if let contentString = foregroundContent ?? backgroundContent,
             let contentData = contentString.data(using: .utf8),
-            let content = try? StoredAlert.decoder.decode(DeviceAlert.Content.self, from: contentData) {
+            let content = try? StoredAlert.decoder.decode(Alert.Content.self, from: contentData) {
             return content.title
         }
         return nil
     }
     
-    public var identifier: DeviceAlert.Identifier {
-        return DeviceAlert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier)
+    public var identifier: Alert.Identifier {
+        return Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier)
     }
     
     public override func willSave() {
@@ -64,7 +64,7 @@ extension StoredAlert {
     }
 }
 
-extension DeviceAlert.Trigger {
+extension Alert.Trigger {
     enum StorageError: Error {
         case invalidStoredInterval, invalidStoredType
     }

--- a/Loop/Managers/Alerts/UserNotificationAlertPresenter.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertPresenter.swift
@@ -1,5 +1,5 @@
 //
-//  UserNotificationDeviceAlertPresenter.swift
+//  UserNotificationAlertPresenter.swift
 //  LoopKit
 //
 //  Created by Rick Pasetto on 4/9/20.
@@ -8,20 +8,20 @@
 
 import LoopKit
 
-class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
+class UserNotificationAlertPresenter: AlertPresenter {
     
     let userNotificationCenter: UserNotificationCenter
-    let log = DiagnosticLog(category: "UserNotificationDeviceAlertPresenter")
+    let log = DiagnosticLog(category: "UserNotificationAlertPresenter")
     
     init(userNotificationCenter: UserNotificationCenter) {
         self.userNotificationCenter = userNotificationCenter
     }
     
-    func issueAlert(_ alert: DeviceAlert) {
+    func issueAlert(_ alert: Alert) {
         issueAlert(alert, timestamp: Date())
     }
 
-    func issueAlert(_ alert: DeviceAlert, timestamp: Date) {
+    func issueAlert(_ alert: Alert, timestamp: Date) {
         DispatchQueue.main.async {
             do {
                 let request = try UNNotificationRequest(from: alert, timestamp: timestamp)
@@ -37,7 +37,7 @@ class UserNotificationDeviceAlertPresenter: DeviceAlertPresenter {
         }
     }
     
-    func retractAlert(identifier: DeviceAlert.Identifier) {
+    func retractAlert(identifier: Alert.Identifier) {
         DispatchQueue.main.async {
             self.userNotificationCenter.removePendingNotificationRequests(withIdentifiers: [identifier.value])
             self.userNotificationCenter.removeDeliveredNotifications(withIdentifiers: [identifier.value])

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -20,7 +20,7 @@ final class DeviceDataManager {
     private let log = DiagnosticLog(category: "DeviceDataManager")
 
     let pluginManager: PluginManager
-    weak var deviceAlertManager: DeviceAlertManager!
+    weak var alertManager: AlertManager!
 
     /// Remember the launch date of the app for diagnostic reporting
     private let launchDate = Date()
@@ -99,7 +99,7 @@ final class DeviceDataManager {
 
     private(set) var loopManager: LoopDataManager!
     
-    init(pluginManager: PluginManager, deviceAlertManager: DeviceAlertManager) {
+    init(pluginManager: PluginManager, alertManager: AlertManager) {
         
         let fileManager = FileManager.default
         let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
@@ -109,7 +109,7 @@ final class DeviceDataManager {
         analyticsServicesManager = AnalyticsServicesManager()
         
         self.pluginManager = pluginManager
-        self.deviceAlertManager = deviceAlertManager
+        self.alertManager = alertManager
 
         if let pumpManagerRawValue = UserDefaults.appGroup?.pumpManagerRawValue {
             pumpManager = pumpManagerFromRawValue(pumpManagerRawValue)
@@ -253,7 +253,7 @@ final class DeviceDataManager {
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
         self.loopManager.generateDiagnosticReport { (loopReport) in
             
-            self.deviceAlertManager.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
+            self.alertManager.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
                 
                 self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
                     let deviceLogReport: String
@@ -313,9 +313,9 @@ private extension DeviceDataManager {
 
         updatePumpManagerBLEHeartbeatPreference()
         if let cgmManager = cgmManager {
-            deviceAlertManager?.addAlertResponder(managerIdentifier: cgmManager.managerIdentifier,
+            alertManager?.addAlertResponder(managerIdentifier: cgmManager.managerIdentifier,
                                                   alertResponder: cgmManager)
-            deviceAlertManager?.addAlertSoundVendor(managerIdentifier: cgmManager.managerIdentifier,
+            alertManager?.addAlertSoundVendor(managerIdentifier: cgmManager.managerIdentifier,
                                                     soundVendor: cgmManager)
         }
     }
@@ -334,9 +334,9 @@ private extension DeviceDataManager {
             loopManager?.doseStore.pumpRecordsBasalProfileStartEvents = pumpRecordsBasalProfileStartEvents
         }
         if let pumpManager = pumpManager {
-            deviceAlertManager?.addAlertResponder(managerIdentifier: pumpManager.managerIdentifier,
+            alertManager?.addAlertResponder(managerIdentifier: pumpManager.managerIdentifier,
                                                   alertResponder: pumpManager)
-            deviceAlertManager?.addAlertSoundVendor(managerIdentifier: pumpManager.managerIdentifier,
+            alertManager?.addAlertSoundVendor(managerIdentifier: pumpManager.managerIdentifier,
                                                     soundVendor: pumpManager)
         }
     }
@@ -417,14 +417,14 @@ extension DeviceDataManager: DeviceManagerDelegate {
 }
 
 // MARK: - UserAlertHandler
-extension DeviceDataManager: DeviceAlertPresenter {
+extension DeviceDataManager: AlertPresenter {
 
-    func issueAlert(_ alert: DeviceAlert) {
-        deviceAlertManager?.issueAlert(alert)
+    func issueAlert(_ alert: Alert) {
+        alertManager?.issueAlert(alert)
     }
     
-    func retractAlert(identifier: DeviceAlert.Identifier) {
-        deviceAlertManager?.retractAlert(identifier: identifier)
+    func retractAlert(identifier: Alert.Identifier) {
+        alertManager?.retractAlert(identifier: identifier)
     }
 }
 

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -14,7 +14,7 @@ struct NotificationManager {
 
     enum Action: String {
         case retryBolus
-        case acknowledgeDeviceAlert
+        case acknowledgeAlert
     }
 
     private static var notificationCategories: Set<UNNotificationCategory> {
@@ -33,15 +33,15 @@ struct NotificationManager {
             options: []
         ))
         
-        let acknowledgeDeviceAlertAction = UNNotificationAction(
-            identifier: Action.acknowledgeDeviceAlert.rawValue,
+        let acknowledgeAlertAction = UNNotificationAction(
+            identifier: Action.acknowledgeAlert.rawValue,
             title: NSLocalizedString("OK", comment: "The title of the notification action to acknowledge a device alert"),
             options: .foreground
         )
         
         categories.append(UNNotificationCategory(
             identifier: LoopNotificationCategory.alert.rawValue,
-            actions: [acknowledgeDeviceAlertAction],
+            actions: [acknowledgeAlertAction],
             intentIdentifiers: [],
             options: .customDismissAction
         ))

--- a/Loop/Views/CorrectionRangeOverridesEditor.swift
+++ b/Loop/Views/CorrectionRangeOverridesEditor.swift
@@ -199,8 +199,8 @@ struct CorrectionRangeOverridesEditor: View {
             }
     }
 
-    private func confirmationAlert() -> Alert {
-        Alert(
+    private func confirmationAlert() -> SwiftUI.Alert {
+        SwiftUI.Alert(
             title: Text("Save Correction Range Overrides?", comment: "Alert title for confirming correction range overrides outside the recommended range"),
             message: Text("One or more of the values you have entered are outside of what Tidepool generally recommends.", comment: "Alert message for confirming correction range overrides outside the recommended range"),
             primaryButton: .cancel(Text("Go Back")),

--- a/Loop/Views/SuspendThresholdEditor.swift
+++ b/Loop/Views/SuspendThresholdEditor.swift
@@ -123,8 +123,8 @@ struct SuspendThresholdEditor: View {
         }
     }
 
-    private func confirmationAlert() -> Alert {
-        Alert(
+    private func confirmationAlert() -> SwiftUI.Alert {
+        SwiftUI.Alert(
             title: Text("Save Suspend Threshold?", comment: "Alert title for confirming a suspend threshold outside the recommended range"),
             message: Text("The suspend threshold you have entered is outside of what Tidepool generally recommends.", comment: "Alert message for confirming a suspend threshold outside the recommended range"),
             primaryButton: .cancel(Text("Go Back")),

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -30,7 +30,7 @@ class AlertManagerTests: XCTestCase {
             acknowledged[alertIdentifier] = true
         }
     }
-
+    
     class MockFileManager: FileManager {
         
         var fileExists = true
@@ -46,7 +46,7 @@ class AlertManagerTests: XCTestCase {
         }
         override func attributesOfItem(atPath path: String) throws -> [FileAttributeKey : Any] {
             return path.contains("Sounds") ? path.contains("existsNewer") ? [.creationDate: newer] : [.creationDate: older] :
-                 [.creationDate: newer]
+                [.creationDate: newer]
         }
         var removedURLs = [URL]()
         override func removeItem(at URL: URL) throws {
@@ -62,7 +62,7 @@ class AlertManagerTests: XCTestCase {
             return []
         }
     }
-
+    
     class MockSoundVendor: AlertSoundVendor {
         func getSoundBaseURL() -> URL? {
             // Hm.  It's not easy to make a "fake" URL, so we'll use this one:
@@ -95,9 +95,9 @@ class AlertManagerTests: XCTestCase {
         mockPresenter = MockPresenter()
         mockUserNotificationCenter = MockUserNotificationCenter()
         alertManager = AlertManager(rootViewController: UIViewController(),
-                                                handlers: [mockPresenter],
-                                                userNotificationCenter: mockUserNotificationCenter,
-                                                fileManager: mockFileManager)
+                                    handlers: [mockPresenter],
+                                    userNotificationCenter: mockUserNotificationCenter,
+                                    fileManager: mockFileManager)
     }
     
     func testIssueAlertOnHandlerCalled() {
@@ -161,13 +161,13 @@ class AlertManagerTests: XCTestCase {
         let date = Date()
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
-                                foregroundContent: content, backgroundContent: content, trigger: .immediate)
-
+                          foregroundContent: content, backgroundContent: content, trigger: .immediate)
+        
         mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
         alertManager = AlertManager(rootViewController: UIViewController(),
-                                                handlers: [mockPresenter],
-                                                userNotificationCenter: mockUserNotificationCenter,
-                                                fileManager: mockFileManager)
+                                    handlers: [mockPresenter],
+                                    userNotificationCenter: mockUserNotificationCenter,
+                                    fileManager: mockFileManager)
         XCTAssertEqual(alert, mockPresenter.issuedAlert)
     }
     
@@ -175,13 +175,13 @@ class AlertManagerTests: XCTestCase {
         let date = Date.distantPast
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
-                                foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
-
+                          foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
+        
         mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
         alertManager = AlertManager(rootViewController: UIViewController(),
-                                                handlers: [mockPresenter],
-                                                userNotificationCenter: mockUserNotificationCenter,
-                                                fileManager: mockFileManager)
+                                    handlers: [mockPresenter],
+                                    userNotificationCenter: mockUserNotificationCenter,
+                                    fileManager: mockFileManager)
         let expected = Alert(identifier: Self.mockIdentifier, foregroundContent: content, backgroundContent: content, trigger: .immediate)
         XCTAssertEqual(expected, mockPresenter.issuedAlert)
     }
@@ -190,13 +190,13 @@ class AlertManagerTests: XCTestCase {
         let date = Date().addingTimeInterval(-15.0) // Pretend the 30-second-delayed alert was issued 15 seconds ago
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
-                                foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
-
+                          foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
+        
         mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
         alertManager = AlertManager(rootViewController: UIViewController(),
-                                                handlers: [mockPresenter],
-                                                userNotificationCenter: mockUserNotificationCenter,
-                                                fileManager: mockFileManager)
+                                    handlers: [mockPresenter],
+                                    userNotificationCenter: mockUserNotificationCenter,
+                                    fileManager: mockFileManager)
         // The trigger for this should be `.delayed` by "something less than 15 seconds",
         // but the exact value depends on the speed of executing this test.
         // As long as it is <= 15 seconds, we call it good.
@@ -213,22 +213,22 @@ class AlertManagerTests: XCTestCase {
         let date = Date.distantPast
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
-                                foregroundContent: content, backgroundContent: content, trigger: .repeating(repeatInterval: 60.0))
-
+                          foregroundContent: content, backgroundContent: content, trigger: .repeating(repeatInterval: 60.0))
+        
         mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
         alertManager = AlertManager(rootViewController: UIViewController(),
-                                                handlers: [mockPresenter],
-                                                userNotificationCenter: mockUserNotificationCenter,
-                                                fileManager: mockFileManager)
+                                    handlers: [mockPresenter],
+                                    userNotificationCenter: mockUserNotificationCenter,
+                                    fileManager: mockFileManager)
         XCTAssertEqual(alert, mockPresenter.issuedAlert)
     }
 }
 
 class MockUserNotificationCenter: UserNotificationCenter {
-        
+    
     var pendingRequests = [UNNotificationRequest]()
     var deliveredRequests = [UNNotificationRequest]()
-            
+    
     func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)? = nil) {
         pendingRequests.append(request)
     }
@@ -238,7 +238,7 @@ class MockUserNotificationCenter: UserNotificationCenter {
             pendingRequests.removeAll { $0.identifier == identifier }
         }
     }
-
+    
     func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
         identifiers.forEach { identifier in
             deliveredRequests.removeAll { $0.identifier == identifier }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -15,11 +15,11 @@ class AlertStoreTests: XCTestCase {
     
     var alertStore: AlertStore!
     
-    static let identifier1 = DeviceAlert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
-    let alert1 = DeviceAlert(identifier: identifier1, foregroundContent: nil, backgroundContent: nil, trigger: .immediate, sound: nil)
-    static let identifier2 = DeviceAlert.Identifier(managerIdentifier: "managerIdentifier2", alertIdentifier: "alertIdentifier2")
-    static let content = DeviceAlert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label", isCritical: true)
-    let alert2 = DeviceAlert(identifier: identifier2, foregroundContent: content, backgroundContent: content, trigger: .immediate, sound: .sound(name: "soundName"))
+    static let identifier1 = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
+    let alert1 = Alert(identifier: identifier1, foregroundContent: nil, backgroundContent: nil, trigger: .immediate, sound: nil)
+    static let identifier2 = Alert.Identifier(managerIdentifier: "managerIdentifier2", alertIdentifier: "alertIdentifier2")
+    static let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label", isCritical: true)
+    let alert2 = Alert(identifier: identifier2, foregroundContent: content, backgroundContent: content, trigger: .immediate, sound: .sound(name: "soundName"))
 
     override func setUp() {
         alertStore = AlertStore()
@@ -30,12 +30,12 @@ class AlertStoreTests: XCTestCase {
     }
     
     func testTriggerTypeIntervalConversion() {
-        let immediate = DeviceAlert.Trigger.immediate
-        let delayed = DeviceAlert.Trigger.delayed(interval: 1.0)
-        let repeating = DeviceAlert.Trigger.repeating(repeatInterval: 2.0)
-        XCTAssertEqual(immediate, try? DeviceAlert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval))
-        XCTAssertEqual(delayed, try? DeviceAlert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval))
-        XCTAssertEqual(repeating, try? DeviceAlert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval))
+        let immediate = Alert.Trigger.immediate
+        let delayed = Alert.Trigger.delayed(interval: 1.0)
+        let repeating = Alert.Trigger.repeating(repeatInterval: 2.0)
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval))
+        XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval))
+        XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval))
         XCTAssertNil(immediate.storedInterval)
     }
     
@@ -50,7 +50,7 @@ class AlertStoreTests: XCTestCase {
         XCTAssertEqual(Date.distantPast, object.issuedDate)
         XCTAssertEqual(0, object.modificationCounter)
         XCTAssertEqual("{\"sound\":{\"name\":\"soundName\"}}", object.sound)
-        XCTAssertEqual(DeviceAlert.Trigger.immediate, object.trigger)
+        XCTAssertEqual(Alert.Trigger.immediate, object.trigger)
     }
     
     func testRecordIssued() {

--- a/LoopTests/Managers/Alerts/InAppModalAlertPresenterTests.swift
+++ b/LoopTests/Managers/Alerts/InAppModalAlertPresenterTests.swift
@@ -25,8 +25,8 @@ class InAppModalAlertPresenterTests: XCTestCase {
             self.handler = handler
         }
         override init() {
-          mockStyle = .default
-          super.init()
+            mockStyle = .default
+            super.init()
         }
         func callHandler() {
             handler?(self)
@@ -95,16 +95,16 @@ class InAppModalAlertPresenterTests: XCTestCase {
         }
         inAppModalAlertPresenter =
             InAppModalAlertPresenter(rootViewController: mockViewController,
-                                           alertManagerResponder: mockAlertManagerResponder,
-                                           soundPlayer: mockSoundPlayer,
-                                           newActionFunc: MockAlertAction.init,
-                                           newTimerFunc: newTimerFunc)
+                                     alertManagerResponder: mockAlertManagerResponder,
+                                     soundPlayer: mockSoundPlayer,
+                                     newActionFunc: MockAlertAction.init,
+                                     newTimerFunc: newTimerFunc)
     }
     
     func testIssueImmediateAlert() {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
         XCTAssertNotNil(alertController)
@@ -116,12 +116,12 @@ class InAppModalAlertPresenterTests: XCTestCase {
     func testIssueImmediateAlertWithSound() {
         let soundName = "soundName"
         let alert = Alert(identifier: alertIdentifier,
-                                foregroundContent: foregroundContent,
-                                backgroundContent: backgroundContent,
-                                trigger: .immediate,
-                                sound: .sound(name: soundName))
+                          foregroundContent: foregroundContent,
+                          backgroundContent: backgroundContent,
+                          trigger: .immediate,
+                          sound: .sound(name: soundName))
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
         XCTAssertNotNil(alertController)
@@ -132,12 +132,12 @@ class InAppModalAlertPresenterTests: XCTestCase {
     
     func testIssueImmediateAlertWithVibrate() {
         let alert = Alert(identifier: alertIdentifier,
-                                foregroundContent: foregroundContent,
-                                backgroundContent: backgroundContent,
-                                trigger: .immediate,
-                                sound: .vibrate)
+                          foregroundContent: foregroundContent,
+                          backgroundContent: backgroundContent,
+                          trigger: .immediate,
+                          sound: .vibrate)
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
         XCTAssertNotNil(alertController)
@@ -148,12 +148,12 @@ class InAppModalAlertPresenterTests: XCTestCase {
     
     func testIssueImmediateAlertWithSilence() {
         let alert = Alert(identifier: alertIdentifier,
-                                foregroundContent: foregroundContent,
-                                backgroundContent: backgroundContent,
-                                trigger: .immediate,
-                                sound: .silence)
+                          foregroundContent: foregroundContent,
+                          backgroundContent: backgroundContent,
+                          trigger: .immediate,
+                          sound: .silence)
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
         XCTAssertNotNil(alertController)
@@ -161,11 +161,11 @@ class InAppModalAlertPresenterTests: XCTestCase {
         XCTAssertEqual(nil, mockSoundPlayer.urlPlayed?.absoluteString)
         XCTAssertFalse(mockSoundPlayer.vibrateCalled)
     }
-
+    
     func testRemoveImmediateAlert() {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         var dismissed = false
         inAppModalAlertPresenter.removeDeliveredAlert(identifier: alert.identifier) {
@@ -183,7 +183,7 @@ class InAppModalAlertPresenterTests: XCTestCase {
             .immediate)
         mockViewController.autoComplete = false
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         mockViewController.viewControllerPresented = nil
         inAppModalAlertPresenter.issueAlert(alert)
@@ -193,7 +193,7 @@ class InAppModalAlertPresenterTests: XCTestCase {
     func testIssueImmediateAlertWithoutForegroundContentDoesNothing() {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .immediate)
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         XCTAssertNil(mockViewController.viewControllerPresented)
     }
@@ -213,7 +213,7 @@ class InAppModalAlertPresenterTests: XCTestCase {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
         mockViewController.autoComplete = false
         inAppModalAlertPresenter.issueAlert(alert)
-            
+        
         waitOnMain()
         // Timer should be created but won't fire yet
         XCTAssertNil(mockViewController.viewControllerPresented)
@@ -232,7 +232,7 @@ class InAppModalAlertPresenterTests: XCTestCase {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
         mockViewController.autoComplete = false
         inAppModalAlertPresenter.issueAlert(alert)
-            
+        
         waitOnMain()
         guard let firstTimer = mockTimer else { XCTFail(); return }
         mockTimer = nil
@@ -252,11 +252,11 @@ class InAppModalAlertPresenterTests: XCTestCase {
     func testIssueDelayedAlertWithoutForegroundContentDoesNothing() {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
         inAppModalAlertPresenter.issueAlert(alert)
-
+        
         waitOnMain()
         XCTAssertNil(mockViewController.viewControllerPresented)
     }
-
+    
     func testRetractAlert() {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
         inAppModalAlertPresenter.issueAlert(alert)
@@ -268,12 +268,12 @@ class InAppModalAlertPresenterTests: XCTestCase {
         waitOnMain()
         XCTAssert(mockTimer?.isValid == false)
     }
-
+    
     func testIssueRepeatingAlert() {
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 0.1))
         mockViewController.autoComplete = false
         inAppModalAlertPresenter.issueAlert(alert)
-            
+        
         waitOnMain()
         // Timer should be created but won't fire yet
         XCTAssertNil(mockViewController.viewControllerPresented)

--- a/LoopTests/Managers/Alerts/InAppModalAlertPresenterTests.swift
+++ b/LoopTests/Managers/Alerts/InAppModalAlertPresenterTests.swift
@@ -1,5 +1,5 @@
 //
-//  InAppModalDeviceAlertPresenterTests.swift
+//  InAppModalAlertPresenterTests.swift
 //  LoopTests
 //
 //  Created by Rick Pasetto on 4/15/20.
@@ -10,7 +10,7 @@ import LoopKit
 import XCTest
 @testable import Loop
 
-class InAppModalDeviceAlertPresenterTests: XCTestCase {
+class InAppModalAlertPresenterTests: XCTestCase {
     
     class MockAlertAction: UIAlertAction {
         typealias Handler = ((UIAlertAction) -> Void)
@@ -33,9 +33,9 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
         }
     }
     
-    class MockAlertManagerResponder: DeviceAlertManagerResponder {
-        var identifierAcknowledged: DeviceAlert.Identifier?
-        func acknowledgeDeviceAlert(identifier: DeviceAlert.Identifier) {
+    class MockAlertManagerResponder: AlertManagerResponder {
+        var identifierAcknowledged: Alert.Identifier?
+        func acknowledgeAlert(identifier: Alert.Identifier) {
             identifierAcknowledged = identifier
         }
     }
@@ -57,7 +57,7 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
         }
     }
     
-    class MockSoundPlayer: DeviceAlertSoundPlayer {
+    class MockSoundPlayer: AlertSoundPlayer {
         var vibrateCalled = false
         func vibrate() {
             vibrateCalled = true
@@ -69,9 +69,9 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     static let managerIdentifier = "managerIdentifier"
-    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: "bar")
-    let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
-    let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+    let alertIdentifier = Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: "bar")
+    let foregroundContent = Alert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
+    let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
     
     var mockTimer: Timer?
     var mockTimerTimeInterval: TimeInterval?
@@ -79,31 +79,31 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     var mockAlertManagerResponder: MockAlertManagerResponder!
     var mockViewController: MockViewController!
     var mockSoundPlayer: MockSoundPlayer!
-    var inAppModalDeviceAlertPresenter: InAppModalDeviceAlertPresenter!
+    var inAppModalAlertPresenter: InAppModalAlertPresenter!
     
     override func setUp() {
         mockAlertManagerResponder = MockAlertManagerResponder()
         mockViewController = MockViewController()
         mockSoundPlayer = MockSoundPlayer()
         
-        let newTimerFunc: InAppModalDeviceAlertPresenter.TimerFactoryFunction = { timeInterval, repeats, block in
+        let newTimerFunc: InAppModalAlertPresenter.TimerFactoryFunction = { timeInterval, repeats, block in
             let timer = Timer(timeInterval: timeInterval, repeats: repeats) { _ in block?() }
             self.mockTimer = timer
             self.mockTimerTimeInterval = timeInterval
             self.mockTimerRepeats = repeats
             return timer
         }
-        inAppModalDeviceAlertPresenter =
-            InAppModalDeviceAlertPresenter(rootViewController: mockViewController,
-                                           deviceAlertManagerResponder: mockAlertManagerResponder,
+        inAppModalAlertPresenter =
+            InAppModalAlertPresenter(rootViewController: mockViewController,
+                                           alertManagerResponder: mockAlertManagerResponder,
                                            soundPlayer: mockSoundPlayer,
                                            newActionFunc: MockAlertAction.init,
                                            newTimerFunc: newTimerFunc)
     }
     
     func testIssueImmediateAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
@@ -115,28 +115,28 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     
     func testIssueImmediateAlertWithSound() {
         let soundName = "soundName"
-        let alert = DeviceAlert(identifier: alertIdentifier,
+        let alert = Alert(identifier: alertIdentifier,
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
                                 sound: .sound(name: soundName))
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
         XCTAssertNotNil(alertController)
         XCTAssertEqual("FOREGROUND", alertController?.title)
-        XCTAssertEqual("\(InAppModalDeviceAlertPresenterTests.managerIdentifier)-\(soundName)", mockSoundPlayer.urlPlayed?.lastPathComponent)
+        XCTAssertEqual("\(InAppModalAlertPresenterTests.managerIdentifier)-\(soundName)", mockSoundPlayer.urlPlayed?.lastPathComponent)
         XCTAssertTrue(mockSoundPlayer.vibrateCalled)
     }
     
     func testIssueImmediateAlertWithVibrate() {
-        let alert = DeviceAlert(identifier: alertIdentifier,
+        let alert = Alert(identifier: alertIdentifier,
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
                                 sound: .vibrate)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
@@ -147,12 +147,12 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueImmediateAlertWithSilence() {
-        let alert = DeviceAlert(identifier: alertIdentifier,
+        let alert = Alert(identifier: alertIdentifier,
                                 foregroundContent: foregroundContent,
                                 backgroundContent: backgroundContent,
                                 trigger: .immediate,
                                 sound: .silence)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         let alertController = mockViewController.viewControllerPresented as? UIAlertController
@@ -163,12 +163,12 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
 
     func testRemoveImmediateAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         var dismissed = false
-        inAppModalDeviceAlertPresenter.removeDeliveredAlert(identifier: alert.identifier) {
+        inAppModalAlertPresenter.removeDeliveredAlert(identifier: alert.identifier) {
             dismissed = true
         }
         
@@ -179,28 +179,28 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueImmediateAlertTwiceOnlyOneShows() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger:
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger:
             .immediate)
         mockViewController.autoComplete = false
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         mockViewController.viewControllerPresented = nil
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
         XCTAssertNil(mockViewController.viewControllerPresented)
     }
     
     func testIssueImmediateAlertWithoutForegroundContentDoesNothing() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .immediate)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         XCTAssertNil(mockViewController.viewControllerPresented)
     }
     
     func testIssueImmediateAlertAcknowledgement() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        inAppModalAlertPresenter.issueAlert(alert)
         waitOnMain()
         let action = (mockViewController.viewControllerPresented as? UIAlertController)?.actions[0] as? MockAlertAction
         XCTAssertNotNil(action)
@@ -210,9 +210,9 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueDelayedAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
         mockViewController.autoComplete = false
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
             
         waitOnMain()
         // Timer should be created but won't fire yet
@@ -229,15 +229,15 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueDelayedAlertTwiceOnlyOneWorks() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
         mockViewController.autoComplete = false
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
             
         waitOnMain()
         guard let firstTimer = mockTimer else { XCTFail(); return }
         mockTimer = nil
         // This should not schedule another timer
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
         
         waitOnMain()
         XCTAssertNil(mockTimer)
@@ -250,29 +250,29 @@ class InAppModalDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueDelayedAlertWithoutForegroundContentDoesNothing() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: nil, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        inAppModalAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         XCTAssertNil(mockViewController.viewControllerPresented)
     }
 
     func testRetractAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        inAppModalAlertPresenter.issueAlert(alert)
         
         waitOnMain()
         XCTAssert(mockTimer?.isValid == true)
-        inAppModalDeviceAlertPresenter.retractAlert(identifier: alert.identifier)
+        inAppModalAlertPresenter.retractAlert(identifier: alert.identifier)
         
         waitOnMain()
         XCTAssert(mockTimer?.isValid == false)
     }
 
     func testIssueRepeatingAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 0.1))
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 0.1))
         mockViewController.autoComplete = false
-        inAppModalDeviceAlertPresenter.issueAlert(alert)
+        inAppModalAlertPresenter.issueAlert(alert)
             
         waitOnMain()
         // Timer should be created but won't fire yet

--- a/LoopTests/Managers/Alerts/UserNotificationAlertPresenterTests.swift
+++ b/LoopTests/Managers/Alerts/UserNotificationAlertPresenterTests.swift
@@ -1,5 +1,5 @@
 //
-//  UserNotificationDeviceAlertPresenterTests.swift
+//  UserNotificationAlertPresenterTests.swift
 //  LoopTests
 //
 //  Created by Rick Pasetto on 4/15/20.
@@ -10,25 +10,25 @@ import LoopKit
 import XCTest
 @testable import Loop
 
-class UserNotificationDeviceAlertPresenterTests: XCTestCase {
+class UserNotificationAlertPresenterTests: XCTestCase {
     
-    var userNotificationDeviceAlertPresenter: UserNotificationDeviceAlertPresenter!
+    var userNotificationAlertPresenter: UserNotificationAlertPresenter!
     
-    let alertIdentifier = DeviceAlert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
-    let foregroundContent = DeviceAlert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
-    let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+    let alertIdentifier = Alert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
+    let foregroundContent = Alert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
+    let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
 
     var mockUserNotificationCenter: MockUserNotificationCenter!
     
     override func setUp() {
         mockUserNotificationCenter = MockUserNotificationCenter()
-        userNotificationDeviceAlertPresenter =
-            UserNotificationDeviceAlertPresenter(userNotificationCenter: mockUserNotificationCenter)
+        userNotificationAlertPresenter =
+            UserNotificationAlertPresenter(userNotificationCenter: mockUserNotificationCenter)
     }
 
     func testIssueImmediateAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -41,17 +41,17 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
-                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
+                AlertUserNotificationUserInfoKey.alert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                AlertUserNotificationUserInfoKey.alertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
     }
     
     func testIssueImmediateCriticalAlert() {
-        let backgroundContent = DeviceAlert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", isCritical: true)
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
+        let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", isCritical: true)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -64,16 +64,16 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":true,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
-                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
+                AlertUserNotificationUserInfoKey.alert.rawValue: "{\"trigger\":\"immediate\",\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":true,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                AlertUserNotificationUserInfoKey.alertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertNil(request.trigger)
         }
     }
     
     func testIssueDelayedAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
-        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .delayed(interval: 0.1))
+        userNotificationAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -86,8 +86,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"delayed\":{\"delayInterval\":0.10000000000000001}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
-                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
+                AlertUserNotificationUserInfoKey.alert.rawValue: "{\"trigger\":{\"delayed\":{\"delayInterval\":0.10000000000000001}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                AlertUserNotificationUserInfoKey.alertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(0.1, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(false, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
@@ -95,8 +95,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testIssueRepeatingAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 100))
-        userNotificationDeviceAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .repeating(repeatInterval: 100))
+        userNotificationAlertPresenter.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
         
@@ -109,8 +109,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
             XCTAssertEqual([
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
-                DeviceAlertUserNotificationUserInfoKey.deviceAlert.rawValue: "{\"trigger\":{\"repeating\":{\"repeatInterval\":100}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
-                DeviceAlertUserNotificationUserInfoKey.deviceAlertTimestamp.rawValue: "0001-01-01T00:00:00Z",
+                AlertUserNotificationUserInfoKey.alert.rawValue: "{\"trigger\":{\"repeating\":{\"repeatInterval\":100}},\"identifier\":{\"managerIdentifier\":\"foo\",\"alertIdentifier\":\"bar\"},\"foregroundContent\":{\"body\":\"foreground\",\"isCritical\":false,\"title\":\"FOREGROUND\",\"acknowledgeActionButtonLabel\":\"\"},\"backgroundContent\":{\"body\":\"background\",\"isCritical\":false,\"title\":\"BACKGROUND\",\"acknowledgeActionButtonLabel\":\"\"}}",
+                AlertUserNotificationUserInfoKey.alertTimestamp.rawValue: "0001-01-01T00:00:00Z",
             ], request.content.userInfo as? [String: String])
             XCTAssertEqual(100, (request.trigger as? UNTimeIntervalNotificationTrigger)?.timeInterval)
             XCTAssertEqual(true, (request.trigger as? UNTimeIntervalNotificationTrigger)?.repeats)
@@ -118,13 +118,13 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
     }
     
     func testRetractAlert() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        userNotificationAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         mockUserNotificationCenter.deliverAll()
         
-        userNotificationDeviceAlertPresenter.retractAlert(identifier: alert.identifier)
+        userNotificationAlertPresenter.retractAlert(identifier: alert.identifier)
         
         waitOnMain()
         XCTAssertTrue(mockUserNotificationCenter.pendingRequests.isEmpty)
@@ -133,8 +133,8 @@ class UserNotificationDeviceAlertPresenterTests: XCTestCase {
 
     
     func testDoesNotShowIfNoBackgroundContent() {
-        let alert = DeviceAlert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: nil, trigger: .immediate)
-        userNotificationDeviceAlertPresenter.issueAlert(alert)
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: nil, trigger: .immediate)
+        userNotificationAlertPresenter.issueAlert(alert)
 
         waitOnMain()
         

--- a/WatchApp Extension/Views/Carb Entry & Bolus/CarbAndBolusFlow.swift
+++ b/WatchApp Extension/Views/Carb Entry & Bolus/CarbAndBolusFlow.swift
@@ -317,7 +317,7 @@ extension CarbAndBolusFlow {
         }
     }
 
-    private func alert(for activeAlert: AlertState) -> Alert {
+    private func alert(for activeAlert: AlertState) -> SwiftUI.Alert {
         switch activeAlert {
         case .bolusRecommendationChanged:
             return recommendedBolusUpdatedAlert
@@ -326,15 +326,15 @@ extension CarbAndBolusFlow {
         }
     }
 
-    private var recommendedBolusUpdatedAlert: Alert {
-        Alert(
+    private var recommendedBolusUpdatedAlert: SwiftUI.Alert {
+        SwiftUI.Alert(
             title: Text("Bolus Recommendation Updated", comment: "Alert title for updated bolus recommendation on Apple Watch"),
             message: Text("Please reconfirm the bolus amount.", comment: "Alert message for updated bolus recommendation on Apple Watch"),
             dismissButton: .default(Text("OK"))
         )
     }
 
-    private func communicationErrorAlert(for error: CarbAndBolusFlowViewModel.Error) -> Alert {
+    private func communicationErrorAlert(for error: CarbAndBolusFlowViewModel.Error) -> SwiftUI.Alert {
         let dismissAction: () -> Void
         switch error {
         case .potentialCarbEntryMessageSendFailure:
@@ -343,7 +343,7 @@ extension CarbAndBolusFlow {
             dismissAction = { self.bolusConfirmationProgress = 0 }
         }
 
-        return Alert(
+        return SwiftUI.Alert(
             title: Text(error.failureReason!),
             message: Text(error.recoverySuggestion!),
             dismissButton: .default(Text("OK"), action: dismissAction)


### PR DESCRIPTION
Soon, we're going to have more "alerts" in the system than just "device alerts".  This renames it to just "Alert".  Note now disambiguation is going to be necessary for `SwiftUI.Alert`.

(Note: this looks like a huge PR, but in actuality it is all just renaming using Xcode)