### PR TITLE
DIY: Add "Services" section to Settings for DIY only

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -20,6 +20,7 @@ struct FeatureFlagConfiguration: Decodable {
     let walshInsulinModelEnabled: Bool
     let fiaspInsulinModelEnabled: Bool
     let observeHealthKitSamplesFromOtherApps: Bool
+    let includeServicesInSettingsEnabled: Bool
 
     fileprivate init() {
         // Swift compiler config is inverse, since the default state is enabled.
@@ -81,6 +82,13 @@ struct FeatureFlagConfiguration: Decodable {
         #else
         self.observeHealthKitSamplesFromOtherApps = true
         #endif
+        
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if INCLUDE_SERVICES_IN_SETTINGS_DISABLED
+        self.includeServicesInSettingsEnabled = false
+        #else
+        self.includeServicesInSettingsEnabled = true
+        #endif
     }
 }
 
@@ -97,6 +105,7 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* walshInsulinModelEnabled: \(walshInsulinModelEnabled)",
             "* fiaspInsulinModelEnabled: \(fiaspInsulinModelEnabled)",
             "* observeHealthKitSamplesFromOtherApps: \(observeHealthKitSamplesFromOtherApps)",
+            "* includeServicesInSettingsEnabled: \(includeServicesInSettingsEnabled)",
         ].joined(separator: "\n")
     }
 }

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1D05219D2469F1F5000EBBDE /* AlertStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D05219C2469F1F5000EBBDE /* AlertStore.swift */; };
 		1D080CBD2473214A00356610 /* AlertStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */; };
 		1D2609AD248EEB9900A6F258 /* LoopAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2609AC248EEB9900A6F258 /* LoopAlertsManager.swift */; };
+		1D49795824E7289700948F05 /* ServicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D49795724E7289700948F05 /* ServicesViewModel.swift */; };
 		1D4990E824A25931005CC357 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E267FB2292456700A3F2AF /* FeatureFlags.swift */; };
 		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
 		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
@@ -644,6 +645,7 @@
 		1D05219C2469F1F5000EBBDE /* AlertStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStore.swift; sourceTree = "<group>"; };
 		1D080CBC2473214A00356610 /* AlertStore.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AlertStore.xcdatamodel; sourceTree = "<group>"; };
 		1D2609AC248EEB9900A6F258 /* LoopAlertsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopAlertsManager.swift; sourceTree = "<group>"; };
+		1D49795724E7289700948F05 /* ServicesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesViewModel.swift; sourceTree = "<group>"; };
 		1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataClass.swift"; sourceTree = "<group>"; };
 		1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		1D80313C24746274002810DF /* AlertStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStoreTests.swift; sourceTree = "<group>"; };
@@ -1728,6 +1730,7 @@
 				89CAB36224C8FE95009EE3CE /* PredictedGlucoseChartView.swift */,
 				438D42FA1D7D11A4003244B0 /* PredictionInputEffectTableViewCell.swift */,
 				439706E522D2E84900C81566 /* PredictionSettingTableViewCell.swift */,
+				1D49795724E7289700948F05 /* ServicesViewModel.swift */,
 				43C3B6EB20B650A80026CAFA /* SettingsImageTableViewCell.swift */,
 				1DE09BA824A3E23F009EE9F9 /* SettingsView.swift */,
 				1DB1CA4E24A56D7600B3B94C /* SettingsViewModel.swift */,
@@ -2876,6 +2879,7 @@
 				4372E487213C86240068E043 /* SampleValue.swift in Sources */,
 				437CEEE41CDE5C0A003C8C80 /* UIImage.swift in Sources */,
 				C1201E2C23ECDBD0002DA84A /* WatchContextRequestUserInfo.swift in Sources */,
+				1D49795824E7289700948F05 /* ServicesViewModel.swift in Sources */,
 				1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */,
 				892D7C5123B54A15008A9656 /* CarbEntryViewController.swift in Sources */,
 				A999D40424663CE1004C89D4 /* DoseStore.swift in Sources */,

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -779,7 +779,7 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                                     bolusVolumes: $0.supportedBolusVolumes,
                                     maximumBasalScheduleEntryCount: $0.maximumBasalScheduleEntryCount)
         }
