### PR TITLE
LOOP-1414: Fix bolus error not showing notification in app

### DIFF
--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -149,7 +149,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         switch notification.request.identifier {
-            // Until these notifications are converted to use the new alert system, they shall still show in the foreground
+        // TODO: Until these notifications are converted to use the new alert system, they shall still show in the foreground
         case LoopNotificationCategory.bolusFailure.rawValue,
              LoopNotificationCategory.pumpReservoirLow.rawValue,
              LoopNotificationCategory.pumpReservoirEmpty.rawValue,

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -148,8 +148,19 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        // UserNotifications are not to be displayed while in the foreground
-        completionHandler([])
+        switch notification.request.identifier {
+            // Until these notifications are converted to use the new alert system, they shall still show in the foreground
+        case LoopNotificationCategory.bolusFailure.rawValue,
+             LoopNotificationCategory.pumpReservoirLow.rawValue,
+             LoopNotificationCategory.pumpReservoirEmpty.rawValue,
+             LoopNotificationCategory.pumpBatteryLow.rawValue,
+             LoopNotificationCategory.pumpExpired.rawValue,
+             LoopNotificationCategory.pumpFault.rawValue:
+            completionHandler([.badge, .sound, .alert])
+        default:
+            // All other userNotifications are not to be displayed while in the foreground
+            completionHandler([])
+        }
     }
     
 }


### PR DESCRIPTION
Some UserNotifications have not yet been converted to use the new alert system.  Until they are converted, this allows them to be shown in-app once again.