### PR TITLE
Unit tests for checking to make sure we can filter HK data on app source

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -26,7 +26,6 @@
 		1D05219D2469F1F5000EBBDE /* AlertStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05219C2469F1F5000EBBDE /* AlertStore.swift */; };
 		1D080CBD2473214A00356610 /* AlertStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */; };
 		1D2609AD248EEB9900A6F258 /* LoopAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2609AC248EEB9900A6F258 /* LoopAlertsManager.swift */; };
-		1D4990E424A16C04005CC357 /* NotificationsCriticalAlertPermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4990E324A16C04005CC357 /* NotificationsCriticalAlertPermissionsViewModel.swift */; };
 		1D4990E824A25931005CC357 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E267FB2292456700A3F2AF /* FeatureFlags.swift */; };
 		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
 		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
@@ -37,6 +36,10 @@
 		1DA7A84224476EAD008257F0 /* AlertManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84124476EAD008257F0 /* AlertManagerTests.swift */; };
 		1DA7A84424477698008257F0 /* InAppModalAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA7A84324477698008257F0 /* InAppModalAlertPresenterTests.swift */; };
 		1DB1065124467E18005542BD /* AlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1065024467E18005542BD /* AlertManager.swift */; };
+		1DB1CA4524A54F9D00B3B94C /* CarbStoreHKFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1CA4424A54F9D00B3B94C /* CarbStoreHKFilterTests.swift */; };
+		1DB1CA4724A54FE000B3B94C /* DoseStoreHKFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1CA4624A54FE000B3B94C /* DoseStoreHKFilterTests.swift */; };
+		1DB1CA4924A55AF100B3B94C /* GlucoseStoreHKFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1CA4824A55AF100B3B94C /* GlucoseStoreHKFilterTests.swift */; };
+		1DB1CA4B24A55CA800B3B94C /* HKHealthStoreQueryMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1CA4A24A55CA800B3B94C /* HKHealthStoreQueryMock.swift */; };
 		1DFE9E172447B6270082C280 /* UserNotificationAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DFE9E162447B6270082C280 /* UserNotificationAlertPresenterTests.swift */; };
 		43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F526D5E1DF2459000A04910 /* HKUnit.swift */; };
 		4302F4E11D4E9C8900F0FCAF /* TextFieldTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */; };
@@ -653,6 +656,10 @@
 		1DA7A84124476EAD008257F0 /* AlertManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertManagerTests.swift; sourceTree = "<group>"; };
 		1DA7A84324477698008257F0 /* InAppModalAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppModalAlertPresenterTests.swift; sourceTree = "<group>"; };
 		1DB1065024467E18005542BD /* AlertManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertManager.swift; sourceTree = "<group>"; };
+		1DB1CA4424A54F9D00B3B94C /* CarbStoreHKFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbStoreHKFilterTests.swift; sourceTree = "<group>"; };
+		1DB1CA4624A54FE000B3B94C /* DoseStoreHKFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoseStoreHKFilterTests.swift; sourceTree = "<group>"; };
+		1DB1CA4824A55AF100B3B94C /* GlucoseStoreHKFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseStoreHKFilterTests.swift; sourceTree = "<group>"; };
+		1DB1CA4A24A55CA800B3B94C /* HKHealthStoreQueryMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HKHealthStoreQueryMock.swift; sourceTree = "<group>"; };
 		1DFE9E162447B6270082C280 /* UserNotificationAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationAlertPresenterTests.swift; sourceTree = "<group>"; };
 		4302F4E01D4E9C8900F0FCAF /* TextFieldTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewController.swift; sourceTree = "<group>"; };
 		4302F4E21D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsulinDeliveryTableViewController.swift; sourceTree = "<group>"; };
@@ -1778,6 +1785,10 @@
 				A9E6DFED246A0460005B1A1C /* Models */,
 				43E2D90F1D20C581004DA55F /* Info.plist */,
 				7D2366E421250E0A0028B67D /* InfoPlist.strings */,
+				1DB1CA4424A54F9D00B3B94C /* CarbStoreHKFilterTests.swift */,
+				1DB1CA4624A54FE000B3B94C /* DoseStoreHKFilterTests.swift */,
+				1DB1CA4824A55AF100B3B94C /* GlucoseStoreHKFilterTests.swift */,
+				1DB1CA4A24A55CA800B3B94C /* HKHealthStoreQueryMock.swift */,
 				A9DAE7CF2332D77F006AE942 /* LoopTests.swift */,
 				8968B113240C55F10074BB48 /* LoopSettingsTests.swift */,
 			);
