### PR TITLE
LOOP-1627: Add button color to communicate state on watch temporary correction range adjustments

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -503,6 +503,9 @@
 		E98A55EF24EDD6E60008715D /* DosingDecisionStoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98A55EE24EDD6E60008715D /* DosingDecisionStoreProtocol.swift */; };
 		E98A55F124EDD85E0008715D /* MockDosingDecisionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98A55F024EDD85E0008715D /* MockDosingDecisionStore.swift */; };
 		E98A55F324EDD9530008715D /* MockSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98A55F224EDD9530008715D /* MockSettingsStore.swift */; };
+		E98A55F524EEE15A0008715D /* OnOffSelectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98A55F424EEE15A0008715D /* OnOffSelectionController.swift */; };
+		E98A55F724EEE1E10008715D /* OnOffSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98A55F624EEE1E10008715D /* OnOffSelectionView.swift */; };
+		E98A55F924EEFC200008715D /* OnOffSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98A55F824EEFC200008715D /* OnOffSelectionViewModel.swift */; };
 		E9C00EF224C6221B00628F35 /* LoopSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C00EEF24C620EF00628F35 /* LoopSettings.swift */; };
 		E9C00EF324C6222400628F35 /* LoopSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C00EEF24C620EF00628F35 /* LoopSettings.swift */; };
 		E9C00EF524C623EF00628F35 /* LoopSettings+Loop.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9C00EF424C623EF00628F35 /* LoopSettings+Loop.swift */; };
@@ -1281,6 +1284,9 @@
 		E98A55EE24EDD6E60008715D /* DosingDecisionStoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DosingDecisionStoreProtocol.swift; sourceTree = "<group>"; };
 		E98A55F024EDD85E0008715D /* MockDosingDecisionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDosingDecisionStore.swift; sourceTree = "<group>"; };
 		E98A55F224EDD9530008715D /* MockSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSettingsStore.swift; sourceTree = "<group>"; };
+		E98A55F424EEE15A0008715D /* OnOffSelectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnOffSelectionController.swift; sourceTree = "<group>"; };
+		E98A55F624EEE1E10008715D /* OnOffSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnOffSelectionView.swift; sourceTree = "<group>"; };
+		E98A55F824EEFC200008715D /* OnOffSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnOffSelectionViewModel.swift; sourceTree = "<group>"; };
 		E9C00EEF24C620EF00628F35 /* LoopSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopSettings.swift; sourceTree = "<group>"; };
 		E9C00EF424C623EF00628F35 /* LoopSettings+Loop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoopSettings+Loop.swift"; sourceTree = "<group>"; };
 		E9C58A7124DB489100487A17 /* LoopDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopDataManagerTests.swift; sourceTree = "<group>"; };
@@ -1448,6 +1454,7 @@
 				43A943891B926B7B0051FA24 /* NotificationController.swift */,
 				892FB4CE220402C0005293EC /* OverrideSelectionController.swift */,
 				4345E40321F68AD9009E00E5 /* TextRowController.swift */,
+				E98A55F424EEE15A0008715D /* OnOffSelectionController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -2068,6 +2075,7 @@
 			isa = PBXGroup;
 			children = (
 				891B508424342BE1005DA578 /* CarbAndBolusFlowViewModel.swift */,
+				E98A55F824EEFC200008715D /* OnOffSelectionViewModel.swift */,
 			);
 			path = "View Models";
 			sourceTree = "<group>";
@@ -2083,6 +2091,7 @@
 				89A605EE2432925D009C1096 /* CompletionCheckmark.swift */,
 				894F6DD8243C060600CCE676 /* ScalablePositionedText.swift */,
 				89A605EA243288E4009C1096 /* TopDownTriangle.swift */,
+				E98A55F624EEE1E10008715D /* OnOffSelectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3291,6 +3300,7 @@
 				895788B1242E69A2002CB114 /* Color.swift in Sources */,
 				89E08FC2242E73DC000D719B /* CarbAmountPositionKey.swift in Sources */,
 				4F11D3C420DD881A006E072C /* WatchHistoricalGlucose.swift in Sources */,
+				E98A55F724EEE1E10008715D /* OnOffSelectionView.swift in Sources */,
 				89E08FCA242E7714000D719B /* UIFont.swift in Sources */,
 				4328E0281CFBE2C500E199AA /* CLKComplicationTemplate.swift in Sources */,
 				4328E01E1CFBE25F00E199AA /* CarbAndBolusFlowController.swift in Sources */,
