### PR TITLE
LOOP-1426: Remove untriggered delayed alerts that have been retracted

### DIFF
--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -290,9 +290,9 @@ public extension Alert {
 
 public extension UNNotificationRequest {
     convenience init(from alert: Alert, timestamp: Date) throws {
-        let uncontent = try alert.getUserNotificationContent(timestamp: timestamp)
+        let content = try alert.getUserNotificationContent(timestamp: timestamp)
         self.init(identifier: alert.identifier.value,
-                  content: uncontent,
+                  content: content,
                   trigger: UNTimeIntervalNotificationTrigger(from: alert.trigger))
     }
 }

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -245,7 +245,10 @@ extension AlertStore {
         let excludingFutureAlerts: Bool
         var predicate: NSPredicate? {
             let datePredicate = NSPredicate(format: "issuedDate >= %@", date as NSDate)
-            // if case .delayed(let interval) = $0.trigger, $0.issuedDate + interval >= date {
+            // This predicate only _includes_ a record if it either has no interval (i.e. is 'immediate')
+            // _or_ it is a 'delayed' (trigger type 1) alert whose time has already come
+            // (that is, issuedDate + triggerInterval < now).  The CAST() directives are necessary to
+            // perform the math inside the predicate.
             let futurePredicate = NSPredicate(format: "triggerInterval == nil OR (triggerType == 1 AND CAST(issuedDate, 'NSNumber') + triggerInterval < CAST(%@, 'NSNumber'))", now as NSDate)
             return excludingFutureAlerts ?
                 NSCompoundPredicate(andPredicateWithSubpredicates: [datePredicate, futurePredicate])

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -259,8 +259,7 @@ extension AlertStore {
             let datePredicate = NSPredicate(format: "issuedDate >= %@", date as NSDate)
             // This predicate only _includes_ a record if it either has no interval (i.e. is 'immediate')
             // _or_ it is a 'delayed' or 'repeating' alert (a non-nil triggerInterval) whose time has already come
-            // (that is, issuedDate + triggerInterval < now).  Note that the CAST() directives are necessary to
-            // perform the math inside the predicate.
+            // (that is, issuedDate + triggerInterval < now).
             let futurePredicate = NSPredicate(format: "triggerInterval == nil OR \(predicateExpressionNotYetExpired)", now as NSDate)
             return excludingFutureAlerts ?
                 NSCompoundPredicate(andPredicateWithSubpredicates: [datePredicate, futurePredicate])

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -82,7 +82,10 @@ public class AlertStore {
                                       completion: ((Result<Void, Error>) -> Void)? = nil) {
         recordUpdateOfLatest(of: identifier,
                              addingPredicate: NSPredicate(format: "acknowledgedDate == nil"),
-                             with: { $0.acknowledgedDate = date; return .save },
+                             with: {
+                                $0.acknowledgedDate = date
+                                return .save
+                             },
                              completion: completion)
     }
     
@@ -241,8 +244,8 @@ extension AlertStore {
     }
     struct SinceDateFilter: QueryFilter {
         let date: Date
-        let now: Date
         let excludingFutureAlerts: Bool
+        let now: Date
         var predicate: NSPredicate? {
             let datePredicate = NSPredicate(format: "issuedDate >= %@", date as NSDate)
             // This predicate only _includes_ a record if it either has no interval (i.e. is 'immediate')
@@ -257,7 +260,7 @@ extension AlertStore {
     }
 
     func executeQuery(since date: Date, excludingFutureAlerts: Bool = true, now: Date = Date(), limit: Int, completion: @escaping (QueryResult<SinceDateFilter>) -> Void) {
-        executeAlertQuery(from: QueryAnchor(filter: SinceDateFilter(date: date, now: now, excludingFutureAlerts: excludingFutureAlerts)), limit: limit, completion: completion)
+        executeAlertQuery(from: QueryAnchor(filter: SinceDateFilter(date: date, excludingFutureAlerts: excludingFutureAlerts, now: now)), limit: limit, completion: completion)
     }
 
     func continueQuery<Filter: QueryFilter>(from anchor: QueryAnchor<Filter>, limit: Int, completion: @escaping (QueryResult<Filter>) -> Void) {


### PR DESCRIPTION
If a delayed alert is issued, but is retracted before it is "triggered" (i.e. before the delay expires), remove it from the database, under the theory that we only should record alerts shown to the user, not ones retracted before they are ever shown.

(Note: I just filed [LOOP-1426](https://tidepool.atlassian.net/browse/LOOP-1426), so we don't yet have consensus on the proper fix for this, nor is it in a sprint.  Nevertheless, I wanted to check the feasibility of the solution, and it was easier than I thought so I thought I'd put up this PR...)

(NOTE: this supercedes https://github.com/tidepool-org/Loop/pull/116 )