### PR TITLE
Capture last user modification of new or updated carb data as user created or updated date

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -58,26 +58,42 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
         }
     }
 
+    fileprivate var lastEntryDate: Date?
+
+    fileprivate func updateLastEntryDate() { lastEntryDate = Date() }
+
     fileprivate var quantity: HKQuantity? {
         didSet {
+            if quantity != oldValue {
+                updateLastEntryDate()
+            }
             updateContinueButtonEnabled()
         }
     }
 
     fileprivate var date = Date() {
         didSet {
+            if date != oldValue {
+                updateLastEntryDate()
+            }
             updateContinueButtonEnabled()
         }
     }
 
     fileprivate var foodType: String? {
         didSet {
+            if foodType != oldValue {
+                updateLastEntryDate()
+            }
             updateContinueButtonEnabled()
         }
     }
 
     fileprivate var absorptionTime: TimeInterval? {
         didSet {
+            if absorptionTime != oldValue {
+                updateLastEntryDate()
+            }
             updateContinueButtonEnabled()
         }
     }
@@ -93,7 +109,8 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
     private var shouldBeginEditingFoodType = false
 
     var updatedCarbEntry: NewCarbEntry? {
-        if  let quantity = quantity,
+        if  let lastEntryDate = lastEntryDate,
+            let quantity = quantity,
             let absorptionTime = absorptionTime ?? defaultAbsorptionTimes?.medium
         {
             if let o = originalCarbEntry, o.quantity == quantity && o.startDate == date && o.foodType == foodType && o.absorptionTime == absorptionTime {
@@ -101,6 +118,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
             }
 
             return NewCarbEntry(
+                date: lastEntryDate,
                 quantity: quantity,
                 startDate: date,
                 foodType: foodType,
@@ -317,6 +335,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
 
     override func restoreUserActivityState(_ activity: NSUserActivity) {
         if let entry = activity.newCarbEntry {
+            lastEntryDate = entry.date
             quantity = entry.quantity
             date = entry.startDate
 
@@ -394,7 +413,7 @@ extension CarbEntryViewController: TextFieldTableViewCellDelegate {
         tableView.endUpdates()
     }
 
-    func textFieldTableViewCellDidEndEditing(_ cell: TextFieldTableViewCell) {
+    func textFieldTableViewCellDidChangeEditing(_ cell: TextFieldTableViewCell) {
         guard let row = tableView.indexPath(for: cell)?.row else { return }
 
         switch Row(rawValue: row) {
@@ -411,19 +430,8 @@ extension CarbEntryViewController: TextFieldTableViewCellDelegate {
         }
     }
 
-    func textFieldTableViewCellDidChangeEditing(_ cell: TextFieldTableViewCell) {
-        guard let row = tableView.indexPath(for: cell)?.row else { return }
-
-        switch Row(rawValue: row) {
-        case .value?:
-            if let cell = cell as? DecimalTextFieldTableViewCell, let number = cell.number {
-                quantity = HKQuantity(unit: preferredCarbUnit, doubleValue: number.doubleValue)
-            } else {
-                quantity = nil
-            }
-        default:
-            break
-        }
+    func textFieldTableViewCellDidEndEditing(_ cell: TextFieldTableViewCell) {
+        textFieldTableViewCellDidChangeEditing(cell)
     }
 }
 

--- a/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
+++ b/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
@@ -29,7 +29,6 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
 
     // MARK: - Other state
     let interactionStartDate = Date()
-    private let carbEntrySyncIdentifier = UUID().uuidString
     private var carbEntryUnderConsideration: NewCarbEntry?
     private var contextUpdateObservation: AnyObject?
     private var hasSentConfirmationMessage = false
@@ -108,8 +107,9 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
         recommendedBolusAmount = nil
     }
 
-    func recommendBolus(forGrams grams: Int, eatenAt carbEntryDate: Date, absorptionTime carbAbsorptionTime: CarbAbsorptionTime) {
+    func recommendBolus(forGrams grams: Int, eatenAt carbEntryDate: Date, absorptionTime carbAbsorptionTime: CarbAbsorptionTime, lastEntryDate: Date) {
         let entry = NewCarbEntry(
+            date: lastEntryDate,
             quantity: HKQuantity(unit: .gram(), doubleValue: Double(grams)),
             startDate: carbEntryDate,
             foodType: nil,

--- a/WatchApp Extension/Views/Carb Entry & Bolus/AbsorptionTimeSelection.swift
+++ b/WatchApp Extension/Views/Carb Entry & Bolus/AbsorptionTimeSelection.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 
 struct AbsorptionTimeSelection: View {
+    @Binding var lastEntryDate: Date
     @Binding var selectedAbsorptionTime: CarbAbsorptionTime
     @Binding var expanded: Bool
     var amount: Int
@@ -30,6 +31,7 @@ struct AbsorptionTimeSelection: View {
         Button(
             action: {
                 if self.expanded {
+                    self.lastEntryDate = Date()
                     self.selectedAbsorptionTime = absorptionTime
                 } else {
                     withAnimation {

--- a/WatchApp Extension/Views/Carb Entry & Bolus/CarbAndBolusFlow.swift
+++ b/WatchApp Extension/Views/Carb Entry & Bolus/CarbAndBolusFlow.swift
@@ -34,6 +34,7 @@ struct CarbAndBolusFlow: View {
     @Environment(\.sizeClass) private var sizeClass
 
     // MARK: - State: Carb Entry
+    @State private var carbLastEntryDate = Date()
     @State private var carbAmount = 15
     @State private var carbEntryDate = Date()
     @State private var carbAbsorptionTime: CarbAbsorptionTime = .medium
@@ -90,6 +91,7 @@ extension CarbAndBolusFlow {
         VStack(spacing: 4) {
             if flowState == .carbEntry {
                 CarbAndDateInput(
+                    lastEntryDate: $carbLastEntryDate,
                     amount: $carbAmount,
                     date: $carbEntryDate,
                     initialDate: viewModel.interactionStartDate,
@@ -108,6 +110,7 @@ extension CarbAndBolusFlow {
 
             if configuration != .manualBolus && flowState != .bolusConfirmation {
                 AbsorptionTimeSelection(
+                    lastEntryDate: $carbLastEntryDate,
                     selectedAbsorptionTime: $carbAbsorptionTime,
                     expanded: absorptionButtonsExpanded,
                     amount: carbAmount
@@ -137,7 +140,7 @@ extension CarbAndBolusFlow {
     }
 
     private func transitionToBolusEntry() {
-        viewModel.recommendBolus(forGrams: carbAmount, eatenAt: carbEntryDate, absorptionTime: carbAbsorptionTime)
+        viewModel.recommendBolus(forGrams: carbAmount, eatenAt: carbEntryDate, absorptionTime: carbAbsorptionTime, lastEntryDate: carbLastEntryDate)
         withAnimation {
             flowState = .bolusEntry
             inputMode = .carbs

--- a/WatchApp Extension/Views/Carb Entry & Bolus/CarbAndDateInput.swift
+++ b/WatchApp Extension/Views/Carb Entry & Bolus/CarbAndDateInput.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 
 struct CarbAndDateInput: View {
+    @Binding var lastEntryDate: Date
     @Binding var amount: Int
     @Binding var date: Date
     var initialDate: Date
@@ -33,11 +34,25 @@ struct CarbAndDateInput: View {
     private var digitalCrownRotation: Binding<Int> {
         switch inputMode {
         case .carbs:
-            return $amount
+            return Binding(
+                get: { self.amount },
+                set: {
+                    if $0 != self.amount {
+                        self.lastEntryDate = Date()
+                        self.amount = $0
+                    }
+                }
+            )
         case .date:
             return Binding(
                 get: { Int(self.date.timeIntervalSince(self.initialDate).minutes) },
-                set: { self.date = self.initialDate.addingTimeInterval(.minutes(Double($0))) }
+                set: {
+                    let date = self.initialDate.addingTimeInterval(.minutes(Double($0)))
+                    if date != self.date {
+                        self.lastEntryDate = Date()
+                        self.date = date
+                    }
+                }
             )
         }
     }
@@ -69,6 +84,8 @@ struct CarbAndDateInput: View {
     }
 
     private func increment() {
+        self.lastEntryDate = Date()
+
         switch self.inputMode {
         case .carbs:
             self.amount = (self.amount + carbIncrement).clamped(to: validCarbAmountRange)
@@ -80,6 +97,8 @@ struct CarbAndDateInput: View {
     }
 
     private func decrement() {
+        self.lastEntryDate = Date()
+
         switch self.inputMode {
         case .carbs:
             self.amount = (self.amount - carbIncrement).clamped(to: validCarbAmountRange)


### PR DESCRIPTION
- Capture lastEntryDate in various views
- Add lastEntryDate to NewCarbEntry

Note: The next few PRs will be against the primary feature branch darinkrauss/LOOP-1417-capture-carbohydrate-entries.v2.ALL, not dev. My intention is to break the large overall feature into smaller, more easily reviewable PRs, and then merge the primary feature branch into dev after a final "summary" PR. (Several of the smaller PRs cannot be merged directly into dev because they would partially break existing functionality without a full replacement.)