### PR TITLE
LOOP-1492: therapy settings navigation

### DIFF
--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -745,7 +745,11 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
         let cgmViewModel = DeviceViewModel(deviceManagerUI: dataManager.cgmManager as? DeviceManagerUI, isSetUp: dataManager.cgmManager != nil) { [weak self] in
             self?.didSelectCGM()
         }
-        let pumpSupportedIncrements = dataManager.pumpManager.map { PumpSupportedIncrements(basalRates: $0.supportedBasalRates, bolusVolumes: $0.supportedBolusVolumes) }
+        let pumpSupportedIncrements = dataManager.pumpManager.map {
+            PumpSupportedIncrements(basalRates: $0.supportedBasalRates,
+                                    bolusVolumes: $0.supportedBolusVolumes,
+                                    maximumBasalScheduleEntryCount: $0.maximumBasalScheduleEntryCount)
+        }
         let viewModel = SettingsViewModel(appNameAndVersion: Bundle.main.localizedNameAndVersion,
                                           notificationsCriticalAlertPermissionsViewModel: notificationsCriticalAlertPermissionsViewModel,
                                           pumpManagerSettingsViewModel: pumpViewModel,
@@ -753,6 +757,7 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                                           therapySettings: dataManager.loopManager.therapySettings,
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
+                                          pumpSyncSchedule: dataManager.pumpManager?.syncBasalRateSchedule,
                                           initialDosingEnabled: dataManager.loopManager.settings.dosingEnabled,
                                           setDosingEnabled: { [weak self] in
                                             self?.setDosingEnabled($0)

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -761,6 +761,9 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                                           initialDosingEnabled: dataManager.loopManager.settings.dosingEnabled,
                                           setDosingEnabled: { [weak self] in
                                             self?.setDosingEnabled($0)
+                                          },
+                                          didSave: { [weak self] in
+                                            self?.saveTherapySetting($0, $1)
         })
         let hostingController = DismissibleHostingController(
             rootView: SettingsView(viewModel: viewModel),
@@ -778,6 +781,35 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
     private func setDosingEnabled(_ value: Bool) {
         DispatchQueue.main.async {
             self.dataManager.loopManager.settings.dosingEnabled = value
+        }
+    }
+    
+    private func saveTherapySetting(_ therapySetting: TherapySetting, _ therapySettings: TherapySettings) {
+        switch therapySetting {
+        case .glucoseTargetRange:
+            dataManager?.loopManager.settings.glucoseTargetRangeSchedule = therapySettings.glucoseTargetRangeSchedule
+        case .correctionRangeOverrides:
+            dataManager?.loopManager.settings.preMealTargetRange = therapySettings.preMealTargetRange
+            dataManager?.loopManager.settings.legacyWorkoutTargetRange = therapySettings.workoutTargetRange
+        case .suspendThreshold:
+            dataManager?.loopManager.settings.suspendThreshold = therapySettings.suspendThreshold
+        case .basalRate:
+            dataManager?.loopManager.basalRateSchedule = therapySettings.basalRateSchedule
+        case .deliveryLimits:
+            dataManager?.loopManager.settings.maximumBasalRatePerHour = therapySettings.maximumBasalRatePerHour
+            dataManager?.loopManager.settings.maximumBolus = therapySettings.maximumBolus
+        case .insulinModel:
+            if let insulinModel = therapySettings.insulinModel {
+                dataManager?.loopManager.insulinModelSettings = InsulinModelSettings(model: insulinModel as! InsulinModel)
+            }
+        case .carbRatio:
+            dataManager?.loopManager.carbRatioSchedule = therapySettings.carbRatioSchedule
+            dataManager?.analyticsServicesManager.didChangeCarbRatioSchedule()
+        case .insulinSensitivity:
+            dataManager?.loopManager.insulinSensitivitySchedule = therapySettings.insulinSensitivitySchedule
+            dataManager?.analyticsServicesManager.didChangeInsulinSensitivitySchedule()
+        case .none:
+            break // NO-OP
         }
     }
 }

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -757,7 +757,8 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                                           therapySettings: dataManager.loopManager.therapySettings,
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
-                                          pumpSyncSchedule: dataManager.pumpManager?.syncBasalRateSchedule,
+                                          syncPumpSchedule: dataManager.pumpManager?.syncBasalRateSchedule,
+                                          sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: dataManager.loopManager.settings.dosingEnabled,
                                           setDosingEnabled: { [weak self] in
                                             self?.setDosingEnabled($0)

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -801,7 +801,8 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
             dataManager?.loopManager.settings.maximumBolus = therapySettings.maximumBolus
         case .insulinModel:
             if let insulinModel = therapySettings.insulinModel {
-                dataManager?.loopManager.insulinModelSettings = InsulinModelSettings(model: insulinModel as! InsulinModel)
+                // TODO: Unify InsulinModelSettings and SettingsStore.InsulinModel
+                dataManager?.loopManager.insulinModelSettings = InsulinModelSettings(from: insulinModel)
             }
         case .carbRatio:
             dataManager?.loopManager.carbRatioSchedule = therapySettings.carbRatioSchedule

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -76,7 +76,8 @@ extension SettingsView {
         Section(header: SectionHeader(label: NSLocalizedString("Configuration", comment: "The title of the Configuration section in settings"))) {
             return NavigationLink(destination: TherapySettingsView(viewModel: TherapySettingsViewModel(therapySettings: viewModel.therapySettings,
                                                                                                        supportedInsulinModelSettings: viewModel.supportedInsulinModelSettings,
-                                                                                                       pumpSupportedIncrements: viewModel.pumpSupportedIncrements))) {
+                                                                                                       pumpSupportedIncrements: viewModel.pumpSupportedIncrements,
+                                                                                                       pumpSyncSchedule: viewModel.pumpSyncSchedule))) {
                 LargeButton(action: { },
                             includeArrow: false,
                             imageView: AnyView(Image("Therapy Icon")),
@@ -197,6 +198,7 @@ public struct SettingsView_Previews: PreviewProvider {
                                           therapySettings: TherapySettings(),
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,
+                                          pumpSyncSchedule: nil,
                                           initialDosingEnabled: true)
         return Group {
             SettingsView(viewModel: viewModel)

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -77,7 +77,8 @@ extension SettingsView {
             return NavigationLink(destination: TherapySettingsView(viewModel: TherapySettingsViewModel(therapySettings: viewModel.therapySettings,
                                                                                                        supportedInsulinModelSettings: viewModel.supportedInsulinModelSettings,
                                                                                                        pumpSupportedIncrements: viewModel.pumpSupportedIncrements,
-                                                                                                       pumpSyncSchedule: viewModel.pumpSyncSchedule))) {
+                                                                                                       pumpSyncSchedule: viewModel.pumpSyncSchedule,
+                                                                                                       didSave: viewModel.didSave))) {
                 LargeButton(action: { },
                             includeArrow: false,
                             imageView: AnyView(Image("Therapy Icon")),

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -77,7 +77,7 @@ extension SettingsView {
             return NavigationLink(destination: TherapySettingsView(viewModel: TherapySettingsViewModel(therapySettings: viewModel.therapySettings,
                                                                                                        supportedInsulinModelSettings: viewModel.supportedInsulinModelSettings,
                                                                                                        pumpSupportedIncrements: viewModel.pumpSupportedIncrements,
-                                                                                                       pumpSyncSchedule: viewModel.pumpSyncSchedule,
+                                                                                                       syncPumpSchedule: viewModel.syncPumpSchedule,
                                                                                                        didSave: viewModel.didSave))) {
                 LargeButton(action: { },
                             includeArrow: false,
@@ -199,7 +199,8 @@ public struct SettingsView_Previews: PreviewProvider {
                                           therapySettings: TherapySettings(),
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,
-                                          pumpSyncSchedule: nil,
+                                          syncPumpSchedule: nil,
+                                          sensitivityOverridesEnabled: false,
                                           initialDosingEnabled: true)
         return Group {
             SettingsView(viewModel: viewModel)

--- a/Loop/Views/SettingsViewModel.swift
+++ b/Loop/Views/SettingsViewModel.swift
@@ -53,6 +53,7 @@ public class SettingsViewModel: ObservableObject {
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
     let pumpSyncSchedule: PumpManager.SyncSchedule?
+    let didSave: TherapySettingsViewModel.SaveCompletion?
 
     lazy private var cancellables = Set<AnyCancellable>()
 
@@ -66,7 +67,8 @@ public class SettingsViewModel: ObservableObject {
                 pumpSyncSchedule: PumpManager.SyncSchedule?,
                 // TODO: This is temporary until I can figure out something cleaner
                 initialDosingEnabled: Bool,
-                setDosingEnabled: ((Bool) -> Void)? = nil
+                setDosingEnabled: ((Bool) -> Void)? = nil,
+                didSave: TherapySettingsViewModel.SaveCompletion? = nil
                 ) {
         self.notificationsCriticalAlertPermissionsViewModel = notificationsCriticalAlertPermissionsViewModel
         self.appNameAndVersion = appNameAndVersion
@@ -78,6 +80,7 @@ public class SettingsViewModel: ObservableObject {
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
         self.pumpSyncSchedule = pumpSyncSchedule
+        self.didSave = didSave
 
         // This strangeness ensures the composed ViewModels' (ObservableObjects') changes get reported to this ViewModel (ObservableObject)
         notificationsCriticalAlertPermissionsViewModel.objectWillChange.sink { [weak self] in

--- a/Loop/Views/SettingsViewModel.swift
+++ b/Loop/Views/SettingsViewModel.swift
@@ -52,6 +52,7 @@ public class SettingsViewModel: ObservableObject {
     var therapySettings: TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
+    let pumpSyncSchedule: PumpManager.SyncSchedule?
 
     lazy private var cancellables = Set<AnyCancellable>()
 
@@ -62,6 +63,7 @@ public class SettingsViewModel: ObservableObject {
                 therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: PumpSupportedIncrements?,
+                pumpSyncSchedule: PumpManager.SyncSchedule?,
                 // TODO: This is temporary until I can figure out something cleaner
                 initialDosingEnabled: Bool,
                 setDosingEnabled: ((Bool) -> Void)? = nil
@@ -75,6 +77,7 @@ public class SettingsViewModel: ObservableObject {
         self.therapySettings = therapySettings
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
+        self.pumpSyncSchedule = pumpSyncSchedule
 
         // This strangeness ensures the composed ViewModels' (ObservableObjects') changes get reported to this ViewModel (ObservableObject)
         notificationsCriticalAlertPermissionsViewModel.objectWillChange.sink { [weak self] in

--- a/Loop/Views/SettingsViewModel.swift
+++ b/Loop/Views/SettingsViewModel.swift
@@ -52,7 +52,8 @@ public class SettingsViewModel: ObservableObject {
     var therapySettings: TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
-    let pumpSyncSchedule: PumpManager.SyncSchedule?
+    let syncPumpSchedule: PumpManager.SyncSchedule?
+    let sensitivityOverridesEnabled: Bool
     let didSave: TherapySettingsViewModel.SaveCompletion?
 
     lazy private var cancellables = Set<AnyCancellable>()
@@ -64,7 +65,8 @@ public class SettingsViewModel: ObservableObject {
                 therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: PumpSupportedIncrements?,
-                pumpSyncSchedule: PumpManager.SyncSchedule?,
+                syncPumpSchedule: PumpManager.SyncSchedule?,
+                sensitivityOverridesEnabled: Bool,
                 // TODO: This is temporary until I can figure out something cleaner
                 initialDosingEnabled: Bool,
                 setDosingEnabled: ((Bool) -> Void)? = nil,
@@ -79,7 +81,8 @@ public class SettingsViewModel: ObservableObject {
         self.therapySettings = therapySettings
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
-        self.pumpSyncSchedule = pumpSyncSchedule
+        self.syncPumpSchedule = syncPumpSchedule
+        self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.didSave = didSave
 
         // This strangeness ensures the composed ViewModels' (ObservableObjects') changes get reported to this ViewModel (ObservableObject)


### PR DESCRIPTION
Wires up navigation through the Therapy Settings editors, connects "saving" (temporarily, until SettingsTableViewController goes away)

See also https://github.com/tidepool-org/LoopKit/pull/158

[LOOP-1492](https://tidepool.atlassian.net/browse/LOOP-1492)