### PR TITLE
Shorten Alert Permissions button in settings

### DIFF
--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -186,7 +186,7 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                 return switchCell
             case .notifications:
                 let cell = tableView.dequeueReusableCell(withIdentifier: SettingsTableViewCell.className, for: indexPath)
-                cell.textLabel?.text = NSLocalizedString("Notification & Critical Alert Permissions", comment: "Title text for Notification & Critical Alert Permissions button cell")
+                cell.textLabel?.text = NSLocalizedString("Alert Permissions", comment: "Title text for Notification & Critical Alert Permissions button cell")
                 if showNotificationsWarning {
                     cell.detailTextLabel?.text = NSLocalizedString("⚠️", comment: "Warning symbol")
                 }


### PR DESCRIPTION
"Notification & Critical Alert Permissions" does not fit on smaller iPhones, and it doesn't match the screen title.  This changes it to just "Alert Permissions"
