### PR TITLE
nate/feature/LOOP-1113/renaming-status-message-hud-view

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -429,8 +429,8 @@
 		B4E96D4F248A6E20002DABAD /* CGMStatusHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E96D4E248A6E20002DABAD /* CGMStatusHUDView.swift */; };
 		B4E96D53248A7386002DABAD /* GlucoseValueHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E96D52248A7386002DABAD /* GlucoseValueHUDView.swift */; };
 		B4E96D55248A7509002DABAD /* GlucoseTrendHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E96D54248A7509002DABAD /* GlucoseTrendHUDView.swift */; };
-		B4E96D57248A7B0F002DABAD /* AlertStatusHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E96D56248A7B0F002DABAD /* AlertStatusHUDView.swift */; };
-		B4E96D59248A7F9A002DABAD /* AlertStatusHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4E96D58248A7F9A002DABAD /* AlertStatusHUDView.xib */; };
+		B4E96D57248A7B0F002DABAD /* StatusMessageHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E96D56248A7B0F002DABAD /* StatusMessageHUDView.swift */; };
+		B4E96D59248A7F9A002DABAD /* StatusMessageHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4E96D58248A7F9A002DABAD /* StatusMessageHUDView.xib */; };
 		B4E96D5B248A8229002DABAD /* StatusBarHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4E96D5A248A8229002DABAD /* StatusBarHUDView.swift */; };
 		B4E96D5D248A82A2002DABAD /* StatusBarHUDView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */; };
 		C10B28461EA9BA5E006EA1FC /* far_future_high_bg_forecast.json in Resources */ = {isa = PBXBuildFile; fileRef = C10B28451EA9BA5E006EA1FC /* far_future_high_bg_forecast.json */; };
@@ -1155,8 +1155,8 @@
 		B4E96D4E248A6E20002DABAD /* CGMStatusHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGMStatusHUDView.swift; sourceTree = "<group>"; };
 		B4E96D52248A7386002DABAD /* GlucoseValueHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseValueHUDView.swift; sourceTree = "<group>"; };
 		B4E96D54248A7509002DABAD /* GlucoseTrendHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseTrendHUDView.swift; sourceTree = "<group>"; };
-		B4E96D56248A7B0F002DABAD /* AlertStatusHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStatusHUDView.swift; sourceTree = "<group>"; };
-		B4E96D58248A7F9A002DABAD /* AlertStatusHUDView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AlertStatusHUDView.xib; sourceTree = "<group>"; };
+		B4E96D56248A7B0F002DABAD /* StatusMessageHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusMessageHUDView.swift; sourceTree = "<group>"; };
+		B4E96D58248A7F9A002DABAD /* StatusMessageHUDView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusMessageHUDView.xib; sourceTree = "<group>"; };
 		B4E96D5A248A8229002DABAD /* StatusBarHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarHUDView.swift; sourceTree = "<group>"; };
 		B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatusBarHUDView.xib; sourceTree = "<group>"; };
 		C10B28451EA9BA5E006EA1FC /* far_future_high_bg_forecast.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = far_future_high_bg_forecast.json; sourceTree = "<group>"; };
@@ -1816,7 +1816,7 @@
 				4F75288E1DFE1DC600C322D6 /* Info.plist */,
 				4F2C15941E09BF3C00E160D4 /* HUDView.xib */,
 				4F2C15961E09E94E00E160D4 /* HUDAssets.xcassets */,
-				B4E96D58248A7F9A002DABAD /* AlertStatusHUDView.xib */,
+				B4E96D58248A7F9A002DABAD /* StatusMessageHUDView.xib */,
 				B4E96D5C248A82A2002DABAD /* StatusBarHUDView.xib */,
 			);
 			path = LoopUI;
@@ -1843,7 +1843,7 @@
 				B4E96D4E248A6E20002DABAD /* CGMStatusHUDView.swift */,
 				B4E96D52248A7386002DABAD /* GlucoseValueHUDView.swift */,
 				B4E96D54248A7509002DABAD /* GlucoseTrendHUDView.swift */,
-				B4E96D56248A7B0F002DABAD /* AlertStatusHUDView.swift */,
+				B4E96D56248A7B0F002DABAD /* StatusMessageHUDView.swift */,
 				B4E96D5A248A8229002DABAD /* StatusBarHUDView.swift */,
 				B48B0BAB24900093009A48DE /* PumpStatusHUDView.swift */,
 			);
@@ -2621,7 +2621,7 @@
 				7D7076451FE06EE0004AC8EA /* InfoPlist.strings in Resources */,
 				4F2C15951E09BF3C00E160D4 /* HUDView.xib in Resources */,
 				B4E96D5D248A82A2002DABAD /* StatusBarHUDView.xib in Resources */,