@@ -3137,12 +3148,16 @@
 				A9A63F8D246B261100588D5B /* DosingDecisionStoreTests.swift in Sources */,
 				A9E6DFEF246A0474005B1A1C /* LoopErrorTests.swift in Sources */,
 				A9E6DFEA246A0448005B1A1C /* PumpManagerErrorTests.swift in Sources */,
+				1DB1CA4724A54FE000B3B94C /* DoseStoreHKFilterTests.swift in Sources */,
 				1DA7A84424477698008257F0 /* InAppModalAlertPresenterTests.swift in Sources */,
+				1DB1CA4924A55AF100B3B94C /* GlucoseStoreHKFilterTests.swift in Sources */,
 				8968B114240C55F10074BB48 /* LoopSettingsTests.swift in Sources */,
 				1DA7A84224476EAD008257F0 /* AlertManagerTests.swift in Sources */,
 				A9E6DFE6246A042E005B1A1C /* CarbStoreTests.swift in Sources */,
 				A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */,
 				A9E6DFEC246A0453005B1A1C /* SetBolusErrorTests.swift in Sources */,
+				1DB1CA4524A54F9D00B3B94C /* CarbStoreHKFilterTests.swift in Sources */,
+				1DB1CA4B24A55CA800B3B94C /* HKHealthStoreQueryMock.swift in Sources */,
 				1DFE9E172447B6270082C280 /* UserNotificationAlertPresenterTests.swift in Sources */,
 				A9E6DFE8246A043D005B1A1C /* DoseStoreTests.swift in Sources */,
 			);

--- a/LoopTests/CarbStoreHKFilterTests.swift
+++ b/LoopTests/CarbStoreHKFilterTests.swift
@@ -1,0 +1,42 @@
+//
+//  CarbStoreHKFilterTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 6/25/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+import XCTest
+import LoopKit
+
+class CarbStoreHKFilterTests: XCTestCase {
+    let sampleFromCurrentApp: [String : Any] = [ "endDate": Date(), "source": HKSource.default() ]
+    let sampleFromOutsideCurrentApp: [String : Any] = [ "endDate": Date(), "source": "other" ]
+
+    func testEntriesFromAllSources() {
+        let e = expectation(description: "\(#function)")
+        e.expectedFulfillmentCount = 2
+        let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
+        let mockHKStore = HKHealthStoreQueryMock(expectation: e)
+        let carbStore = CarbStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: false, cacheStore: pc)
+        carbStore.getCarbEntries(start: Date.distantPast) { _ in }
+        wait(for: [e], timeout: 1.0)
+        guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate) else { return }
+        XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp))
+        XCTAssertTrue(predicate.evaluate(with: sampleFromOutsideCurrentApp))
+    }
+    
+    func testEntriesFromCurrentAppOnly() {
+        let e = expectation(description: "\(#function)")
+        e.expectedFulfillmentCount = 2
+        let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
+        let mockHKStore = HKHealthStoreQueryMock(expectation: e)
+        let carbStore = CarbStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: true, cacheStore: pc)
+        carbStore.getCarbEntries(start: Date.distantPast) { _ in }
+        wait(for: [e], timeout: 1.0)
+        guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate) else { return }
+        XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp))
+        XCTAssertFalse(predicate.evaluate(with: sampleFromOutsideCurrentApp))
+    }
+}

