### PR TITLE
nate/fix/LOOP-309/colour-corrections

### DIFF
--- a/Loop/Base.lproj/Main.storyboard
+++ b/Loop/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="74s-IX-WF0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="74s-IX-WF0">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
@@ -287,9 +287,9 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="6T4-P6-RWt">
                                             <rect key="frame" x="133" y="167" width="109" height="50"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7dr-6C-JSN" customClass="CircleMaskView" customModule="Loop" customModuleProvider="target">
+                                                <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7dr-6C-JSN" customClass="CircleMaskView" customModule="Loop" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                                    <color key="backgroundColor" red="0.38823529410000002" green="0.85490196080000003" blue="0.21960784310000001" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" name="carbs"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="7dr-6C-JSN" secondAttribute="height" multiplier="1:1" id="OpK-4E-9Q6"/>
                                                     </constraints>

--- a/LoopUI/Charts/CarbEffectChart.swift
+++ b/LoopUI/Charts/CarbEffectChart.swift
@@ -74,7 +74,7 @@ extension CarbEffectChart {
 
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
-        let carbFillColor = UIColor.carbTintColor.withAlphaComponent(0.8)
+        let carbFillColor = UIColor.carbTintColor.withAlphaComponent(0.5)
         let carbBlendMode: CGBlendMode
         if #available(iOSApplicationExtension 13.0, iOS 13.0, *) {
             switch traitCollection.userInterfaceStyle {

--- a/LoopUI/Extensions/Color.swift
+++ b/LoopUI/Extensions/Color.swift
@@ -21,7 +21,7 @@ extension Color {
     // The loopAccent color is intended to be use as the app accent color.
     public static let loopAccent = Color("accent")
     
-    static public let warning = Color("warning")
+    public static let warning = Color("warning")
 }
 
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-309

Corrected carb effects colour (not to bias the review, but should be the `carbs` green with alpha of 0.5).