### PR TITLE
Fix watch storyboard

### DIFF
--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -10,7 +10,7 @@
         <!--CarbAndBolusFlowController-->
         <scene sceneID="wDd-ld-Qg8">
             <objects>
-                <hostingController identifier="CarbAndBolusFlowController" id="YfQ-6P-aH4"/>
+                <hostingController identifier="CarbAndBolusFlowController" id="YfQ-6P-aH4" customClass="CarbAndBolusFlowController" customModule="WatchApp_Extension"/>
             </objects>
             <point key="canvasLocation" x="38" y="370"/>
         </scene>


### PR DESCRIPTION
When I was working on LOOP-1627, I removed a reference to the WatchApp Extension for the carb/bolus entry view, which makes those screens appear blank in the current build. This PR updates the reference to fit the regression.