-				B4E96D59248A7F9A002DABAD /* AlertStatusHUDView.xib in Resources */,
+				B4E96D59248A7F9A002DABAD /* StatusMessageHUDView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3222,7 +3222,7 @@
 				4F75289C1DFE1F6000C322D6 /* GlucoseHUDView.swift in Sources */,
 				B4E96D53248A7386002DABAD /* GlucoseValueHUDView.swift in Sources */,
 				4FB76FB81E8C429D00B39636 /* CGPoint.swift in Sources */,
-				B4E96D57248A7B0F002DABAD /* AlertStatusHUDView.swift in Sources */,
+				B4E96D57248A7B0F002DABAD /* StatusMessageHUDView.swift in Sources */,
 				43FCEEB5221BCA020013DD30 /* COBChart.swift in Sources */,
 				4F75289E1DFE1F6000C322D6 /* LoopCompletionHUDView.swift in Sources */,
 			);

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1265,9 +1265,9 @@ final class StatusTableViewController: ChartsTableViewController {
                     addPumpManagerViewToHUD(view)
                 }
                 pumpManagerHUDProvider.visible = active && onscreen
-                hudView.pumpStatusHUD.dismissAlert()
+                hudView.pumpStatusHUD.dismissMessage()
             } else {
-                hudView.pumpStatusHUD.presentAddPumpAlert()
+                hudView.pumpStatusHUD.presentAddPumpMessage()
             }
         }
     }
