### PR TITLE
Rename HealthKit observation related FeatureFlag

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -19,7 +19,7 @@ struct FeatureFlagConfiguration: Decodable {
     let simulatedCoreDataEnabled: Bool
     let walshInsulinModelEnabled: Bool
     let fiaspInsulinModelEnabled: Bool
-    let observeHealthKitForCurrentAppOnly: Bool
+    let observeHealthKitSamplesFromOtherApps: Bool
 
     fileprivate init() {
         // Swift compiler config is inverse, since the default state is enabled.
@@ -75,10 +75,11 @@ struct FeatureFlagConfiguration: Decodable {
         self.fiaspInsulinModelEnabled = true
         #endif
         
-        #if OBSERVE_HEALTHKIT_FOR_CURRENT_APP_ONLY
-        self.observeHealthKitForCurrentAppOnly = true
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if OBSERVE_HEALTH_KIT_SAMPLES_FROM_OTHER_APPS_DISABLED
+        self.observeHealthKitSamplesFromOtherApps = false
         #else
-        self.observeHealthKitForCurrentAppOnly = false
+        self.observeHealthKitSamplesFromOtherApps = true
         #endif
     }
 }
@@ -95,6 +96,7 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* simulatedCoreDataEnabled: \(simulatedCoreDataEnabled)",
             "* walshInsulinModelEnabled: \(walshInsulinModelEnabled)",
             "* fiaspInsulinModelEnabled: \(fiaspInsulinModelEnabled)",
+            "* observeHealthKitSamplesFromOtherApps: \(observeHealthKitSamplesFromOtherApps)",
         ].joined(separator: "\n")
     }
 }

--- a/Learn/Managers/DataManager.swift
+++ b/Learn/Managers/DataManager.swift
@@ -34,7 +34,6 @@ final class DataManager {
 
         carbStore = CarbStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             cacheLength: .hours(24),
             defaultAbsorptionTimes: (fast: .minutes(30), medium: .hours(3), slow: .hours(5)),
@@ -45,7 +44,6 @@ final class DataManager {
 
         doseStore = DoseStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             observationEnabled: false,
             insulinModel: insulinModelSettings?.model,
@@ -55,7 +53,6 @@ final class DataManager {
 
         glucoseStore = GlucoseStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: false,
             cacheStore: cacheStore,
             observationEnabled: false
         )

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -75,14 +75,14 @@ class StatusViewController: UIViewController, NCWidgetProviding {
 
     lazy var glucoseStore = GlucoseStore(
         healthStore: healthStore,
-        observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+        observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
         cacheStore: cacheStore,
         observationEnabled: false
     )
 
     lazy var doseStore = DoseStore(
         healthStore: healthStore,
-        observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+        observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
         cacheStore: cacheStore,
         observationEnabled: false,
         insulinModel: defaults?.insulinModelSettings?.model,
@@ -92,7 +92,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
     
     let absorptionTimes = LoopSettings.defaultCarbAbsorptionTimes
     lazy var carbStore = CarbStore(healthStore: healthStore,
-                                   observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+                                   observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
                                    cacheStore: cacheStore,
                                    cacheLength: TimeInterval(days: 1),
                                    defaultAbsorptionTimes: absorptionTimes,

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -80,7 +80,7 @@ final class LoopDataManager {
 
         carbStore = CarbStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
             defaultAbsorptionTimes: absorptionTimes,
@@ -93,7 +93,7 @@ final class LoopDataManager {
 
         doseStore = DoseStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
             insulinModel: insulinModelSettings?.model,
@@ -107,7 +107,7 @@ final class LoopDataManager {
 
         glucoseStore = GlucoseStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: localCacheDuration,
             observationInterval: .hours(24)

--- a/WatchApp Extension/Managers/LoopDataManager.swift
+++ b/WatchApp Extension/Managers/LoopDataManager.swift
@@ -68,7 +68,7 @@ class LoopDataManager {
 
         carbStore = CarbStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: cacheDuration,
             defaultAbsorptionTimes: absorptionTimes,
@@ -77,7 +77,7 @@ class LoopDataManager {
         )
         glucoseStore = GlucoseStore(
             healthStore: healthStore,
-            observeHealthKitForCurrentAppOnly: FeatureFlags.observeHealthKitForCurrentAppOnly,
+            observeHealthKitSamplesFromOtherApps: FeatureFlags.observeHealthKitSamplesFromOtherApps,
             cacheStore: cacheStore,
             cacheLength: .hours(4)
         )


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1417
- Rename FeatureFlags.observeHealthKitForCurrentAppOnly to observeHealthKitSamplesFromOtherApps
- Rename OBSERVE_HEALTHKIT_FOR_CURRENT_APP_ONLY to OBSERVE_HEALTH_KIT_SAMPLES_FROM_OTHER_APPS_DISABLED
- Preparation for CarbStore using Core Data as "source of truth"
- Set default observeHealthKitSamplesFromOtherApps for various stores

Note: The primary reason for this change is future work for LOOP-1417 where the "source of truth" for Carb data will be in Core Data and not HealthKit. At this point, Loop-sourced data will no longer be read from HealthKit. This yields 4 states for reading data from HealthKit in HealthKitSampleStore and thus the need for two booleans:

1. read Loop data, read non-Loop data - DIY insulin, glucose
2. read Loop data, don't read non-Loop data - Tidepool insulin, glucose
3. don't read Loop data, read non-Loop data - DIY carbs
4. don't read Loop data, don't read non-Loop data - Tidepool carbs

Note: I'm breaking up LOOP-1417 into multiple smaller PRs (though the last one is still quite large).