### PR TITLE
LOOP-1380: Text Changes, plus appName environment

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
 		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
 		1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D80313C24746274002810DF /* AlertStoreTests.swift */; };
+		1D872C9524AD176E006317D4 /* Environment+AppName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D872C9424AD176E006317D4 /* Environment+AppName.swift */; };
 		1DA46B602492E2E300D71A63 /* NotificationsCriticalAlertPermissionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA46B5F2492E2E300D71A63 /* NotificationsCriticalAlertPermissionsView.swift */; };
 		1DA649A7244126CD00F61E75 /* UserNotificationAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A6244126CD00F61E75 /* UserNotificationAlertPresenter.swift */; };
 		1DA649A9244126DA00F61E75 /* InAppModalAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA649A8244126DA00F61E75 /* InAppModalAlertPresenter.swift */; };
@@ -647,6 +648,7 @@
 		1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataClass.swift"; sourceTree = "<group>"; };
 		1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		1D80313C24746274002810DF /* AlertStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStoreTests.swift; sourceTree = "<group>"; };
+		1D872C9424AD176E006317D4 /* Environment+AppName.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Environment+AppName.swift"; sourceTree = "<group>"; };
 		1DA46B5F2492E2E300D71A63 /* NotificationsCriticalAlertPermissionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsCriticalAlertPermissionsView.swift; sourceTree = "<group>"; };
 		1DA649A6244126CD00F61E75 /* UserNotificationAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserNotificationAlertPresenter.swift; sourceTree = "<group>"; };
 		1DA649A8244126DA00F61E75 /* InAppModalAlertPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InAppModalAlertPresenter.swift; sourceTree = "<group>"; };
@@ -1890,6 +1892,7 @@
 				438991661E91B563000EEF90 /* ChartPoint.swift */,
 				43649A621C7A347F00523D7F /* CollectionType.swift */,
 				43FCEEAC221A66780013DD30 /* DateFormatter.swift */,
+				1D872C9424AD176E006317D4 /* Environment+AppName.swift */,
 				434F54561D287FDB002A9274 /* NibLoadable.swift */,
 				43FCEEAE221A67A70013DD30 /* NumberFormatter+Charts.swift */,
 			);
@@ -3199,6 +3202,7 @@
 				43FCEEB3221BC3B60013DD30 /* DoseChart.swift in Sources */,
 				4F7528AA1DFE215100C322D6 /* HKUnit.swift in Sources */,
 				1DA46B602492E2E300D71A63 /* NotificationsCriticalAlertPermissionsView.swift in Sources */,
+				1D872C9524AD176E006317D4 /* Environment+AppName.swift in Sources */,
 				4FB76FB61E8C426900B39636 /* ChartPointsTouchHighlightLayerViewCache.swift in Sources */,
 				4F2C15931E09BF2C00E160D4 /* HUDView.swift in Sources */,
 				43BFF0B71E45C20C00FF19A9 /* NumberFormatter.swift in Sources */,

--- a/LoopUI/Extensions/Environment+AppName.swift
+++ b/LoopUI/Extensions/Environment+AppName.swift
@@ -1,0 +1,20 @@
+//
+//  Environment+AppName.swift
+//  LoopUI
+//
+//  Created by Rick Pasetto on 7/1/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+private struct AppNameKey: EnvironmentKey {
+    static let defaultValue = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+}
+
+public extension EnvironmentValues {
+    var appName: String {
+        get { self[AppNameKey.self] }
+        set { self[AppNameKey.self] = newValue }
+    }
+}

--- a/LoopUI/Views/NotificationsCriticalAlertPermissionsView.swift
+++ b/LoopUI/Views/NotificationsCriticalAlertPermissionsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 public struct NotificationsCriticalAlertPermissionsView: View, HorizontalSizeClassOverride {
     @Environment(\.dismiss) var dismiss
+    @Environment(\.appName) var appName
 
     private let backButtonText: String
     @ObservedObject private var viewModel: NotificationsCriticalAlertPermissionsViewModel
@@ -58,10 +59,9 @@ extension NotificationsCriticalAlertPermissionsView {
                 }
             }
             DescriptiveText(label: LocalizedString("""
-                Notifications can appear while you are using another app on your iPhone, or while your iPhone is locked.
-
-                Notifications let you know about issues Tidepool Loop has without needing to open the app.
-                You can customize when you want to recieve notificiations, and how they should be delivered inside Tidepool Loop.
+                Notifications appear on your Lock screen or pop up while you’re using other apps.
+                
+                Notifications give you important \(appName) app information without requiring you to open the app.  You can customize when and how you want to receive these notifications.
                 """, comment: "Manage Notifications in Settings descriptive text"))
         }
     }
@@ -78,7 +78,7 @@ extension NotificationsCriticalAlertPermissionsView {
                 }
             }
             DescriptiveText(label: LocalizedString("""
-                Critical Alerts will always play a sound and appear on the Lock screen even if your iPhone is muted or Do Not Disturb is on.
+                Critical Alerts are a type of notification that will always play a sound and appear on your Lock screen, even if your iPhone is muted or if Do Not Disturb is on.
                 """, comment: "Manage Notifications in Settings descriptive text"))
         }
     }
@@ -88,7 +88,6 @@ extension NotificationsCriticalAlertPermissionsView {
             NavigationLink(destination: Text("Get help with Notification & Critical Alert Permissions screen")) {
                 Text(LocalizedString("Get help with Notification & Critical Alert Permissions", comment: "Get help with Notification & Critical Alert Permissions support button text"))
             }
-            DescriptiveText(label: LocalizedString("Text description here.", comment: ""))
         }
     }
 


### PR DESCRIPTION
I decided to get a head start on [LOOP-1422](https://tidepool.atlassian.net/browse/LOOP-1422) by just adding an `appName` `@Environment` for easy use in `LoopUI`.

[LOOP-1380](https://tidepool.atlassian.net/browse/LOOP-1380)