@@ -1275,9 +1275,9 @@ final class StatusTableViewController: ChartsTableViewController {
     private func configureCGMManagerHUDViews() {
         if let hudView = hudView {
             if deviceManager.cgmManager != nil {
-                hudView.cgmStatusHUD.dismissAlert()
+                hudView.cgmStatusHUD.dismissMessage()
             } else {
-                hudView.cgmStatusHUD.presentAddCGMAlert()
+                hudView.cgmStatusHUD.presentAddCGMMessage()
             }
         }
     }

--- a/LoopUI/StatusMessageHUDView.xib
+++ b/LoopUI/StatusMessageHUDView.xib
@@ -7,10 +7,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="AlertStatusHUDView" customModule="LoopUI" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="StatusMessageHUDView" customModule="LoopUI" customModuleProvider="target">
             <connections>
-                <outlet property="alertIcon" destination="d0U-8x-dAf" id="7sK-VQ-QAe"/>
-                <outlet property="alertMessageLabel" destination="csC-XY-a5C" id="6kO-Ag-hi9"/>
+                <outlet property="messageIcon" destination="d0U-8x-dAf" id="x6s-5s-Yog"/>
+                <outlet property="messageLabel" destination="csC-XY-a5C" id="n7s-z4-XjB"/>
             </connections>
         </placeholder>
         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" id="vCH-Wo-Q6s">

--- a/LoopUI/Views/CGMStatusHUDView.swift
+++ b/LoopUI/Views/CGMStatusHUDView.swift
@@ -34,7 +34,7 @@ public final class CGMStatusHUDView: DeviceStatusHUDView, NibLoadable {
     
     override func setup() {
         super.setup()
-        alertStatusView.setIconPosition(.right)
+        statusMessageView.setIconPosition(.right)
     }
     
     public override func tintColorDidChange() {
@@ -45,15 +45,15 @@ public final class CGMStatusHUDView: DeviceStatusHUDView, NibLoadable {
     }
     
     public func presentAddCGMAlert() {
-        alertStatusView.alertMessageLabel.text = LocalizedString("Add CGM", comment: "Title text for button to set up a CGM")
-        alertStatusView.alertMessageLabel.tintColor = .label
-        alertStatusView.alertIcon.image = UIImage(systemName: "plus.circle")
-        alertStatusView.alertIcon.tintColor = .systemBlue
+        statusMessageView.messageLabel.text = LocalizedString("Add CGM", comment: "Title text for button to set up a CGM")
+        statusMessageView.messageLabel.tintColor = .label
+        statusMessageView.messageIcon.image = UIImage(systemName: "plus.circle")
+        statusMessageView.messageIcon.tintColor = .systemBlue
         presentAlert()
     }
     
     override public func presentAlert() {
-        guard !statusStackView.arrangedSubviews.contains(alertStatusView) else {
+        guard !statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
         
@@ -67,7 +67,7 @@ public final class CGMStatusHUDView: DeviceStatusHUDView, NibLoadable {
     }
     
     override public func dismissAlert() {
-        guard statusStackView.arrangedSubviews.contains(alertStatusView) else {
+        guard statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
         

--- a/LoopUI/Views/CGMStatusHUDView.swift
+++ b/LoopUI/Views/CGMStatusHUDView.swift
@@ -44,15 +44,15 @@ public final class CGMStatusHUDView: DeviceStatusHUDView, NibLoadable {
         glucoseTrendHUD.tintColor = tintColor
     }
     
-    public func presentAddCGMAlert() {
+    public func presentAddCGMMessage() {
         statusMessageView.messageLabel.text = LocalizedString("Add CGM", comment: "Title text for button to set up a CGM")
         statusMessageView.messageLabel.tintColor = .label
         statusMessageView.messageIcon.image = UIImage(systemName: "plus.circle")
         statusMessageView.messageIcon.tintColor = .systemBlue
-        presentAlert()
+        presentMessage()
     }
     
-    override public func presentAlert() {
+    override public func presentMessage() {
         guard !statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
@@ -63,15 +63,15 @@ public final class CGMStatusHUDView: DeviceStatusHUDView, NibLoadable {
         statusStackView.removeArrangedSubview(glucoseValueHUD)
         statusStackView.removeArrangedSubview(glucoseTrendHUD)
         
-        super.presentAlert()
+        super.presentMessage()
     }
     
-    override public func dismissAlert() {
+    override public func dismissMessage() {
         guard statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
         
-        super.dismissAlert()
+        super.dismissMessage()
         
         statusStackView.addArrangedSubview(glucoseValueHUD)
         statusStackView.addArrangedSubview(glucoseTrendHUD)

--- a/LoopUI/Views/DeviceStatusHUDView.swift
+++ b/LoopUI/Views/DeviceStatusHUDView.swift
@@ -13,9 +13,9 @@ import LoopKitUI
 
 @objc open class DeviceStatusHUDView: BaseHUDView {
     
-    public var alertStatusView: AlertStatusHUDView! {
+    public var statusMessageView: StatusMessageHUDView! {
         didSet {
-            alertStatusView.isHidden = true
+            statusMessageView.isHidden = true
         }
     }
     
@@ -35,19 +35,19 @@ import LoopKitUI
     @IBOutlet public weak var statusStackView: UIStackView!
     
     func setup() {
-        if alertStatusView == nil {
-            alertStatusView = AlertStatusHUDView(frame: self.frame)
+        if statusMessageView == nil {
+            statusMessageView = StatusMessageHUDView(frame: self.frame)
         }
     }
     
     func presentAlert() {
-        statusStackView?.addArrangedSubview(alertStatusView)
-        alertStatusView.isHidden = false
+        statusStackView?.addArrangedSubview(statusMessageView)
+        statusMessageView.isHidden = false
     }
     
     func dismissAlert() {
         // need to also hide this view, since it will be added back to the stack at some point
-        alertStatusView.isHidden = true
-        statusStackView?.removeArrangedSubview(alertStatusView)
+        statusMessageView.isHidden = true
+        statusStackView?.removeArrangedSubview(statusMessageView)
     }
 }

--- a/LoopUI/Views/DeviceStatusHUDView.swift
+++ b/LoopUI/Views/DeviceStatusHUDView.swift
@@ -40,12 +40,12 @@ import LoopKitUI
         }
     }
     
-    func presentAlert() {
+    func presentMessage() {
         statusStackView?.addArrangedSubview(statusMessageView)
         statusMessageView.isHidden = false
     }
     
-    func dismissAlert() {
+    func dismissMessage() {
         // need to also hide this view, since it will be added back to the stack at some point
         statusMessageView.isHidden = true
         statusStackView?.removeArrangedSubview(statusMessageView)

--- a/LoopUI/Views/PumpStatusHUDView.swift
+++ b/LoopUI/Views/PumpStatusHUDView.swift
@@ -33,7 +33,7 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
     
     override func setup() {
         super.setup()
-        alertStatusView.setIconPosition(.left)        
+        statusMessageView.setIconPosition(.left)
     }
     
     public override func tintColorDidChange() {
@@ -44,15 +44,15 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
     }
     
     public func presentAddPumpAlert() {
-        alertStatusView.alertMessageLabel.text = LocalizedString("Add Pump", comment: "Title text for button to set up a pump")
-        alertStatusView.alertMessageLabel.tintColor = .label
-        alertStatusView.alertIcon.image = UIImage(systemName: "plus.circle")
-        alertStatusView.alertIcon.tintColor = .systemBlue
+        statusMessageView.messageLabel.text = LocalizedString("Add Pump", comment: "Title text for button to set up a pump")
+        statusMessageView.messageLabel.tintColor = .label
+        statusMessageView.messageIcon.image = UIImage(systemName: "plus.circle")
+        statusMessageView.messageIcon.tintColor = .systemBlue
         presentAlert()
     }
     
     override public func presentAlert() {
-        guard !statusStackView.arrangedSubviews.contains(alertStatusView) else {
+        guard !statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
         
@@ -69,7 +69,7 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
     }
     
     override public func dismissAlert() {
-        guard statusStackView.arrangedSubviews.contains(alertStatusView) else {
+        guard statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
         

--- a/LoopUI/Views/PumpStatusHUDView.swift
+++ b/LoopUI/Views/PumpStatusHUDView.swift
@@ -43,15 +43,15 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
         pumpManagerProvidedHUD?.tintColor = tintColor
     }
     
-    public func presentAddPumpAlert() {
+    public func presentAddPumpMessage() {
         statusMessageView.messageLabel.text = LocalizedString("Add Pump", comment: "Title text for button to set up a pump")
         statusMessageView.messageLabel.tintColor = .label
         statusMessageView.messageIcon.image = UIImage(systemName: "plus.circle")
         statusMessageView.messageIcon.tintColor = .systemBlue
-        presentAlert()
+        presentMessage()
     }
     
-    override public func presentAlert() {
+    override public func presentMessage() {
         guard !statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
@@ -65,15 +65,15 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
             statusStackView.removeArrangedSubview(pumpManagerProvidedHUD)
         }
 
-        super.presentAlert()
+        super.presentMessage()
     }
     
-    override public func dismissAlert() {
+    override public func dismissMessage() {
         guard statusStackView.arrangedSubviews.contains(statusMessageView) else {
             return
         }
         
-        super.dismissAlert()
+        super.dismissMessage()
         
         statusStackView.addArrangedSubview(basalRateHUD)
         basalRateHUD.isHidden = false

--- a/LoopUI/Views/StatusMessageHUDView.swift
+++ b/LoopUI/Views/StatusMessageHUDView.swift
@@ -1,5 +1,5 @@
 //
-//  AlertStatusHUDView.swift
+//  StatusMessageHUDView.swift
 //  LoopUI
 //
 //  Created by Nathaniel Hamming on 2020-06-05.
@@ -8,15 +8,15 @@
 
 import UIKit
 
-public class AlertStatusHUDView: UIView, NibLoadable {
+public class StatusMessageHUDView: UIView, NibLoadable {
     
     private var stackView: UIStackView!
     
-    @IBOutlet public weak var alertMessageLabel: UILabel!
+    @IBOutlet public weak var messageLabel: UILabel!
     
-    @IBOutlet public weak var alertIcon: UIImageView! {
+    @IBOutlet public weak var messageIcon: UIImageView! {
         didSet {
-            alertIcon.tintColor = tintColor
+            messageIcon.tintColor = tintColor
         }
     }
     
@@ -27,17 +27,17 @@ public class AlertStatusHUDView: UIView, NibLoadable {
     
     private var iconPosition: IconPosition = .right {
         didSet {
-            stackView.removeArrangedSubview(alertMessageLabel)
-            stackView.removeArrangedSubview(alertIcon)
+            stackView.removeArrangedSubview(messageLabel)
+            stackView.removeArrangedSubview(messageIcon)
             switch iconPosition {
             case .left:
-                stackView.addArrangedSubview(alertIcon)
-                stackView.addArrangedSubview(alertMessageLabel)
-                alertMessageLabel.textAlignment = .left
+                stackView.addArrangedSubview(messageIcon)
+                stackView.addArrangedSubview(messageLabel)
+                messageLabel.textAlignment = .left
             case .right:
-                stackView.addArrangedSubview(alertMessageLabel)
-                stackView.addArrangedSubview(alertIcon)
-                alertMessageLabel.textAlignment = .right
+                stackView.addArrangedSubview(messageLabel)
+                stackView.addArrangedSubview(messageIcon)
+                messageLabel.textAlignment = .right
             }
         }
     }
@@ -53,7 +53,7 @@ public class AlertStatusHUDView: UIView, NibLoadable {
     }
     
     func setup() {
-        stackView = (AlertStatusHUDView.nib().instantiate(withOwner: self, options: nil)[0] as! UIStackView)
+        stackView = (StatusMessageHUDView.nib().instantiate(withOwner: self, options: nil)[0] as! UIStackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(stackView)
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1113

Renaming `AlertStatusHUDView` to a more generic `StatusMessageHUDView` since not all status reports will include an alert (e.g., may just be informative like a CGM warm up).
