### PR TITLE
New Settings: add "delete [Pump,CGM] data" feature (testing only)

### DIFF
--- a/Loop/View Controllers/SettingsTableViewController.swift
+++ b/Loop/View Controllers/SettingsTableViewController.swift
@@ -771,12 +771,22 @@ final class SettingsTableViewController: UITableViewController, IdentifiableClas
     }
     
     private func presentTemporaryNewSettings(_ tableView: UITableView, _ indexPath: IndexPath) {
-        let pumpViewModel = DeviceViewModel(deviceManagerUI: dataManager.pumpManager, isSetUp: dataManager.pumpManager != nil) { [weak self] in
+        let pumpViewModel = DeviceViewModel(
+            deviceManagerUI: dataManager.pumpManager,
+            isSetUp: dataManager.pumpManager != nil,
+            deleteData: (dataManager.pumpManager is TestingPumpManager) ? { [weak self] in self?.dataManager.deleteTestingPumpData()
+                } : nil,
+            onTapped: { [weak self] in
             self?.didSelectPump()
-        }
-        let cgmViewModel = DeviceViewModel(deviceManagerUI: dataManager.cgmManager as? DeviceManagerUI, isSetUp: dataManager.cgmManager != nil) { [weak self] in
+        })
+        let cgmViewModel = DeviceViewModel(
+            deviceManagerUI: dataManager.cgmManager as? DeviceManagerUI,
+            isSetUp: dataManager.cgmManager != nil,
+            deleteData: (dataManager.cgmManager is TestingCGMManager) ? { [weak self] in self?.dataManager.deleteTestingCGMData()
+                } : nil,
+            onTapped: { [weak self] in
             self?.didSelectCGM()
-        }
+        })
         let pumpSupportedIncrements = dataManager.pumpManager.map {
             PumpSupportedIncrements(basalRates: $0.supportedBasalRates,
                                     bolusVolumes: $0.supportedBolusVolumes,

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -29,6 +29,12 @@ public struct SettingsView: View, HorizontalSizeClassOverride {
                 }
                 therapySettingsSection
                 deviceSettingsSection
+                if viewModel.pumpManagerSettingsViewModel.isTestingDevice {
+                    deletePumpDataSection
+                }
+                if viewModel.cgmManagerSettingsViewModel.isTestingDevice {
+                    deleteCgmDataSection
+                }
                 supportSection
             }
             .listStyle(GroupedListStyle())
@@ -130,6 +136,30 @@ extension SettingsView {
         }
     }
     
+    private var deletePumpDataSection: some View {
+        Section {
+            Button(action: { self.viewModel.pumpManagerSettingsViewModel.deleteData?() }) {
+                HStack {
+                    Spacer()
+                    Text("Delete Pump Data").accentColor(.destructive)
+                    Spacer()
+                }
+            }
+        }
+    }
+    
+    private var deleteCgmDataSection: some View {
+        Section {
+            Button(action: { self.viewModel.cgmManagerSettingsViewModel.deleteData?() }) {
+                HStack {
+                    Spacer()
+                    Text("Delete CGM Data").accentColor(.destructive)
+                    Spacer()
+                }
+            }
+        }
+    }
+    
     private var supportSection: some View {
         Section(header: SectionHeader(label: NSLocalizedString("Support", comment: "The title of the support section in settings"))) {
             NavigationLink(destination: Text("Support")) {
@@ -214,8 +244,8 @@ public struct SettingsView_Previews: PreviewProvider {
             
             SettingsView(viewModel: viewModel)
                 .colorScheme(.dark)
-                .previewDevice(PreviewDevice(rawValue: "iPhone XS Max"))
-                .previewDisplayName("XS Max dark")
+                .previewDevice(PreviewDevice(rawValue: "iPhone 11 Pro Max"))
+                .previewDisplayName("11 Pro dark")
         }
     }
 }

--- a/Loop/Views/SettingsViewModel.swift
+++ b/Loop/Views/SettingsViewModel.swift
@@ -15,16 +15,22 @@ import SwiftUI
 public class DeviceViewModel: ObservableObject {
     public init(deviceManagerUI: DeviceManagerUI? = nil,
                 isSetUp: Bool = false,
+                deleteData: (() -> Void)? = nil,
                 onTapped: @escaping () -> Void = { }) {
         self.deviceManagerUI = deviceManagerUI
         self.isSetUp = isSetUp
+        self.deleteData = deleteData
         self.onTapped = onTapped
     }
     
     let deviceManagerUI: DeviceManagerUI?
-
-    @Published private(set) var isSetUp: Bool = false
+    let deleteData: (() -> Void)?
     
+    @Published private(set) var isSetUp: Bool = false
+    var isTestingDevice: Bool {
+        return deleteData != nil
+    }
+
     var image: UIImage? { deviceManagerUI?.smallImage }
     var name: String { deviceManagerUI?.localizedTitle ?? "" }
    


### PR DESCRIPTION
For testing only, and for backward-compatibility with the "old" settings screen, this adds the "delete pump data" and "delete CGM data" buttons to the new settings screen.