--- a/LoopTests/DoseStoreHKFilterTests.swift
+++ b/LoopTests/DoseStoreHKFilterTests.swift
@@ -1,0 +1,42 @@
+//
+//  DoseStoreHKFilterTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 6/25/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+import XCTest
+import LoopKit
+
+class DoseStoreHKFilterTests: XCTestCase {
+    let sampleFromCurrentApp: [String : Any] = [ "endDate": Date(), "source": HKSource.default() ]
+    let sampleFromOutsideCurrentApp: [String : Any] = [ "endDate": Date(), "source": "other" ]
+
+    func testEntriesFromAllSources() {
+        let e = expectation(description: "\(#function)")
+        e.expectedFulfillmentCount = 2
+        let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
+        let mockHKStore = HKHealthStoreQueryMock(expectation: e)
+        let doseStore = DoseStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: false, cacheStore: pc, insulinModel: nil, basalProfile: nil, insulinSensitivitySchedule: nil)
+        doseStore.getNormalizedDoseEntries(start: Date.distantPast.addingTimeInterval(1.0)) { _ in }
+        wait(for: [e], timeout: 1.0)
+        guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate) else { return }
+        XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp))
+        XCTAssertTrue(predicate.evaluate(with: sampleFromOutsideCurrentApp))
+    }
+    
+    func testEntriesFromCurrentAppOnly() {
+        let e = expectation(description: "\(#function)")
+        e.expectedFulfillmentCount = 2
+        let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
+        let mockHKStore = HKHealthStoreQueryMock(expectation: e)
+        let doseStore = DoseStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: true, cacheStore: pc, insulinModel: nil, basalProfile: nil, insulinSensitivitySchedule: nil)
+        doseStore.getNormalizedDoseEntries(start: Date.distantPast.addingTimeInterval(1.0)) { _ in }
+        wait(for: [e], timeout: 1.0)
+        guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate) else { return }
+        XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp))
+        XCTAssertFalse(predicate.evaluate(with: sampleFromOutsideCurrentApp))
+    }
+}

--- a/LoopTests/GlucoseStoreHKFilterTests.swift
+++ b/LoopTests/GlucoseStoreHKFilterTests.swift
@@ -1,0 +1,42 @@
+//
+//  GlucoseStoreHKFilterTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 6/25/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+import XCTest
+import LoopKit
+
+class GlucoseStoreHKFilterTests: XCTestCase {
+    let sampleFromCurrentApp: [String : Any] = [ "endDate": Date(), "source": HKSource.default() ]
+    let sampleFromOutsideCurrentApp: [String : Any] = [ "endDate": Date(), "source": "other" ]
+
+    func testEntriesFromAllSources() {
+        let e = expectation(description: "\(#function)")
+        e.expectedFulfillmentCount = 2
+        let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
+        let mockHKStore = HKHealthStoreQueryMock(expectation: e)
+        let glucoseStore = GlucoseStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: false, cacheStore: pc)
+        glucoseStore.getGlucoseSamples(start: Date.distantPast) { _ in }
+        wait(for: [e], timeout: 1.0)
+        guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate) else { return }
+        XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp))
+        XCTAssertTrue(predicate.evaluate(with: sampleFromOutsideCurrentApp))
+    }
+    
+    func testEntriesFromCurrentAppOnly() {
+        let e = expectation(description: "\(#function)")
+        e.expectedFulfillmentCount = 2
+        let pc = PersistenceController(directoryURL: URL.init(fileURLWithPath: ""))
+        let mockHKStore = HKHealthStoreQueryMock(expectation: e)
+        let glucoseStore = GlucoseStore(healthStore: mockHKStore, observeHealthKitForCurrentAppOnly: true, cacheStore: pc)
+        glucoseStore.getGlucoseSamples(start: Date.distantPast) { _ in }
+        wait(for: [e], timeout: 1.0)
+        guard let predicate = try? XCTUnwrap(mockHKStore.lastQuery?.predicate) else { return }
+        XCTAssertTrue(predicate.evaluate(with: sampleFromCurrentApp))
+        XCTAssertFalse(predicate.evaluate(with: sampleFromOutsideCurrentApp))
+    }
+}

--- a/LoopTests/HKHealthStoreQueryMock.swift
+++ b/LoopTests/HKHealthStoreQueryMock.swift
@@ -1,0 +1,24 @@
+//
+//  HKHealthStoreQueryMock.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 6/25/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import HealthKit
+import XCTest
+
+class HKHealthStoreQueryMock: HKHealthStore {
+    var lastQuery: HKQuery?
+    let expectation: XCTestExpectation
+    init(expectation: XCTestExpectation) {
+        self.expectation = expectation
+        super.init()
+    }
+    override func execute(_ query: HKQuery) {
+        lastQuery = query
+        expectation.fulfill()
+    }
+}
+


### PR DESCRIPTION
Normally, such tests would be closer to where the code that implements the filter would be (in this case, LoopKit).  However, due to the fact that LoopKit doesn't have the HealthKit entitlement, but Loop does, I put the tests here.
(Thanks to Darin for pointing this out)