@@ -3305,6 +3315,7 @@
 				898ECA69218ABDA9001E9D35 /* CLKTextProvider+Compound.m in Sources */,
 				4372E48C213CB6750068E043 /* Double.swift in Sources */,
 				89A605ED24328972009C1096 /* BolusArrow.swift in Sources */,
+				E98A55F924EEFC200008715D /* OnOffSelectionViewModel.swift in Sources */,
 				892FB4CF220402C0005293EC /* OverrideSelectionController.swift in Sources */,
 				89E08FD0242E8B2B000D719B /* BolusConfirmationView.swift in Sources */,
 				43785E972120E4500057DED1 /* INRelevantShortcutStore+Loop.swift in Sources */,
@@ -3321,6 +3332,7 @@
 				43517917230A0E1A0072ECC0 /* WKInterfaceLabel.swift in Sources */,
 				895788B3242E69A2002CB114 /* ActionButton.swift in Sources */,
 				894F6DD3243BCBDB00CCE676 /* Environment+SizeClass.swift in Sources */,
+				E98A55F524EEE15A0008715D /* OnOffSelectionController.swift in Sources */,
 				4328E01A1CFBE1DA00E199AA /* ActionHUDController.swift in Sources */,
 				4F11D3C320DD84DB006E072C /* GlucoseBackfillRequestUserInfo.swift in Sources */,
 				435400351C9F878D00D5819C /* SetBolusUserInfo.swift in Sources */,

--- a/Loop/Base.lproj/Main.storyboard
+++ b/Loop/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="74s-IX-WF0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="74s-IX-WF0">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -979,7 +979,7 @@
         <image name="settings" width="25" height="40"/>
         <image name="workout" width="30" height="29"/>
         <namedColor name="carbs">
-            <color red="0.3880000114440918" green="0.85500001907348633" blue="0.2199999988079071" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.66699999570846558" blue="0.22400000691413879" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/WatchApp Extension/Controllers/ActionHUDController.swift
+++ b/WatchApp Extension/Controllers/ActionHUDController.swift
@@ -10,6 +10,7 @@ import WatchKit
 import WatchConnectivity
 import LoopKit
 import LoopCore
+import SwiftUI
 
 
 final class ActionHUDController: HUDInterfaceController {
@@ -113,12 +114,11 @@ final class ActionHUDController: HUDInterfaceController {
         guard let range = loopManager.settings.preMealTargetRange else {
             return
         }
-
-        presentOnOffActionSheet(
-            title: NSLocalizedString("Pre-Meal", comment: "Title for sheet to enable/disable pre-meal on watch"),
-            message: formattedGlucoseRangeString(from: range),
-            onSelection: setPreMealEnabled
-        )
+        
+        let buttonToSelect = loopManager.settings.preMealOverride?.isActive() == true ? SelectedButton.on : SelectedButton.off
+        
+        let viewModel = OnOffSelectionViewModel(title: NSLocalizedString("Pre-Meal", comment: "Title for sheet to enable/disable pre-meal on watch"), message: formattedGlucoseRangeString(from: range), onSelection: setPreMealEnabled, selectedButton: buttonToSelect, selectedButtonTint: .carbsColor)
+        presentController(withName: OnOffSelectionController.className, context: viewModel)
     }
 
     func setPreMealEnabled(_ isPreMealEnabled: Bool) {
@@ -182,14 +182,19 @@ final class ActionHUDController: HUDInterfaceController {
                 ? sendOverride(nil)
                 : presentController(withName: OverrideSelectionController.className, context: self as OverrideSelectionControllerDelegate)
         } else if let range = loopManager.settings.legacyWorkoutTargetRange {
-            presentOnOffActionSheet(
+            let buttonToSelect = loopManager.settings.nonPreMealOverrideEnabled() == true ? SelectedButton.on : SelectedButton.off
+            
+            let viewModel = OnOffSelectionViewModel(
                 title: NSLocalizedString("Workout", comment: "Title for sheet to enable/disable workout mode on watch"),
                 message: formattedGlucoseRangeString(from: range),
                 onSelection: { isWorkoutEnabled in
                     let override = isWorkoutEnabled ? self.loopManager.settings.legacyWorkoutOverride(for: .infinity) : nil
                     self.sendOverride(override)
-                }
+                },
+                selectedButton: buttonToSelect,
+                selectedButtonTint: .glucose
             )
+            presentController(withName: OnOffSelectionController.className, context: viewModel)
         }
     }
 
@@ -252,31 +257,6 @@ final class ActionHUDController: HUDInterfaceController {
                 )
             }
         }
