### PR TITLE
Prevent suspend threshold from being raised above temp correction range bounds

### DIFF
--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -484,10 +484,20 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                 present(hostingController, animated: true)
             case .suspendThreshold:
                 func presentSuspendThresholdEditor(initialValue: HKQuantity?, unit: HKUnit) {
+                    let settings = dataManager.loopManager.settings
+                    let maxAllowableSuspendThreshold = [
+                        settings.glucoseTargetRangeSchedule?.minLowerBound().doubleValue(for: unit),
+                        settings.preMealTargetRange?.minValue,
+                        settings.legacyWorkoutTargetRange?.minValue
+                    ]
+                    .compactMap { $0 }
+                    .min()
+                    .map { HKQuantity(unit: unit, doubleValue: $0) }
+
                     let editor = SuspendThresholdEditor(
                         value: initialValue,
                         unit: unit,
-                        maxValue: dataManager.loopManager.settings.glucoseTargetRangeSchedule?.minLowerBound(),
+                        maxValue: maxAllowableSuspendThreshold,
                         onSave: { [dataManager, tableView] newValue in
                             dataManager!.loopManager.settings.suspendThreshold = GlucoseThreshold(unit: unit, value: newValue.doubleValue(for: unit))
 


### PR DESCRIPTION
Prevents a crasher resulting from suspend threshold being raised above the upper bound of a temp correction range.