-        let servicesViewModel = ServicesViewModel(showServices: !Bundle.main.bundleDisplayName.contains("Tidepool"), // Hack for now, until we get rid of this VC
+        let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: availableServices,
                                                   activeServices: activeServices,
                                                   delegate: self)

--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -782,10 +782,13 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
                                     bolusVolumes: $0.supportedBolusVolumes,
                                     maximumBasalScheduleEntryCount: $0.maximumBasalScheduleEntryCount)
         }
+        let servicesViewModel = ServicesViewModel(showServices: true, availableServices: availableServices, activeServices: activeServices)
+        
         let viewModel = SettingsViewModel(appNameAndVersion: Bundle.main.localizedNameAndVersion,
                                           notificationsCriticalAlertPermissionsViewModel: notificationsCriticalAlertPermissionsViewModel,
                                           pumpManagerSettingsViewModel: pumpViewModel,
                                           cgmManagerSettingsViewModel: cgmViewModel,
+                                          servicesViewModel: servicesViewModel,
                                           therapySettings: dataManager.loopManager.therapySettings,
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,

--- a/Loop/Views/ServicesViewModel.swift
+++ b/Loop/Views/ServicesViewModel.swift
@@ -9,18 +9,40 @@
 import LoopKit
 import SwiftUI
 
+public protocol ServicesViewModelDelegate: class {
+    func addService(identifier: String)
+    func gotoService(identifier: String)
+}
+
 public class ServicesViewModel: ObservableObject {
     
     @Published var showServices: Bool
     @Published var availableServices: [AvailableService]
     @Published var activeServices: [Service]
     
+    var inactiveServices: [AvailableService] {
+        return availableServices.filter { availableService in
+            !activeServices.contains { $0.serviceIdentifier == availableService.identifier }
+        }
+    }
+    
+    weak var delegate: ServicesViewModelDelegate?
+    
     init(showServices: Bool,
-                availableServices: [AvailableService],
-                activeServices: [Service]) {
+         availableServices: [AvailableService],
+         activeServices: [Service],
+         delegate: ServicesViewModelDelegate? = nil) {
         self.showServices = showServices
         self.activeServices = activeServices
         self.availableServices = availableServices
+        self.delegate = delegate
     }
     
+    func didTapService(_ index: Int) {
+        delegate?.gotoService(identifier: activeServices[index].serviceIdentifier)
+    }
+    
+    func didTapAddService(_ availableService: AvailableService) {
+        delegate?.addService(identifier: availableService.identifier)
+    }
 }

--- a/Loop/Views/ServicesViewModel.swift
+++ b/Loop/Views/ServicesViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  ServicesViewModel.swift
+//  Loop
+//
+//  Created by Rick Pasetto on 8/14/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+import SwiftUI
+
+public class ServicesViewModel: ObservableObject {
+    
+    @Published var showServices: Bool
+    @Published var availableServices: [AvailableService]
+    @Published var activeServices: [Service]
+    
+    init(showServices: Bool,
+                availableServices: [AvailableService],
+                activeServices: [Service]) {
+        self.showServices = showServices
+        self.activeServices = activeServices
+        self.availableServices = availableServices
+    }
+    
+}

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -17,6 +17,8 @@ public struct SettingsView: View, HorizontalSizeClassOverride {
 
     @ObservedObject var viewModel: SettingsViewModel
 
+    @State var showServiceChooser: Bool = false
+    
     public init(viewModel: SettingsViewModel) {
         self.viewModel = viewModel
     }
@@ -79,13 +81,14 @@ extension SettingsView {
         
     private var therapySettingsSection: some View {
         Section(header: SectionHeader(label: NSLocalizedString("Configuration", comment: "The title of the Configuration section in settings"))) {
-            return NavigationLink(destination: TherapySettingsView(viewModel: TherapySettingsViewModel(mode: .settings,
-                                                                                                       therapySettings: viewModel.therapySettings,
-                                                                                                       supportedInsulinModelSettings: viewModel.supportedInsulinModelSettings,
-                                                                                                       pumpSupportedIncrements: viewModel.pumpSupportedIncrements,
-                                                                                                       syncPumpSchedule: viewModel.syncPumpSchedule,
-                                                                                                       chartColors: .primary,
-                                                                                                       didSave: viewModel.didSave))) {
+            return NavigationLink(destination: TherapySettingsView(
+                viewModel: TherapySettingsViewModel(mode: .settings,
+                                                    therapySettings: viewModel.therapySettings,
+                                                    supportedInsulinModelSettings: viewModel.supportedInsulinModelSettings,
+                                                    pumpSupportedIncrements: viewModel.pumpSupportedIncrements,
+                                                    syncPumpSchedule: viewModel.syncPumpSchedule,
+                                                    chartColors: .primary,
+                                                    didSave: viewModel.didSave))) {
                 LargeButton(action: { },
                             includeArrow: false,
                             imageView: AnyView(Image("Therapy Icon")),
@@ -136,15 +139,32 @@ extension SettingsView {
     
     private var servicesSection: some View {
         Section(header: SectionHeader(label: NSLocalizedString("Services", comment: "The title of the services section in settings"))) {
-            ForEach(viewModel.servicesViewModel.activeServices.indices, id: \.self) { _ in
-                NavigationLink(destination: Text("Services")) {
-                     Text(NSLocalizedString("Services", comment: "The title of the support section in settings"))
-                }
+            ForEach(viewModel.servicesViewModel.activeServices.indices, id: \.self) { index in
+                // TODO: this "dismiss then call didTapService()" here is temporary, until we've completely gotten rid of SettingsTableViewController
+                Button(action: { self.dismiss(); self.viewModel.servicesViewModel.didTapService(index) }, label: {
+                    Text(self.viewModel.servicesViewModel.activeServices[index].localizedTitle)
+                })
+                    .accentColor(.primary)
             }
-            Button(action: { /*self.viewModel.servicesViewModel.addService()*/ }, label: {
-                Text(NSLocalizedString("Add Service", comment: "The title of the support section in settings"))
+            Button(action: { self.showServiceChooser = true }, label: {
+                Text("Add Service", comment: "The title of the services section in settings")
             })
+                .actionSheet(isPresented: $showServiceChooser) {
+                    ActionSheet(title: Text("Add Service", comment: "The title of the services section in settings"), buttons: serviceChoices)
+                }
         }
+    }
+    
+    private var serviceChoices: [ActionSheet.Button] {
+        var result = viewModel.servicesViewModel.inactiveServices.map { availableService in
+            ActionSheet.Button.default(Text(availableService.localizedTitle)) {
+                // TODO: this "dismiss then call didTapAddService()" here is temporary, until we've completely gotten rid of SettingsTableViewController
+                self.dismiss()
+                self.viewModel.servicesViewModel.didTapAddService(availableService)
+            }
+        }
+        result.append(.cancel())
+        return result
     }
     
     private var supportSection: some View {
@@ -211,8 +231,27 @@ fileprivate struct LargeButton: View {
     }
 }
 
-let servicesViewModel = ServicesViewModel(showServices: true, availableServices: [], activeServices: [MockService()])
-
+fileprivate class FakeService1: Service {
+    static var localizedTitle: String = "Service 1"
+    static var serviceIdentifier: String = "FakeService1"
+    var serviceDelegate: ServiceDelegate?
+    var rawState: RawStateValue = [:]
+    required init?(rawState: RawStateValue) {}
+    convenience init() { self.init(rawState: [:])! }
+    var available: AvailableService { AvailableService(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
+}
+fileprivate class FakeService2: Service {
+    static var localizedTitle: String = "Service 2"
+    static var serviceIdentifier: String = "FakeService2"
+    var serviceDelegate: ServiceDelegate?
+    var rawState: RawStateValue = [:]
+    required init?(rawState: RawStateValue) {}
+    convenience init() { self.init(rawState: [:])! }
+    var available: AvailableService { AvailableService(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
+}
+fileprivate let servicesViewModel = ServicesViewModel(showServices: true,
+                                                      availableServices: [FakeService1().available, FakeService2().available],
+                                                      activeServices: [FakeService1()])
 public struct SettingsView_Previews: PreviewProvider {
     public static var previews: some View {
         let viewModel = SettingsViewModel(appNameAndVersion: "Tidepool Loop v1.2.3.456",

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -8,6 +8,7 @@
 
 import LoopKit
 import LoopKitUI
+import MockKit
 import SwiftUI
 
 public struct SettingsView: View, HorizontalSizeClassOverride {
@@ -29,6 +30,9 @@ public struct SettingsView: View, HorizontalSizeClassOverride {
                 }
                 therapySettingsSection
                 deviceSettingsSection
+                if viewModel.servicesViewModel.showServices {
+                    servicesSection
+                }
                 supportSection
             }
             .listStyle(GroupedListStyle())
@@ -130,6 +134,19 @@ extension SettingsView {
         }
     }
     
+    private var servicesSection: some View {
+        Section(header: SectionHeader(label: NSLocalizedString("Services", comment: "The title of the services section in settings"))) {
+            ForEach(viewModel.servicesViewModel.activeServices.indices, id: \.self) { _ in
+                NavigationLink(destination: Text("Services")) {
+                     Text(NSLocalizedString("Services", comment: "The title of the support section in settings"))
+                }
+            }
+            Button(action: { /*self.viewModel.servicesViewModel.addService()*/ }, label: {
+                Text(NSLocalizedString("Add Service", comment: "The title of the support section in settings"))
+            })
+        }
+    }
+    
     private var supportSection: some View {
         Section(header: SectionHeader(label: NSLocalizedString("Support", comment: "The title of the support section in settings"))) {
             NavigationLink(destination: Text("Support")) {
@@ -193,12 +210,15 @@ fileprivate struct LargeButton: View {
     }
 }
 
+let servicesViewModel = ServicesViewModel(showServices: true, availableServices: [], activeServices: [MockService()])
+
 public struct SettingsView_Previews: PreviewProvider {
     public static var previews: some View {
         let viewModel = SettingsViewModel(appNameAndVersion: "Tidepool Loop v1.2.3.456",
                                           notificationsCriticalAlertPermissionsViewModel: NotificationsCriticalAlertPermissionsViewModel(),
                                           pumpManagerSettingsViewModel: DeviceViewModel(),
                                           cgmManagerSettingsViewModel: DeviceViewModel(),
+                                          servicesViewModel: servicesViewModel,
                                           therapySettings: TherapySettings(),
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,

--- a/Loop/Views/SettingsViewModel.swift
+++ b/Loop/Views/SettingsViewModel.swift
@@ -49,6 +49,7 @@ public class SettingsViewModel: ObservableObject {
 
     var pumpManagerSettingsViewModel: DeviceViewModel
     var cgmManagerSettingsViewModel: DeviceViewModel
+    var servicesViewModel: ServicesViewModel
     var therapySettings: TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: PumpSupportedIncrements?
@@ -62,6 +63,7 @@ public class SettingsViewModel: ObservableObject {
                 notificationsCriticalAlertPermissionsViewModel: NotificationsCriticalAlertPermissionsViewModel,
                 pumpManagerSettingsViewModel: DeviceViewModel,
                 cgmManagerSettingsViewModel: DeviceViewModel,
+                servicesViewModel: ServicesViewModel,
                 therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: PumpSupportedIncrements?,
@@ -84,6 +86,8 @@ public class SettingsViewModel: ObservableObject {
         self.syncPumpSchedule = syncPumpSchedule
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.didSave = didSave
+        
+        self.servicesViewModel = servicesViewModel
 
         // This strangeness ensures the composed ViewModels' (ObservableObjects') changes get reported to this ViewModel (ObservableObject)
         notificationsCriticalAlertPermissionsViewModel.objectWillChange.sink { [weak self] in


### PR DESCRIPTION
As part of the process of replacing the "old" Settings UI (`SettingsTableViewController`) with the new one (`SettingsView`), we need to provide the ability to add services and go to their settings.  This is minimal wiring to do just that within the new UI.  It is minimal because eventually `SettingsTableViewController` will go away, and this will need to be re-forged anyway.

(Note: it follows the "wiring" pattern already established with the devices...namely delegating the UI presentation work to `SettingsTableViewController`)