-    }
-
-    private func presentOnOffActionSheet(
-        title: String,
-        message: String?,
-        onSelection setEnabled: @escaping (_ isEnabled: Bool) -> Void
-    ) {
-        presentAlert(
-            withTitle: title,
-            message: message,
-            preferredStyle: .actionSheet,
-            actions: [
-                WKAlertAction(
-                    title: NSLocalizedString("On", comment: "Button text for enabling temporary correction range"),
-                    style: .default,
-                    handler: { setEnabled(true) }
-                ),
-
-                WKAlertAction(
-                    title: NSLocalizedString("Off", comment: "Button text for disabling temporary correction range"),
-                    style: .default,
-                    handler: { setEnabled(false) }
-                )
-            ]
-        )
     }
 }
 

--- a/WatchApp Extension/Controllers/ActionHUDController.swift
+++ b/WatchApp Extension/Controllers/ActionHUDController.swift
@@ -116,8 +116,8 @@ final class ActionHUDController: HUDInterfaceController {
         }
         
         let buttonToSelect = loopManager.settings.preMealOverride?.isActive() == true ? SelectedButton.on : SelectedButton.off
-        
         let viewModel = OnOffSelectionViewModel(title: NSLocalizedString("Pre-Meal", comment: "Title for sheet to enable/disable pre-meal on watch"), message: formattedGlucoseRangeString(from: range), onSelection: setPreMealEnabled, selectedButton: buttonToSelect, selectedButtonTint: .carbsColor)
+        
         presentController(withName: OnOffSelectionController.className, context: viewModel)
     }
 

--- a/WatchApp Extension/Controllers/OnOffSelectionController.swift
+++ b/WatchApp Extension/Controllers/OnOffSelectionController.swift
@@ -6,11 +6,8 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-import WatchKit
 import SwiftUI
-import HealthKit
 import LoopCore
