### PR TITLE
LOOP-1412: Play back alerts from AlertStore, not Notification Center

### DIFF
--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -176,27 +176,6 @@ extension AlertManager {
         }
     }
 
-    private func determineNewTrigger(from alert: Alert, timestamp: Date) -> Alert.Trigger {
-        switch alert.trigger {
-        case .immediate:
-            return alert.trigger
-        case .delayed(let interval):
-            let triggerTime = timestamp.addingTimeInterval(interval)
-            let timeIntervalSinceNow = triggerTime.timeIntervalSinceNow
-            if timeIntervalSinceNow < 0 {
-                // Trigger time has passed...trigger immediately
-                return .immediate
-            } else {
-                return .delayed(interval: timeIntervalSinceNow)
-            }
-        case .repeating:
-            // Strange case here: if it is a repeating trigger, we can't really play back exactly
-            // at the right "remaining time" and then repeat at the original period.  So, I think
-            // the best we can do is just use the original trigger
-            return alert.trigger
-        }
-    }
-
 }
 
 // MARK: Alert storage access

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -61,7 +61,7 @@ public final class AlertManager {
             [UserNotificationAlertPresenter(userNotificationCenter: userNotificationCenter),
             InAppModalAlertPresenter(rootViewController: rootViewController, alertManagerResponder: self)]
             
-        playbackAlertsFromUserNotificationCenter()
+        playbackAlertsFromPersistence()
     }
 
     public func addAlertResponder(managerIdentifier: String, alertResponder: AlertResponder) {
@@ -155,6 +155,28 @@ extension AlertManager {
 // MARK: Alert Playback
 
 extension AlertManager {
+    
+    private func playbackAlertsFromPersistence() {
+//        playbackAlertsFromUserNotificationCenter()
+        playbackAlertsFromAlertStore()
+    }
+    
+    private func playbackAlertsFromAlertStore() {
+        alertStore.lookupAllUnacknowledged {
+            switch $0 {
+            case .failure(let error):
+                self.log.error("Could not fetch unacknowledged alerts: %@", error.localizedDescription)
+            case .success(let alerts):
+                alerts.forEach { alert in
+                    do {
+                        self.replayAlert(try Alert(from: alert))
+                    } catch {
+                        self.log.error("Error decoding alert from persistent storage: %@", error.localizedDescription)
+                    }
+                }
+            }
+        }
+    }
     
     private func playbackAlertsFromUserNotificationCenter() {
     

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -60,7 +60,7 @@ public final class AlertManager {
             [UserNotificationAlertPresenter(userNotificationCenter: userNotificationCenter),
             InAppModalAlertPresenter(rootViewController: rootViewController, alertManagerResponder: self)]
         
-        self.playbackAlertsFromPersistence()
+        playbackAlertsFromPersistence()
     }
 
     public func addAlertResponder(managerIdentifier: String, alertResponder: AlertResponder) {

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -32,7 +32,6 @@ public class AlertStore {
             let storageFileURL = storageDirectoryURL
                 .appendingPathComponent("AlertStore")
                 .appendingPathComponent("AlertStore.sqlite")
-            print("storageFile = \(storageFileURL.path)")
             storeDescription.url = storageFileURL
         } else {
             storeDescription.type = NSInMemoryStoreType
@@ -144,8 +143,6 @@ extension AlertStore {
                 fetchRequest.sortDescriptors = [ NSSortDescriptor(key: "modificationCounter", ascending: false) ]
                 fetchRequest.fetchLimit = 1
                 let result = try self.managedObjectContext.fetch(fetchRequest)
-                print("predicate = \(fetchRequest.predicate)")
-                print("result.last = \(result.last?.modificationCounter)")
                 completion(.success(result.last))
             } catch {
                 completion(.failure(error))

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -116,6 +116,24 @@ extension AlertStore {
             }
         }
     }
+    
+    public func lookupAllUnacknowledged(completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+        managedObjectContext.perform {
+            do {
+                let fetchRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
+                fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    NSPredicate(format: "acknowledgedDate == nil"),
+                    NSPredicate(format: "retractedDate == nil")
+                ])
+                fetchRequest.sortDescriptors = [ NSSortDescriptor(key: "modificationCounter", ascending: true) ]
+                fetchRequest.fetchLimit = 20 // TODO: Seems reasonable to put some limit here, but is this a good value?
+                let result = try self.managedObjectContext.fetch(fetchRequest)
+                completion(.success(result))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
 
 }
 

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -120,7 +120,7 @@ extension Alert.Trigger {
         case 0: self = .immediate
         case 1:
             if let storedInterval = storedInterval {
-                if let storageDate = storageDate {
+                if let storageDate = storageDate, storageDate <= now {
                     let intervalLeft = storedInterval.doubleValue - now.timeIntervalSince(storageDate)
                     if intervalLeft <= 0 {
                         self = .immediate

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -68,7 +68,10 @@ extension Alert {
                                         storedInterval: storedAlert.triggerInterval,
                                         storageDate: adjustedForStorageTime ? storedAlert.issuedDate : nil)
         self.init(identifier: storedAlert.identifier,
-                  foregroundContent: fgContent, backgroundContent: bgContent, trigger: trigger, sound: sound)
+                  foregroundContent: fgContent,
+                  backgroundContent: bgContent,
+                  trigger: trigger,
+                  sound: sound)
     }
 }
 

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -134,7 +134,9 @@ extension Alert.Trigger {
                 throw StorageError.invalidStoredInterval
             }
         case 2:
-            // TODO: for now, we do not adjust repeating triggers by storage date
+            // Strange case here: if it is a repeating trigger, we can't really play back exactly
+            // at the right "remaining time" and then repeat at the original period.  So, I think
+            // the best we can do is just use the original trigger
             if let storedInterval = storedInterval {
                 self = .repeating(repeatInterval: storedInterval.doubleValue)
             } else {

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -74,6 +74,38 @@ class AlertManagerTests: XCTestCase {
         }
     }
     
+    class MockAlertStore: AlertStore {
+        
+        var issuedAlert: Alert?
+        override public func recordIssued(alert: Alert, at date: Date = Date(), _ completion: ((Result<Void, Error>) -> Void)? = nil) {
+            issuedAlert = alert
+            completion?(.success)
+        }
+        
+        var acknowledgedAlertIdentifier: Alert.Identifier?
+        var acknowledgedAlertDate: Date?
+        override public func recordAcknowledgement(of identifier: Alert.Identifier, at date: Date = Date(),
+                                                   _ completion: ((Result<Void, Error>) -> Void)? = nil) {
+            acknowledgedAlertIdentifier = identifier
+            acknowledgedAlertDate = date
+            completion?(.success)
+        }
+        
+        var retractededAlertIdentifier: Alert.Identifier?
+        var retractedAlertDate: Date?
+        override public func recordRetraction(of identifier: Alert.Identifier, at date: Date = Date(),
+                                              _ completion: ((Result<Void, Error>) -> Void)? = nil) {
+            retractededAlertIdentifier = identifier
+            retractedAlertDate = date
+            completion?(.success)
+        }
+
+        var storedAlerts = [StoredAlert]()
+        override public func lookupAllUnacknowledged(completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+            completion(.success(storedAlerts))
+        }
+    }
+    
     static let mockManagerIdentifier = "mockManagerIdentifier"
     static let mockTypeIdentifier = "mockTypeIdentifier"
     static let mockIdentifier = Alert.Identifier(managerIdentifier: mockManagerIdentifier, alertIdentifier: mockTypeIdentifier)
@@ -82,6 +114,7 @@ class AlertManagerTests: XCTestCase {
     var mockFileManager: MockFileManager!
     var mockPresenter: MockPresenter!
     var mockUserNotificationCenter: MockUserNotificationCenter!
+    var mockAlertStore: MockAlertStore!
     var alertManager: AlertManager!
     var isInBackground = true
     
@@ -94,11 +127,16 @@ class AlertManagerTests: XCTestCase {
         mockFileManager = MockFileManager()
         mockPresenter = MockPresenter()
         mockUserNotificationCenter = MockUserNotificationCenter()
+        mockAlertStore = MockAlertStore()
         alertManager = AlertManager(rootViewController: UIViewController(),
                                     handlers: [mockPresenter],
                                     userNotificationCenter: mockUserNotificationCenter,
                                     fileManager: mockFileManager,
-                                    inMemoryAlertStore: true)
+                                    alertStore: mockAlertStore)
+    }
+
+    override func tearDown() {
+        mockAlertStore = nil
     }
     
     func testIssueAlertOnHandlerCalled() {
@@ -154,21 +192,18 @@ class AlertManagerTests: XCTestCase {
         XCTAssertEqual(["doesntExist", "existsOlder"], mockFileManager.copiedSrcURLs.map { $0.lastPathComponent })
         XCTAssertEqual(["\(Self.mockManagerIdentifier)-doesntExist", "\(Self.mockManagerIdentifier)-existsOlder"], mockFileManager.copiedDstURLs.map { $0.lastPathComponent })
     }
-    
-    // Unfortunately, it is not very easy to test playback of delivered notifications, because we
-    // can't construct UNNotifications.  Hopefully, the code footprint in `AlertManager.playbackDeliveredNotification` is small enough, because it calls common code under test.
-    
-    func testPlaybackPendingImmediateNotification() {
-        let date = Date()
+        
+    func testPlaybackPendingImmediateAlert() {
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
                           foregroundContent: content, backgroundContent: content, trigger: .immediate)
+        mockAlertStore.storedAlerts = [StoredAlert(from: alert, context: mockAlertStore.managedObjectContext)]
         
-        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
         alertManager = AlertManager(rootViewController: UIViewController(),
                                     handlers: [mockPresenter],
                                     userNotificationCenter: mockUserNotificationCenter,
-                                    fileManager: mockFileManager)
+                                    fileManager: mockFileManager,
+                                    alertStore: mockAlertStore)
         XCTAssertEqual(alert, mockPresenter.issuedAlert)
     }
     
@@ -177,12 +212,14 @@ class AlertManagerTests: XCTestCase {
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
                           foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
-        
-        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        let storedAlert = StoredAlert(from: alert, context: mockAlertStore.managedObjectContext)
+        storedAlert.issuedDate = date
+        mockAlertStore.storedAlerts = [storedAlert]
         alertManager = AlertManager(rootViewController: UIViewController(),
                                     handlers: [mockPresenter],
                                     userNotificationCenter: mockUserNotificationCenter,
-                                    fileManager: mockFileManager)
+                                    fileManager: mockFileManager,
+                                    alertStore: mockAlertStore)
         let expected = Alert(identifier: Self.mockIdentifier, foregroundContent: content, backgroundContent: content, trigger: .immediate)
         XCTAssertEqual(expected, mockPresenter.issuedAlert)
     }
@@ -192,12 +229,15 @@ class AlertManagerTests: XCTestCase {
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
                           foregroundContent: content, backgroundContent: content, trigger: .delayed(interval: 30.0))
-        
-        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        let storedAlert = StoredAlert(from: alert, context: mockAlertStore.managedObjectContext)
+        storedAlert.issuedDate = date
+        mockAlertStore.storedAlerts = [storedAlert]
         alertManager = AlertManager(rootViewController: UIViewController(),
                                     handlers: [mockPresenter],
                                     userNotificationCenter: mockUserNotificationCenter,
-                                    fileManager: mockFileManager)
+                                    fileManager: mockFileManager,
+                                    alertStore: mockAlertStore)
+
         // The trigger for this should be `.delayed` by "something less than 15 seconds",
         // but the exact value depends on the speed of executing this test.
         // As long as it is <= 15 seconds, we call it good.
@@ -215,12 +255,15 @@ class AlertManagerTests: XCTestCase {
         let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
         let alert = Alert(identifier: Self.mockIdentifier,
                           foregroundContent: content, backgroundContent: content, trigger: .repeating(repeatInterval: 60.0))
-        
-        mockUserNotificationCenter.pendingRequests = [ try! UNNotificationRequest(from: alert, timestamp: date) ]
+        let storedAlert = StoredAlert(from: alert, context: mockAlertStore.managedObjectContext)
+        storedAlert.issuedDate = date
+        mockAlertStore.storedAlerts = [storedAlert]
         alertManager = AlertManager(rootViewController: UIViewController(),
                                     handlers: [mockPresenter],
                                     userNotificationCenter: mockUserNotificationCenter,
-                                    fileManager: mockFileManager)
+                                    fileManager: mockFileManager,
+                                    alertStore: mockAlertStore)
+
         XCTAssertEqual(alert, mockPresenter.issuedAlert)
     }
 }

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -97,7 +97,8 @@ class AlertManagerTests: XCTestCase {
         alertManager = AlertManager(rootViewController: UIViewController(),
                                     handlers: [mockPresenter],
                                     userNotificationCenter: mockUserNotificationCenter,
-                                    fileManager: mockFileManager)
+                                    fileManager: mockFileManager,
+                                    inMemoryAlertStore: true)
     }
     
     func testIssueAlertOnHandlerCalled() {

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -77,7 +77,7 @@ class AlertManagerTests: XCTestCase {
     class MockAlertStore: AlertStore {
         
         var issuedAlert: Alert?
-        override public func recordIssued(alert: Alert, at date: Date = Date(), _ completion: ((Result<Void, Error>) -> Void)? = nil) {
+        override public func recordIssued(alert: Alert, at date: Date = Date(), completion: ((Result<Void, Error>) -> Void)? = nil) {
             issuedAlert = alert
             completion?(.success)
         }
@@ -85,7 +85,7 @@ class AlertManagerTests: XCTestCase {
         var acknowledgedAlertIdentifier: Alert.Identifier?
         var acknowledgedAlertDate: Date?
         override public func recordAcknowledgement(of identifier: Alert.Identifier, at date: Date = Date(),
-                                                   _ completion: ((Result<Void, Error>) -> Void)? = nil) {
+                                                   completion: ((Result<Void, Error>) -> Void)? = nil) {
             acknowledgedAlertIdentifier = identifier
             acknowledgedAlertDate = date
             completion?(.success)
@@ -94,7 +94,7 @@ class AlertManagerTests: XCTestCase {
         var retractededAlertIdentifier: Alert.Identifier?
         var retractedAlertDate: Date?
         override public func recordRetraction(of identifier: Alert.Identifier, at date: Date = Date(),
-                                              _ completion: ((Result<Void, Error>) -> Void)? = nil) {
+                                              completion: ((Result<Void, Error>) -> Void)? = nil) {
             retractededAlertIdentifier = identifier
             retractedAlertDate = date
             completion?(.success)

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -72,8 +72,8 @@ class AlertStoreTests: XCTestCase {
     
     func testRecordIssued() {
         let expect = self.expectation(description: #function)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.fetch(identifier: Self.identifier1, self.expectSuccess { storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.fetch(identifier: Self.identifier1, completion: self.expectSuccess { storedAlerts in
                 XCTAssertEqual(1, storedAlerts.count)
                 XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                 XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
@@ -89,9 +89,9 @@ class AlertStoreTests: XCTestCase {
         let expect = self.expectation(description: #function)
         let issuedDate = Date.distantPast
         let acknowledgedDate = issuedDate.addingTimeInterval(1)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.recordAcknowledgement(of: Self.identifier1, at: acknowledgedDate, self.expectSuccess {
-                self.alertStore.fetch(identifier: Self.identifier1, self.expectSuccess { storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.recordAcknowledgement(of: Self.identifier1, at: acknowledgedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.identifier1, completion: self.expectSuccess { storedAlerts in
                     XCTAssertEqual(1, storedAlerts.count)
                     XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                     XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
@@ -108,9 +108,9 @@ class AlertStoreTests: XCTestCase {
         let expect = self.expectation(description: #function)
         let issuedDate = Date.distantPast
         let retractedDate = issuedDate.addingTimeInterval(2)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, self.expectSuccess {
-                self.alertStore.fetch(identifier: Self.identifier1, self.expectSuccess { storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.identifier1, completion: self.expectSuccess { storedAlerts in
                     XCTAssertEqual(1, storedAlerts.count)
                     XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                     XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
@@ -130,10 +130,10 @@ class AlertStoreTests: XCTestCase {
         let issuedDate = Date.distantPast
         let retractedDate = issuedDate.addingTimeInterval(2)
         let acknowledgedDate = issuedDate.addingTimeInterval(4)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, self.expectSuccess {
-                self.alertStore.recordAcknowledgement(of: Self.identifier1, at: acknowledgedDate, self.expectSuccess {
-                    self.alertStore.fetch(identifier: Self.identifier1, self.expectSuccess { storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.recordAcknowledgement(of: Self.identifier1, at: acknowledgedDate, completion: self.expectSuccess {
+                    self.alertStore.fetch(identifier: Self.identifier1, completion: self.expectSuccess { storedAlerts in
                         XCTAssertEqual(1, storedAlerts.count)
                         XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                         XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
@@ -152,10 +152,10 @@ class AlertStoreTests: XCTestCase {
         let issuedDate = Date.distantPast
         let retractedDate = issuedDate.addingTimeInterval(2)
         let acknowledgedDate = issuedDate.addingTimeInterval(4)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.recordAcknowledgement(of: Self.identifier1, at: acknowledgedDate, self.expectSuccess {
-                self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, self.expectSuccess {
-                    self.alertStore.fetch(identifier: Self.identifier1, self.expectSuccess { storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.recordAcknowledgement(of: Self.identifier1, at: acknowledgedDate, completion: self.expectSuccess {
+                self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, completion: self.expectSuccess {
+                    self.alertStore.fetch(identifier: Self.identifier1, completion: self.expectSuccess { storedAlerts in
                         XCTAssertEqual(1, storedAlerts.count)
                         XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                         XCTAssertEqual(issuedDate, storedAlerts[0].issuedDate)
@@ -171,8 +171,8 @@ class AlertStoreTests: XCTestCase {
     
     func testEmptyQuery() {
         let expect = self.expectation(description: #function)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.executeQuery(since: Date.distantPast, limit: 0, self.expectSuccess { _, storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.executeQuery(since: Date.distantPast, limit: 0, completion: self.expectSuccess { _, storedAlerts in
                 XCTAssertTrue(storedAlerts.isEmpty)
                 expect.fulfill()
             })
@@ -182,8 +182,8 @@ class AlertStoreTests: XCTestCase {
     
     func testSimpleQuery() {
         let expect = self.expectation(description: #function)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.executeQuery(since: Date.distantPast, limit: 100, self.expectSuccess { anchor, storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.executeQuery(since: Date.distantPast, limit: 100, completion: self.expectSuccess { anchor, storedAlerts in
                 XCTAssertEqual(1, anchor.modificationCounter)
                 XCTAssertEqual(1, storedAlerts.count)
                 XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
@@ -200,16 +200,16 @@ class AlertStoreTests: XCTestCase {
         let expect = self.expectation(description: #function)
         let issuedDate = Date.distantPast
         let retractedDate = issuedDate.addingTimeInterval(2)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.executeQuery(since: Date.distantPast, limit: 100, self.expectSuccess { anchor, storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.executeQuery(since: Date.distantPast, limit: 100, completion: self.expectSuccess { anchor, storedAlerts in
                 XCTAssertEqual(1, anchor.modificationCounter)
                 XCTAssertEqual(1, storedAlerts.count)
                 XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
                 XCTAssertEqual(Date.distantPast, storedAlerts[0].issuedDate)
                 XCTAssertNil(storedAlerts[0].acknowledgedDate)
                 XCTAssertNil(storedAlerts[0].retractedDate)
-                self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, self.expectSuccess {
-                    self.alertStore.executeQuery(since: Date.distantPast, limit: 100, self.expectSuccess { anchor, storedAlerts in
+                self.alertStore.recordRetraction(of: Self.identifier1, at: retractedDate, completion: self.expectSuccess {
+                    self.alertStore.executeQuery(since: Date.distantPast, limit: 100, completion: self.expectSuccess { anchor, storedAlerts in
                         XCTAssertEqual(2, anchor.modificationCounter)
                         XCTAssertEqual(1, storedAlerts.count)
                         XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
@@ -226,10 +226,10 @@ class AlertStoreTests: XCTestCase {
     
     func testQueryByDate() {
         let expect = self.expectation(description: #function)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
             let now = Date()
-            self.alertStore.recordIssued(alert: self.alert2, at: now, self.expectSuccess {
-                self.alertStore.executeQuery(since: now, limit: 100, self.expectSuccess { anchor, storedAlerts in
+            self.alertStore.recordIssued(alert: self.alert2, at: now, completion: self.expectSuccess {
+                self.alertStore.executeQuery(since: now, limit: 100, completion: self.expectSuccess { anchor, storedAlerts in
                     XCTAssertEqual(2, anchor.modificationCounter)
                     XCTAssertEqual(1, storedAlerts.count)
                     XCTAssertEqual(Self.identifier2, storedAlerts[0].identifier)
@@ -245,9 +245,9 @@ class AlertStoreTests: XCTestCase {
     
     func testQueryWithLimit() {
         let expect = self.expectation(description: #function)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, self.expectSuccess {
-            self.alertStore.recordIssued(alert: self.alert2, at: Date(), self.expectSuccess {
-                self.alertStore.executeQuery(since: Date.distantPast, limit: 1, self.expectSuccess { anchor, storedAlerts in
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: self.expectSuccess {
+            self.alertStore.recordIssued(alert: self.alert2, at: Date(), completion: self.expectSuccess {
+                self.alertStore.executeQuery(since: Date.distantPast, limit: 1, completion: self.expectSuccess { anchor, storedAlerts in
                     XCTAssertEqual(1, anchor.modificationCounter)
                     XCTAssertEqual(1, storedAlerts.count)
                     XCTAssertEqual(Self.identifier1, storedAlerts[0].identifier)
@@ -263,11 +263,11 @@ class AlertStoreTests: XCTestCase {
     
     func testQueryThenContinue() {
         let expect = self.expectation(description: #function)
-        alertStore.recordIssued(alert: alert1, at: Date.distantPast, expectSuccess {
+        alertStore.recordIssued(alert: alert1, at: Date.distantPast, completion: expectSuccess {
             let now = Date()
-            self.alertStore.recordIssued(alert: self.alert2, at: now, self.expectSuccess {
-                self.alertStore.executeQuery(since: Date.distantPast, limit: 1, self.expectSuccess { anchor, _ in
-                    self.alertStore.continueQuery(from: anchor, limit: 1, self.expectSuccess { anchor, storedAlerts in
+            self.alertStore.recordIssued(alert: self.alert2, at: now, completion: self.expectSuccess {
+                self.alertStore.executeQuery(since: Date.distantPast, limit: 1, completion: self.expectSuccess { anchor, _ in
+                    self.alertStore.continueQuery(from: anchor, limit: 1, completion: self.expectSuccess { anchor, storedAlerts in
                         XCTAssertEqual(2, anchor.modificationCounter)
                         XCTAssertEqual(1, storedAlerts.count)
                         XCTAssertEqual(Self.identifier2, storedAlerts[0].identifier)
@@ -290,8 +290,8 @@ class AlertStoreTests: XCTestCase {
             (alert2, false, false),
             (alert1, true, false)
         ]) {
-            self.alertStore.recordAcknowledgement(of: self.alert1.identifier, at: now, self.expectSuccess {
-                self.alertStore.fetch(self.expectSuccess { storedAlerts in
+            self.alertStore.recordAcknowledgement(of: self.alert1.identifier, at: now, completion: self.expectSuccess {
+                self.alertStore.fetch(completion: self.expectSuccess { storedAlerts in
                     XCTAssertEqual(3, storedAlerts.count)
                     // Last one is last-modified
                     XCTAssertNotNil(storedAlerts.last)
@@ -373,7 +373,7 @@ class AlertStoreTests: XCTestCase {
     private func fillWith(startDate: Date, data: [(alert: Alert, acknowledged: Bool, retracted: Bool)], _ completion: @escaping () -> Void) {
         let increment = 1.0
         if let value = data.first {
-            alertStore.recordIssued(alert: value.alert, at: startDate, self.expectSuccess {
+            alertStore.recordIssued(alert: value.alert, at: startDate, completion: self.expectSuccess {
                 var next = startDate.addingTimeInterval(increment)
                 self.maybeRecordAcknowledge(acknowledged: value.acknowledged, identifier: value.alert.identifier, at: next) {
                     next = next.addingTimeInterval(increment)
@@ -389,7 +389,7 @@ class AlertStoreTests: XCTestCase {
     
     private func maybeRecordAcknowledge(acknowledged: Bool, identifier: Alert.Identifier, at date: Date, _ completion: @escaping () -> Void) {
         if acknowledged {
-            self.alertStore.recordAcknowledgement(of: identifier, at: date, self.expectSuccess(completion))
+            self.alertStore.recordAcknowledgement(of: identifier, at: date, completion: self.expectSuccess(completion))
         } else {
             completion()
         }
@@ -397,7 +397,7 @@ class AlertStoreTests: XCTestCase {
     
     private func maybeRecordRetracted(retracted: Bool, identifier: Alert.Identifier, at date: Date, _ completion: @escaping () -> Void) {
         if retracted {
-            self.alertStore.recordRetraction(of: identifier, at: date, self.expectSuccess(completion))
+            self.alertStore.recordRetraction(of: identifier, at: date, completion: self.expectSuccess(completion))
         } else {
             completion()
         }


### PR DESCRIPTION
Switches to using the AlertStore instead of Notification Center to play back alerts upon startup.

- introduces new query to look for all "unacknowledged" alerts
- makes sure to acknowledge and retract the right "last" alert (before we weren't checking if the last alert of that identifier was already acknowledged or retracted)
- removes code to use Notification Center to play back alerts

Adds unit tests