### PR TITLE
LOOP-1392 Alerts should be stored in iOS persistent storage for a limited amount of time

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 		A966152723EA5A26005D8B29 /* DerivedAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152523EA5A25005D8B29 /* DerivedAssets.xcassets */; };
 		A966152A23EA5A37005D8B29 /* DefaultAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152823EA5A37005D8B29 /* DefaultAssets.xcassets */; };
 		A966152B23EA5A37005D8B29 /* DerivedAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152923EA5A37005D8B29 /* DerivedAssets.xcassets */; };
+		A98556852493F901000FD662 /* AlertStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98556842493F901000FD662 /* AlertStore+SimulatedCoreData.swift */; };
 		A999D40424663CE1004C89D4 /* DoseStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A999D40324663CE1004C89D4 /* DoseStore.swift */; };
 		A999D40624663D18004C89D4 /* PumpManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A999D40524663D18004C89D4 /* PumpManagerError.swift */; };
 		A999D40824663D6D004C89D4 /* SetBolusError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A999D40724663D6D004C89D4 /* SetBolusError.swift */; };
@@ -1106,6 +1107,7 @@
 		A966152523EA5A25005D8B29 /* DerivedAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DerivedAssets.xcassets; sourceTree = "<group>"; };
 		A966152823EA5A37005D8B29 /* DefaultAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DefaultAssets.xcassets; sourceTree = "<group>"; };
 		A966152923EA5A37005D8B29 /* DerivedAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DerivedAssets.xcassets; sourceTree = "<group>"; };
+		A98556842493F901000FD662 /* AlertStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AlertStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A999D40324663CE1004C89D4 /* DoseStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoseStore.swift; sourceTree = "<group>"; };
 		A999D40524663D18004C89D4 /* PumpManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerError.swift; sourceTree = "<group>"; };
 		A999D40724663D6D004C89D4 /* SetBolusError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetBolusError.swift; sourceTree = "<group>"; };
@@ -1633,6 +1635,7 @@
 		43E344A01B9E144300C85C07 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				A98556842493F901000FD662 /* AlertStore+SimulatedCoreData.swift */,
 				C1D289B422F90A52003FFBD9 /* BasalDeliveryState.swift */,
 				A999D40924663DC7004C89D4 /* CarbStore.swift */,
 				A9F703722489BC8500C98AD8 /* CarbStore+SimulatedCoreData.swift */,
@@ -2855,6 +2858,7 @@
 				A9C62D892331703100535612 /* LoggingServicesManager.swift in Sources */,
 				89E267FF229267DF00A3F2AF /* Optional.swift in Sources */,
 				43785E982120E7060057DED1 /* Intents.intentdefinition in Sources */,
+				A98556852493F901000FD662 /* AlertStore+SimulatedCoreData.swift in Sources */,
 				899433B823FE129800FA4BEA /* OverrideBadgeView.swift in Sources */,
 				4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */,
 				4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */,

--- a/Loop/AppDelegate.swift
+++ b/Loop/AppDelegate.swift
@@ -32,7 +32,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         UIDevice.current.isBatteryMonitoringEnabled = true
 
-        alertManager = AlertManager(rootViewController: rootViewController)
+        alertManager = AlertManager(rootViewController: rootViewController, expireAfter: Bundle.main.localCacheDuration ?? .days(1))
         deviceDataManager = DeviceDataManager(pluginManager: pluginManager, alertManager: alertManager)
         loopAlertsManager = LoopAlertsManager(alertManager: alertManager)
 

--- a/Loop/Extensions/AlertStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/AlertStore+SimulatedCoreData.swift
@@ -17,7 +17,7 @@ extension AlertStore {
     private var simulatedPerDay: Int { 12 }
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: expireDate)
         let endDate = Calendar.current.startOfDay(for: historicalEndDate)
         var simulated = [DatedAlert]()
