### PR TITLE
LOOP-1160: "scroll" to Bolus Entry when Enter Bolus is tapped

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -36,6 +36,7 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
             }
             // As of iOS 13, we can't programmatically scroll to the Bolus entry text field.  This ugly hack scoots the
             // list up instead, so the summarySection is visible and the keyboard shows when you tap "Enter Bolus".
+            // Unfortunately, after entry, the field scoots back down and remains hidden.  So this is not a great solution.
             // TODO: Fix this in Xcode 12 when we're building for iOS 14.
             .padding(.top, shouldBolusEntryBecomeFirstResponder ? -200 : -28)
             .listStyle(GroupedListStyle())

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -34,7 +34,10 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                 historySection
                 summarySection
             }
-            .padding(.top, -28) // Bring the top card up closer to the navigation bar
+            // As of iOS 13, we can't programmatically scroll to the Bolus entry text field.  This ugly hack scoots the
+            // list up instead, so the summarySection is visible and the keyboard shows when you tap "Enter Bolus".
+            // TODO: Fix this in Xcode 12 when we're building for iOS 14.
+            .padding(.top, shouldBolusEntryBecomeFirstResponder ? -200 : -28)
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, horizontalOverride)
 


### PR DESCRIPTION
This ugly hack is due to the fact that SwiftUI cannot _yet_ programmatically scroll.  The hack is to conditionally add negative padding to reveal the Bolus entry text field.  It isn't pretty, but it seems to sort of work.  Unfortunately, after entry, it scoots back down and remains hidden under the buttons.  The user can still scroll afterwards.
~Still needs Design to approve the behavior.~
I showed Matt L this behavior, and he "pre-approved" it