-import LoopKit
 
 
 final class OnOffSelectionController: WKHostingController<OnOffSelectionView>, IdentifiableClass {

--- a/WatchApp Extension/Controllers/OnOffSelectionController.swift
+++ b/WatchApp Extension/Controllers/OnOffSelectionController.swift
@@ -1,0 +1,30 @@
+//
+//  OnOffSelectionController.swift
+//  WatchApp Extension
+//
+//  Created by Anna Quinlan on 8/20/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import WatchKit
+import SwiftUI
+import HealthKit
+import LoopCore
+import LoopKit
+
+
+final class OnOffSelectionController: WKHostingController<OnOffSelectionView>, IdentifiableClass {
+    
+    private var viewModel: OnOffSelectionViewModel = OnOffSelectionViewModel(title: "", message: "", onSelection: {_ in })
+    
+    override func awake(withContext context: Any?) {
+        if let model = context as? OnOffSelectionViewModel {
+            model.dismiss = { self.dismiss() }
+            self.viewModel = model
+        }
+    }
+
+    override var body: OnOffSelectionView {
+        OnOffSelectionView(viewModel: viewModel)
+    }
+}

--- a/WatchApp Extension/Controllers/OnOffSelectionController.swift
+++ b/WatchApp Extension/Controllers/OnOffSelectionController.swift
@@ -15,10 +15,12 @@ final class OnOffSelectionController: WKHostingController<OnOffSelectionView>, I
     private var viewModel: OnOffSelectionViewModel = OnOffSelectionViewModel(title: "", message: "", onSelection: {_ in })
     
     override func awake(withContext context: Any?) {
-        if let model = context as? OnOffSelectionViewModel {
-            model.dismiss = { self.dismiss() }
-            self.viewModel = model
+        guard let model = context as? OnOffSelectionViewModel  else {
+            fatalError("OnOffSelectionController invoked without proper context")
         }
+        
+        model.dismiss = { self.dismiss() }
+        self.viewModel = model
     }
 
     override var body: OnOffSelectionView {

--- a/WatchApp Extension/View Models/OnOffSelectionViewModel.swift
+++ b/WatchApp Extension/View Models/OnOffSelectionViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  OnOffSelectionViewModel.swift
+//  WatchApp Extension
+//
+//  Created by Anna Quinlan on 8/20/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+enum SelectedButton {
+    case on
+    case off
+    case none
+}
+
+class OnOffSelectionViewModel: ObservableObject {
+    var title: String
+    var message: String
+    var onSelection: (Bool) -> Void
+    var dismiss: (() -> Void)?
+    var selectedButton: SelectedButton
+    var selectedButtonTint: UIColor
+    
+    init(
+        title: String,
+        message: String,
+        onSelection: @escaping (Bool) -> Void,
+        dismiss: (() -> Void)? = nil,
+        selectedButton: SelectedButton = .none,
+        selectedButtonTint: UIColor = .tintColor
+    ) {
+        self.title = title
+        self.message = message
+        self.onSelection = onSelection
+        self.dismiss = dismiss
+        self.selectedButton = selectedButton
+        self.selectedButtonTint = selectedButtonTint
+    }
+}

--- a/WatchApp Extension/View Models/OnOffSelectionViewModel.swift
+++ b/WatchApp Extension/View Models/OnOffSelectionViewModel.swift
@@ -11,7 +11,6 @@ import SwiftUI
 enum SelectedButton {
     case on
     case off
-    case none
 }
 
 class OnOffSelectionViewModel: ObservableObject {
@@ -27,7 +26,7 @@ class OnOffSelectionViewModel: ObservableObject {
         message: String,
         onSelection: @escaping (Bool) -> Void,
         dismiss: (() -> Void)? = nil,
-        selectedButton: SelectedButton = .none,
+        selectedButton: SelectedButton = .off,
         selectedButtonTint: UIColor = .tintColor
     ) {
         self.title = title

--- a/WatchApp Extension/Views/OnOffSelectionView.swift
+++ b/WatchApp Extension/Views/OnOffSelectionView.swift
@@ -7,9 +7,6 @@
 //
 
 import SwiftUI
-import HealthKit
-import LoopKit
-
 
 struct OnOffSelectionView: View {
     // MARK: - Initialization

--- a/WatchApp Extension/Views/OnOffSelectionView.swift
+++ b/WatchApp Extension/Views/OnOffSelectionView.swift
@@ -1,0 +1,93 @@
+//
+//  OnOffSelectionView.swift
+//  WatchApp Extension
+//
+//  Created by Anna Quinlan on 8/20/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import HealthKit
+import LoopKit
+
+
+struct OnOffSelectionView: View {
+    // MARK: - Initialization
+    var viewModel: OnOffSelectionViewModel
+
+    // MARK: - View Tree
+
+    var body: some View {
+        VStack {
+            Spacer()
+            titleStack
+            Spacer()
+            if viewModel.selectedButton == .on {
+                buttonStackWithOnSelected
+            } else if viewModel.selectedButton == .off {
+                buttonStackWithOffSelected
+            }
+        }
+    }
+    
+    var titleStack: some View {
+        VStack(spacing: 2) {
+            Text(viewModel.title)
+            Text(viewModel.message)
+        }
+    }
+    
+    var buttonStackWithOnSelected: some View {
+        VStack(spacing: 5) {
+            onButton
+            .background(Color(viewModel.selectedButtonTint).cornerRadius(20.0))
+            offButton
+        }
+    }
+    
+    var buttonStackWithOffSelected: some View {
+        VStack(spacing: 5) {
+            onButton
+            offButton
+            .background(Color(viewModel.selectedButtonTint).cornerRadius(20.0))
+        }
+    }
+    
+    var onButton: some View {
+        Button(action: {
+            self.viewModel.onSelection(true)
+            self.viewModel.dismiss?()
+        }) {
+            Text("On", comment: "Label for on button")
+        }
+        .cornerRadius(20)
+    }
+    
+    var offButton: some View {
+        Button(action: {
+            self.viewModel.onSelection(false)
+            self.viewModel.dismiss?()
+        }) {
+            Text("Off", comment: "Label for off button")
+        }
+        .cornerRadius(20)
+    }
+}
+
+struct OnOffSelectionView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            OnOffSelectionView(viewModel: OnOffSelectionViewModel(title: "Pre-Meal", message: "80-90 mg/dL", onSelection: {_ in print("hi")}, selectedButton: .on, selectedButtonTint: .carbsColor))
+            .previewDevice(PreviewDevice(rawValue: "Apple Watch Series 2 - 38mm"))
+            
+            OnOffSelectionView(viewModel: OnOffSelectionViewModel(title: "Pre-Meal", message: "80-90 mg/dL", onSelection: {_ in print("hi")}, selectedButton: .off, selectedButtonTint: .carbsColor))
+            .previewDevice(PreviewDevice(rawValue: "Apple Watch Series 2 - 42mm"))
+            
+            OnOffSelectionView(viewModel: OnOffSelectionViewModel(title: "Workout", message: "180-190 mg/dL", onSelection: {_ in print("hi")}, selectedButton: .on, selectedButtonTint: .glucose))
+            .previewDevice(PreviewDevice(rawValue: "Apple Watch Series 4 - 44mm"))
+            
+            OnOffSelectionView(viewModel: OnOffSelectionViewModel(title: "Workout", message: "180-190 mg/dL", onSelection: {_ in print("hi")}, selectedButton: .off, selectedButtonTint: .glucose))
+            .previewDevice(PreviewDevice(rawValue: "Apple Watch Series 4 - 40mm"))
+        }
+    }
+}

--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="16097" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rNf-Mh-tID">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="16097.2" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="rNf-Mh-tID">
     <device id="watch38"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -10,7 +10,7 @@
         <!--CarbAndBolusFlowController-->
         <scene sceneID="wDd-ld-Qg8">
             <objects>
-                <hostingController identifier="CarbAndBolusFlowController" id="YfQ-6P-aH4" customClass="CarbAndBolusFlowController" customModule="WatchApp_Extension"/>
+                <hostingController identifier="CarbAndBolusFlowController" id="YfQ-6P-aH4"/>
             </objects>
             <point key="canvasLocation" x="38" y="370"/>
         </scene>
@@ -385,6 +385,13 @@
             </objects>
             <point key="canvasLocation" x="706" y="370"/>
         </scene>
+        <!--OnOffSelectionController-->
+        <scene sceneID="ZRh-QV-fVl">
+            <objects>
+                <hostingController identifier="OnOffSelectionController" id="xhP-v4-5Vx" customClass="OnOffSelectionController" customModule="WatchApp_Extension"/>
+            </objects>
+            <point key="canvasLocation" x="369" y="370"/>
+        </scene>
     </scenes>
     <color key="tintColor" red="0.29803921570000003" green="0.85098039219999999" blue="0.3921568627" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
     <resources>
@@ -397,28 +404,28 @@
         <image name="pre-meal" width="44" height="44"/>
         <image name="workout" width="44" height="44"/>
         <namedColor name="carbs">
-            <color red="0.3880000114440918" green="0.85500001907348633" blue="0.2199999988079071" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.66699999570846558" blue="0.22400000691413879" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="carbs-dark">
-            <color red="0.070000000298023224" green="0.11999999731779099" blue="0.039999999105930328" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.66699999570846558" blue="0.22400000691413879" alpha="0.15000000596046448" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="insulin">
-            <color red="1" green="0.58399999141693115" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.33300000429153442" green="0.41200000047683716" blue="0.94900000095367432" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="insulin-dark">
-            <color red="1" green="0.58399999141693115" blue="0.0" alpha="0.15000000596046448" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.33300000429153442" green="0.41200000047683716" blue="0.94900000095367432" alpha="0.15000000596046448" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="insulin-notification-background">
-            <color red="1" green="0.58399999141693115" blue="0.0" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.33300000429153442" green="0.41200000047683716" blue="0.94900000095367432" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="separator">
             <color red="0.72200000286102295" green="0.72200000286102295" blue="0.72200000286102295" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="workout">
-            <color red="0.31000000238418579" green="0.67799997329711914" blue="0.97299998998641968" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.46700000762939453" green="0.36500000953674316" blue="0.79600000381469727" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="workout-dark">
-            <color red="0.019999999552965164" green="0.10000000149011612" blue="0.14000000059604645" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.46700000762939453" green="0.36500000953674316" blue="0.79600000381469727" alpha="0.15000000596046448" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1627

This PR adds coloring to the correction range overrides selection in order to indicate if the preset is currently enabled. Since (as far as I can find) there is no way to do this with the previous implementation, I re-wrote the pop-up screen in SwiftUI.