@@ -41,7 +41,7 @@ extension AlertStore {
         completion(addAlerts(alerts: simulated))
     }
 
-    public func purgeHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
         purge(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Extensions/AlertStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/AlertStore+SimulatedCoreData.swift
@@ -20,11 +20,11 @@ extension AlertStore {
     public func generateSimulatedHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: expireDate)
         let endDate = Calendar.current.startOfDay(for: historicalEndDate)
-        var simulated = [Alert]()
+        var simulated = [DatedAlert]()
 
         while startDate < endDate {
             for index in 0..<simulatedPerDay {
-                simulated.append(Alert.simulated(date: startDate.addingTimeInterval(.hours(24) * Double(index) / Double(simulatedPerDay))))
+                simulated.append(DatedAlert.simulated(date: startDate.addingTimeInterval(.hours(24) * Double(index) / Double(simulatedPerDay))))
             }
 
             if simulated.count >= simulatedLimit {
@@ -46,19 +46,20 @@ extension AlertStore {
     }
 }
 
-fileprivate extension Alert {
-    static func simulated(date: Date) -> Alert {
-        return Alert(identifier: Alert.Identifier(managerIdentifier: "simulatedManagerIdentifier",
-                                                  alertIdentifier: "simulatedAlertIdentifier"),
-                     foregroundContent: Alert.Content(title: "Simulated Alert Foreground Title",
-                                                      body: "The body of a foreground simulated alert approximates an actual alert body.",
-                                                      acknowledgeActionButtonLabel: "Acknowledged",
-                                                      isCritical: false),
-                     backgroundContent: Alert.Content(title: "Simulated Alert Background Title",
-                                                      body: "The body of a background simulated alert approximates an actual alert body.",
-                                                      acknowledgeActionButtonLabel: "Acknowledged",
-                                                      isCritical: false),
-                     trigger: .delayed(interval: 60),
-                     sound: .sound(name: "simulated"))
+fileprivate extension AlertStore.DatedAlert {
+    static func simulated(date: Date) -> AlertStore.DatedAlert {
+        let alert = Alert(identifier: Alert.Identifier(managerIdentifier: "simulatedManagerIdentifier",
+                                                       alertIdentifier: "simulatedAlertIdentifier"),
+                          foregroundContent: Alert.Content(title: "Simulated Alert Foreground Title",
+                                                           body: "The body of a foreground simulated alert approximates an actual alert body.",
+                                                           acknowledgeActionButtonLabel: "Acknowledged",
+                                                           isCritical: false),
+                          backgroundContent: Alert.Content(title: "Simulated Alert Background Title",
+                                                           body: "The body of a background simulated alert approximates an actual alert body.",
+                                                           acknowledgeActionButtonLabel: "Acknowledged",
+                                                           isCritical: false),
+                          trigger: .delayed(interval: 60),
+                          sound: .sound(name: "simulated"))
+        return AlertStore.DatedAlert(date: date, alert: alert)
     }
 }

--- a/Loop/Extensions/AlertStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/AlertStore+SimulatedCoreData.swift
@@ -1,0 +1,64 @@
+//
+//  AlertStore+SimulatedCoreData.swift
+//  Loop
+//
+//  Created by Darin Krauss on 6/12/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopKit
+
+// MARK: - Simulated Core Data
+
+extension AlertStore {
+    private var historicalEndDate: Date { Date(timeIntervalSinceNow: -.hours(24)) }
+
+    private var simulatedPerDay: Int { 12 }
+    private var simulatedLimit: Int { 10000 }
+
+    public func generateSimulatedHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
+        var startDate = Calendar.current.startOfDay(for: expireDate)
+        let endDate = Calendar.current.startOfDay(for: historicalEndDate)
+        var simulated = [Alert]()
+
+        while startDate < endDate {
+            for index in 0..<simulatedPerDay {
+                simulated.append(Alert.simulated(date: startDate.addingTimeInterval(.hours(24) * Double(index) / Double(simulatedPerDay))))
+            }
+
+            if simulated.count >= simulatedLimit {
+                if let error = addAlerts(alerts: simulated) {
+                    completion(error)
+                    return
+                }
+                simulated = []
+            }
+
+            startDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
+        }
+
+        completion(addAlerts(alerts: simulated))
+    }
+
+    public func purgeHistoricalStoredAlerts(completion: @escaping (Error?) -> Void) {
+        purge(before: historicalEndDate, completion: completion)
+    }
+}
+
+fileprivate extension Alert {
+    static func simulated(date: Date) -> Alert {
+        return Alert(identifier: Alert.Identifier(managerIdentifier: "simulatedManagerIdentifier",
+                                                  alertIdentifier: "simulatedAlertIdentifier"),
+                     foregroundContent: Alert.Content(title: "Simulated Alert Foreground Title",
+                                                      body: "The body of a foreground simulated alert approximates an actual alert body.",
+                                                      acknowledgeActionButtonLabel: "Acknowledged",
+                                                      isCritical: false),
+                     backgroundContent: Alert.Content(title: "Simulated Alert Background Title",
+                                                      body: "The body of a background simulated alert approximates an actual alert body.",
+                                                      acknowledgeActionButtonLabel: "Acknowledged",
+                                                      isCritical: false),
+                     trigger: .delayed(interval: 60),
+                     sound: .sound(name: "simulated"))
+    }
+}

--- a/Loop/Extensions/CarbStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/CarbStore+SimulatedCoreData.swift
@@ -19,7 +19,7 @@ extension CarbStore {
     private var simulatedDeletedPerDay: Int { 3 }
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalCarbObjects(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalCarbObjects(completion: @escaping (Error?) -> Void) {
         generateSimulatedHistoricalStoredCarbObjects() { error in
             guard error == nil else {
                 completion(error)
@@ -101,7 +101,7 @@ extension CarbStore {
         return addError
     }
 
-    public func purgeHistoricalCarbObjects(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalCarbObjects(completion: @escaping (Error?) -> Void) {
         purgeCachedCarbEntries(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Extensions/DoseStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/DoseStore+SimulatedCoreData.swift
@@ -20,7 +20,7 @@ extension DoseStore {
     private var simulatedOtherPerDay: Int { 1 }
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalPumpEvents(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalPumpEvents(completion: @escaping (Error?) -> Void) {
         generatedSimulatedHistoricalBasalPumpEvents() { error in
             guard error == nil else {
                 completion(error)
@@ -125,7 +125,7 @@ extension DoseStore {
         completion(addPumpEvents(events: simulated))
     }
 
-    public func purgeHistoricalPumpEvents(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalPumpEvents(completion: @escaping (Error?) -> Void) {
         purgePumpEventObjects(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Extensions/DosingDecisionStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/DosingDecisionStore+SimulatedCoreData.swift
@@ -18,7 +18,7 @@ extension DosingDecisionStore {
     private var simulatedStartDateInterval: TimeInterval { .minutes(5) }
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalDosingDecisionObjects(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalDosingDecisionObjects(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: expireDate)
         let endDate = Calendar.current.startOfDay(for: historicalEndDate)
         var simulated = [StoredDosingDecision]()
@@ -51,7 +51,7 @@ extension DosingDecisionStore {
         return addError
     }
 
-    public func purgeHistoricalDosingDecisionObjects(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalDosingDecisionObjects(completion: @escaping (Error?) -> Void) {
         purgeDosingDecisions(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Extensions/GlucoseStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/GlucoseStore+SimulatedCoreData.swift
@@ -21,7 +21,7 @@ extension GlucoseStore {
     private var simulatedValueIncrement: Double { 2.0 * .pi / 72.0 }    // 6 hour period
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalGlucoseObjects(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalGlucoseObjects(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: earliestCacheDate)
         let endDate = Calendar.current.startOfDay(for: historicalEndDate)
         var value = 0.0
@@ -56,7 +56,7 @@ extension GlucoseStore {
         return addError
     }
 
-    public func purgeHistoricalGlucoseObjects(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalGlucoseObjects(completion: @escaping (Error?) -> Void) {
         purgeCachedGlucoseObjects(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Extensions/PersistentDeviceLog+SimulatedCoreData.swift
+++ b/Loop/Extensions/PersistentDeviceLog+SimulatedCoreData.swift
@@ -17,7 +17,7 @@ extension PersistentDeviceLog {
     private var simulatedPerHour: Int { 250 }
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalDeviceLogEntries(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalDeviceLogEntries(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: earliestLogEntryDate)
         let endDate = Calendar.current.startOfDay(for: historicalEndDate)
         var simulated = [StoredDeviceLogEntry]()
@@ -41,7 +41,7 @@ extension PersistentDeviceLog {
         completion(addStoredDeviceLogEntries(entries: simulated))
     }
 
-    public func purgeHistoricalDeviceLogEntries(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalDeviceLogEntries(completion: @escaping (Error?) -> Void) {
         purgeLogEntries(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Extensions/SettingsStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/SettingsStore+SimulatedCoreData.swift
@@ -17,7 +17,7 @@ extension SettingsStore {
     private var simulatedPerDay: Int { 2 }
     private var simulatedLimit: Int { 10000 }
 
-    public func generateSimulatedHistoricalSettingsObjects(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalSettingsObjects(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: expireDate)
         let endDate = Calendar.current.startOfDay(for: historicalEndDate)
         var simulated = [StoredSettings]()
@@ -52,7 +52,7 @@ extension SettingsStore {
         return addError
     }
 
-    public func purgeHistoricalSettingsObjects(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalSettingsObjects(completion: @escaping (Error?) -> Void) {
         purgeSettings(before: historicalEndDate, completion: completion)
     }
 }

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -45,7 +45,7 @@ public final class AlertManager {
     private let userNotificationCenter: UserNotificationCenter
     private let fileManager: FileManager
 
-    private let alertStore: AlertStore
+    let alertStore: AlertStore
 
     public init(rootViewController: UIViewController,
                 handlers: [AlertPresenter]? = nil,

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -50,13 +50,15 @@ public final class AlertManager {
     public init(rootViewController: UIViewController,
                 handlers: [AlertPresenter]? = nil,
                 userNotificationCenter: UserNotificationCenter = UNUserNotificationCenter.current(),
-                fileManager: FileManager = FileManager.default) {
+                fileManager: FileManager = FileManager.default,
+                expireAfter: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */) {
         self.userNotificationCenter = userNotificationCenter
         self.fileManager = fileManager
         let documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
         alertStore = AlertStore(storageFileURL: documentsDirectory?
             .appendingPathComponent("AlertStore")
-            .appendingPathComponent("AlertStore.sqlite"))
+            .appendingPathComponent("AlertStore.sqlite"),
+                                expireAfter: expireAfter)
         self.handlers = handlers ??
             [UserNotificationAlertPresenter(userNotificationCenter: userNotificationCenter),
             InAppModalAlertPresenter(rootViewController: rootViewController, alertManagerResponder: self)]

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -293,12 +293,12 @@ extension Result where Success == Void {
 // MARK: - Core Data (Bulk) - TEST ONLY
 
 extension AlertStore {
-    public struct DatedAlert {
+    struct DatedAlert {
         let date: Date
         let alert: Alert
     }
 
-    public func addAlerts(alerts: [DatedAlert]) -> Error? {
+    func addAlerts(alerts: [DatedAlert]) -> Error? {
         guard !alerts.isEmpty else {
             return nil
         }

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -20,9 +20,11 @@ public class AlertStore {
 
     private let persistentContainer: NSPersistentContainer
         
+    private let expireAfter: TimeInterval
+
     private let log = DiagnosticLog(category: "AlertStore")
     
-    public init(storageFileURL: URL? = nil) {
+    public init(storageFileURL: URL? = nil, expireAfter: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */) {
         managedObjectContext = NSManagedObjectContext(concurrencyType: .privateQueueConcurrencyType)
         managedObjectContext.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy
         managedObjectContext.automaticallyMergesChangesFromParent = true
@@ -43,6 +45,8 @@ public class AlertStore {
             }
         }
         managedObjectContext.persistentStoreCoordinator = persistentContainer.persistentStoreCoordinator
+
+        self.expireAfter = expireAfter
     }
 }
 
@@ -56,6 +60,7 @@ extension AlertStore {
             do {
                 try self.managedObjectContext.save()
                 self.log.default("Recorded alert: %{public}@", alert.identifier.value)
+                self.purgeExpired()
                 completion?(.success)
             } catch {
                 self.log.error("Could not store alert: %{public}@, %{public}@", alert.identifier.value, String(describing: error))
@@ -86,6 +91,7 @@ extension AlertStore {
                         do {
                             try self.managedObjectContext.save()
                             self.log.default("Recorded alert: %{public}@", identifier.value)
+                            self.purgeExpired()
                             completion?(.success)
                         } catch {
                             self.log.error("Could not store alert: %{public}@, %{public}@", identifier.value, String(describing: error))
@@ -117,6 +123,29 @@ extension AlertStore {
         }
     }
 
+}
+
+// MARK: Alert Purging
+
+extension AlertStore {
+    var expireDate: Date {
+        return Date(timeIntervalSinceNow: -expireAfter)
+    }
+
+    private func purgeExpired() {
+        purge(before: expireDate)
+    }
+
+    func purge(before date: Date, completion: ((Error?) -> Void)? = nil) {
+        do {
+            let count = try self.managedObjectContext.purgeObjects(of: StoredAlert.self, matching: NSPredicate(format: "issuedDate < %@", date as NSDate))
+            self.log.info("Purged %d StoredAlerts", count)
+            completion?(nil)
+        } catch let error {
+            self.log.error("Unable to purge StoredAlerts: %{public}@", String(describing: error))
+            completion?(error)
+        }
+    }
 }
 
 // MARK: Query Support
@@ -225,5 +254,36 @@ extension Alert.Identifier {
 extension Result where Success == Void {
     static var success: Result {
         return Result.success(Void())
+    }
+}
+
+// MARK: - Core Data (Bulk) - TEST ONLY
+
+extension AlertStore {
+    public func addAlerts(alerts: [Alert]) -> Error? {
+        guard !alerts.isEmpty else {
+            return nil
+        }
+
+        var error: Error?
+
+        self.managedObjectContext.performAndWait {
+            for alert in alerts {
+                _ = StoredAlert(from: alert, context: self.managedObjectContext)
+            }
+
+            do {
+                try self.managedObjectContext.save()
+            } catch let saveError {
+                error = saveError
+            }
+        }
+
+        guard error == nil else {
+            return error
+        }
+
+        self.log.info("Added %d StoredAlerts", alerts.count)
+        return nil
     }
 }

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -168,7 +168,9 @@ extension AlertStore {
 
     func purge(before date: Date, completion: ((Error?) -> Void)? = nil) {
         do {
-            let count = try self.managedObjectContext.purgeObjects(of: StoredAlert.self, matching: NSPredicate(format: "issuedDate < %@", date as NSDate))
+            let fetchRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "issuedDate < %@", date as NSDate)
+            let count = try self.managedObjectContext.deleteObjects(matching: fetchRequest)
             self.log.info("Purged %d StoredAlerts", count)
             completion?(nil)
         } catch let error {

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -293,7 +293,12 @@ extension Result where Success == Void {
 // MARK: - Core Data (Bulk) - TEST ONLY
 
 extension AlertStore {
-    public func addAlerts(alerts: [Alert]) -> Error? {
+    public struct DatedAlert {
+        let date: Date
+        let alert: Alert
+    }
+
+    public func addAlerts(alerts: [DatedAlert]) -> Error? {
         guard !alerts.isEmpty else {
             return nil
         }
@@ -302,7 +307,8 @@ extension AlertStore {
 
         self.managedObjectContext.performAndWait {
             for alert in alerts {
-                _ = StoredAlert(from: alert, context: self.managedObjectContext)
+                let storedAlert = StoredAlert(from: alert.alert, context: self.managedObjectContext, issuedDate: alert.date)
+                storedAlert.acknowledgedDate = alert.date
             }
 
             do {

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -823,7 +823,7 @@ extension DeviceDataManager {
 // MARK: - Simulated Core Data
 
 extension DeviceDataManager {
-    public func generateSimulatedHistoricalCoreData(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalCoreData(completion: @escaping (Error?) -> Void) {
         guard FeatureFlags.simulatedCoreDataEnabled else {
             fatalError("\(#function) should be invoked only when simulated core data is enabled")
         }
@@ -843,7 +843,7 @@ extension DeviceDataManager {
         }
     }
 
-    public func purgeHistoricalCoreData(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalCoreData(completion: @escaping (Error?) -> Void) {
         guard FeatureFlags.simulatedCoreDataEnabled else {
             fatalError("\(#function) should be invoked only when simulated core data is enabled")
         }

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -833,7 +833,13 @@ extension DeviceDataManager {
                 completion(error)
                 return
             }
-            self.deviceLog.generateSimulatedHistoricalDeviceLogEntries(completion: completion)
+            self.deviceLog.generateSimulatedHistoricalDeviceLogEntries() { error in
+                guard error == nil else {
+                    completion(error)
+                    return
+                }
+                self.alertManager.alertStore.generateSimulatedHistoricalStoredAlerts(completion: completion)
+            }
         }
     }
 
@@ -842,12 +848,18 @@ extension DeviceDataManager {
             fatalError("\(#function) should be invoked only when simulated core data is enabled")
         }
 
-        deviceLog.purgeHistoricalDeviceLogEntries() { error in
+        alertManager.alertStore.purgeHistoricalStoredAlerts() { error in
             guard error == nil else {
                 completion(error)
                 return
             }
-            self.loopManager.purgeHistoricalCoreData(completion: completion)
+            self.deviceLog.purgeHistoricalDeviceLogEntries() { error in
+                guard error == nil else {
+                    completion(error)
+                    return
+                }
+                self.loopManager.purgeHistoricalCoreData(completion: completion)
+            }
         }
     }
 }

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1738,7 +1738,7 @@ private extension StoredSettings.InsulinModel {
 // MARK: - Simulated Core Data
 
 extension LoopDataManager {
-    public func generateSimulatedHistoricalCoreData(completion: @escaping (Error?) -> Void) {
+    func generateSimulatedHistoricalCoreData(completion: @escaping (Error?) -> Void) {
         guard FeatureFlags.simulatedCoreDataEnabled else {
             fatalError("\(#function) should be invoked only when simulated core data is enabled")
         }
@@ -1770,7 +1770,7 @@ extension LoopDataManager {
         }
     }
     
-    public func purgeHistoricalCoreData(completion: @escaping (Error?) -> Void) {
+    func purgeHistoricalCoreData(completion: @escaping (Error?) -> Void) {
         guard FeatureFlags.simulatedCoreDataEnabled else {
             fatalError("\(#function) should be invoked only when simulated core data is enabled")
         }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1392
- Add expireAfter and expireDate to AlertStore
- Purge expired alerts
- Add Core Data bulk add support to AlertStore
- Add simulated Core Data support to AlertStore

Requesting @rickpasetto and one other reviewer, please.