### PR TITLE
Exclude retracted alerts in the Issue Report

### DIFF
--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -181,9 +181,9 @@ extension AlertManager {
 
 // MARK: Alert storage access
 extension AlertManager {
-
-    func getStoredEntries(startDate: Date, completion: @escaping (_ report: String) -> Void) {
-        alertStore.executeQuery(since: startDate, limit: 100) { result in
+    
+    func getStoredEntries(startDate: Date, excludeRetracted: Bool = false, completion: @escaping (_ report: String) -> Void) {
+        alertStore.executeQuery(since: startDate, excludeRetracted: excludeRetracted, limit: 100) { result in
             switch result {
             case .failure(let error):
                 completion("Error: \(error)")

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -218,11 +218,18 @@ extension AlertStore {
     }
     struct SinceDateFilter: QueryFilter {
         let date: Date
-        var predicate: NSPredicate? { NSPredicate(format: "issuedDate >= %@", date as NSDate) }
+        let excludeRetracted: Bool
+        var predicate: NSPredicate? {
+            let datePredicate = NSPredicate(format: "issuedDate >= %@", date as NSDate)
+            return excludeRetracted ?
+                NSCompoundPredicate(andPredicateWithSubpredicates: [datePredicate, NSPredicate(format: "retractedDate == nil")])
+                : datePredicate
+        }
     }
-
-    func executeQuery(since date: Date, limit: Int, completion: @escaping (QueryResult<SinceDateFilter>) -> Void) {
-        executeAlertQuery(from: QueryAnchor(filter: SinceDateFilter(date: date)), limit: limit, completion: completion)
+    
+    func executeQuery(since date: Date, excludeRetracted: Bool = false, limit: Int, completion: @escaping (QueryResult<SinceDateFilter>) -> Void) {
+        executeAlertQuery(from: QueryAnchor(filter: SinceDateFilter(date: date, excludeRetracted: excludeRetracted)),
+                          limit: limit, completion: completion)
     }
 
     func continueQuery<Filter: QueryFilter>(from anchor: QueryAnchor<Filter>, limit: Int, completion: @escaping (QueryResult<Filter>) -> Void) {

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -255,7 +255,7 @@ final class DeviceDataManager {
     func generateDiagnosticReport(_ completion: @escaping (_ report: String) -> Void) {
         self.loopManager.generateDiagnosticReport { (loopReport) in
 
-            self.alertManager.getStoredEntries(startDate: Date() - .hours(48)) { (alertReport) in
+            self.alertManager.getStoredEntries(startDate: Date() - .hours(48), excludeRetracted: true) { (alertReport) in
 
                 self.deviceLog.getLogEntries(startDate: Date() - .hours(48)) { (result) in
                     let deviceLogReport: String

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -372,6 +372,21 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: 1)
     }
     
+    func testQueryExcludeRetracted() {
+        let expect = self.expectation(description: #function)
+        fillWith(startDate: Date.distantPast, data: [
+            (alert1, false, true),
+            (alert2, false, false),
+            (alert1, false, true)
+        ]) {
+            self.alertStore.executeQuery(since: Date.distantPast, excludeRetracted: true, limit: 10, completion: self.expectSuccess { result in
+                self.assertEqual([self.alert2], result.1)
+                expect.fulfill()
+            })
+        }
+        wait(for: [expect], timeout: 1)
+    }
+    
     private func fillWith(startDate: Date, data: [(alert: Alert, acknowledged: Bool, retracted: Bool)], _ completion: @escaping () -> Void) {
         let increment = 1.0
         if let value = data.first {


### PR DESCRIPTION
Dumping the log of alerts into the Issue Report was only done as a way to verify that we are storing them.  The problem is, some alerts are constantly issued and retracted once they are no longer valid (e.g. the Dexcom "signal loss" alert for example), so the Issue Report becomes flooded with retracted (canceled) alerts.  This adds an option to the query to filter out retracted alerts, which Issue Report uses.

(Thanks to Shawn for pointing this out)