### PR TITLE
Remove unnecessary properties from carb structures

### DIFF
--- a/Loop/Extensions/CarbStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/CarbStore+SimulatedCoreData.swift
@@ -117,15 +117,13 @@ fileprivate extension StoredCarbEntry {
                                foodType: "Simulated",
                                absorptionTime: absorptionTime,
                                createdByCurrentApp: true,
-                               externalID: UUID().uuidString,
-                               isUploaded: false)
+                               externalID: UUID().uuidString)
     }
 }
 
 fileprivate extension DeletedCarbEntry {
     static func simulated(startDate: Date) -> DeletedCarbEntry {
         return DeletedCarbEntry(externalID: UUID().uuidString,
-                                isUploaded: false,
                                 startDate: startDate,
                                 uuid: UUID(),
                                 syncIdentifier: UUID().uuidString,

--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -104,8 +104,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
                 quantity: quantity,
                 startDate: date,
                 foodType: foodType,
-                absorptionTime: absorptionTime,
-                externalID: originalCarbEntry?.externalID
+                absorptionTime: absorptionTime
             )
         } else {
             return nil

--- a/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
+++ b/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
@@ -113,8 +113,7 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
             quantity: HKQuantity(unit: .gram(), doubleValue: Double(grams)),
             startDate: carbEntryDate,
             foodType: nil,
-            absorptionTime: absorptionTime(for: carbAbsorptionTime),
-            syncIdentifier: UUID().uuidString
+            absorptionTime: absorptionTime(for: carbAbsorptionTime)
         )
 
         guard entry.quantity.doubleValue(for: .gram()) > 0 else {


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1417
- Remove unused uploadState from CachedCarbObject and DeletedCarbObject
- Remove unused isUploaded from StoredCarbEntry and DeletedCarbEntry
- Remove unused createdByCurrentApp, externalID, syncIdentifier, and isUploaded from NewCarbEntry