### PR TITLE
LOOP-1160: Show '--' if there's no iob or cob (instead of 0)

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -468,6 +468,10 @@ struct LabeledQuantity: View {
     }
 
     var valueText: Text {
+        guard let quantity = quantity else {
+            return Text("--")
+        }
+        
         let formatter = QuantityFormatter()
         formatter.setPreferredNumberFormatter(for: unit)
 
@@ -475,7 +479,7 @@ struct LabeledQuantity: View {
             formatter.numberFormatter.maximumFractionDigits = maxFractionDigits
         }
 
-        guard let string = formatter.string(from: quantity ?? HKQuantity(unit: unit, doubleValue: 0), for: unit) else {
+        guard let string = formatter.string(from: quantity, for: unit) else {
             assertionFailure("Unable to format \(String(describing: quantity)) \(unit)")
             return Text("")
         }


### PR DESCRIPTION
@ps2 After reflection, since Matt L. seemed to be okay with either '--' and '0', I'm going with the safer choice of showing "--" in the case of missing IOB or COB.  I'd like your ok on that.