### PR TITLE
LOOP-473-474 Eliminate Walsh and Fiasp insulin models

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -18,6 +18,8 @@ struct FeatureFlagConfiguration: Decodable {
     let criticalAlertsEnabled: Bool
     let scenariosEnabled: Bool
     let simulatedCoreDataEnabled: Bool
+    let walshInsulinModelEnabled: Bool
+    let fiaspInsulinModelEnabled: Bool
 
     fileprivate init() {
         // Swift compiler config is inverse, since the default state is enabled.
@@ -58,6 +60,20 @@ struct FeatureFlagConfiguration: Decodable {
         #else
         self.simulatedCoreDataEnabled = false
         #endif
+
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if WALSH_INSULIN_MODEL_DISABLED
+        self.walshInsulinModelEnabled = false
+        #else
+        self.walshInsulinModelEnabled = true
+        #endif
+
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if FIASP_INSULIN_MODEL_DISABLED
+        self.fiaspInsulinModelEnabled = false
+        #else
+        self.fiaspInsulinModelEnabled = true
+        #endif
     }
 }
 
@@ -71,6 +87,8 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* criticalAlertsEnabled: \(criticalAlertsEnabled)",
             "* scenariosEnabled: \(scenariosEnabled)",
             "* simulatedCoreDataEnabled: \(simulatedCoreDataEnabled)",
+            "* walshInsulinModelEnabled: \(walshInsulinModelEnabled)",
+            "* fiaspInsulinModelEnabled: \(fiaspInsulinModelEnabled)",
         ].joined(separator: "\n")
     }
 }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-473
- https://tidepool.atlassian.net/browse/LOOP-474
- Add feature flags to disable Walsh and Fiasp insulin models
- Do not display Walsh and Fiasp insulin models in settings

Requesting two reviewers, please.