### PR TITLE
LOOP-1254: Change cancel bolus error content

### DIFF
--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -11,10 +11,13 @@ import LoopKit
 
 /// Class responsible for monitoring "system level" operations and alerting the user to any anomalous situations (e.g. bluetooth off)
 class LoopAlertsManager: NSObject {
+    
+    static let managerIdentifier = "Loop"
+    
     private var bluetoothCentralManager: CBCentralManager!
     private lazy var log = DiagnosticLog(category: String(describing: LoopAlertsManager.self))
     private weak var alertManager: AlertManager?
-    private let bluetoothPoweredOffIdentifier = Alert.Identifier(managerIdentifier: Alert.defaultManagerIdentifier, alertIdentifier: "bluetoothPoweredOff")
+    private let bluetoothPoweredOffIdentifier = Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: "bluetoothPoweredOff")
 
     init(alertManager: AlertManager) {
         super.init()

--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -14,7 +14,7 @@ class LoopAlertsManager: NSObject {
     private var bluetoothCentralManager: CBCentralManager!
     private lazy var log = DiagnosticLog(category: String(describing: LoopAlertsManager.self))
     private weak var alertManager: AlertManager?
-    private let bluetoothPoweredOffIdentifier = Alert.Identifier(managerIdentifier: "Loop", alertIdentifier: "bluetoothPoweredOff")
+    private let bluetoothPoweredOffIdentifier = Alert.Identifier(managerIdentifier: Alert.defaultManagerIdentifier, alertIdentifier: "bluetoothPoweredOff")
 
     init(alertManager: AlertManager) {
         super.init()

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1050,9 +1050,7 @@ final class StatusTableViewController: ChartsTableViewController {
     private func presentErrorCancelingBolus(_ error: (Error)) {
         self.log.error("Error Canceling Bolus: %@", error.localizedDescription)
         let title = NSLocalizedString("Error Canceling Bolus", comment: "The alert title for an error while canceling a bolus")
-        let body = NSLocalizedString("""
-                                    The app was unable to stop the bolus in progress. Move your iPhone closer to the pump and try again. Confirm total insulin delivered in your insulin delivery history and monitor your glucose closely.
-                                    """, comment: "The alert body for an error while canceling a bolus")
+        let body = NSLocalizedString("The app was unable to stop the bolus in progress. Move your iPhone closer to the pump and try again. Confirm total insulin delivered in your insulin delivery history and monitor your glucose closely.", comment: "The alert body for an error while canceling a bolus")
         let action = UIAlertAction(
             title: NSLocalizedString("com.loudnate.LoopKit.errorAlertActionTitle", value: "OK", comment: "The title of the action used to dismiss an error alert"), style: .default)
         let alert = UIAlertController(title: title, message: body, preferredStyle: .alert)

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1028,7 +1028,7 @@ final class StatusTableViewController: ChartsTableViewController {
                                 // show user confirmation and actual delivery amount?
                                 break
                             case .failure(let error):
-                                self.log.error("Error Canceling Bolus: %@", error.localizedDescription)
+                                self.presentErrorCancelingBolus(error)
                                 if case .inProgress(let dose) = self.bolusState {
                                     self.updateHUDandStatusRows(statusRowMode: .bolusing(dose: dose), newSize: nil, animated: true)
                                 } else {
@@ -1045,6 +1045,19 @@ final class StatusTableViewController: ChartsTableViewController {
         case .hud:
             break
         }
+    }
+
+    private func presentErrorCancelingBolus(_ error: (Error)) {
+        self.log.error("Error Canceling Bolus: %@", error.localizedDescription)
+        let title = NSLocalizedString("Error Canceling Bolus", comment: "The alert title for an error while canceling a bolus")
+        let body = NSLocalizedString("""
+                                    The app was unable to stop the bolus in progress. Move your iPhone closer to the pump and try again. Confirm total insulin delivered in your insulin delivery history and monitor your glucose closely.
+                                    """, comment: "The alert body for an error while canceling a bolus")
+        let action = UIAlertAction(
+            title: NSLocalizedString("com.loudnate.LoopKit.errorAlertActionTitle", value: "OK", comment: "The title of the action used to dismiss an error alert"), style: .default)
+        let alert = UIAlertController(title: title, message: body, preferredStyle: .alert)
+        alert.addAction(action)
+        self.present(alert, animated: true, completion: nil)
     }
 
     // MARK: - Actions

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1028,8 +1028,7 @@ final class StatusTableViewController: ChartsTableViewController {
                                 // show user confirmation and actual delivery amount?
                                 break
                             case .failure(let error):
-                                let alert = UIAlertController(with: error, title: NSLocalizedString("Error Canceling Bolus", comment: "The alert title for an error while canceling a bolus"))
-                                self.present(alert, animated: true, completion: nil)
+                                self.log.error("Error Canceling Bolus: %@", error.localizedDescription)
                                 if case .inProgress(let dose) = self.bolusState {
                                     self.updateHUDandStatusRows(statusRowMode: .bolusing(dose: dose), newSize: nil, animated: true)
                                 } else {


### PR DESCRIPTION
Note: I took the liberty of also changing it to use the new Alert facility...
Note also: I also thought that the responsibility for issuing this [Device] alert really shouldn't belong in `StatusTableViewController`, so I'm moving it into the device manager(s).

See also https://github.com/tidepool-org/LoopKit/pull/117

[LOOP-1254](https://tidepool.atlassian.net/browse/LOOP-1254)