### PR TITLE
nate/fix/LOOP-1890/watch-button-state-colour

### DIFF
--- a/WatchApp Extension/Controllers/ActionHUDController.swift
+++ b/WatchApp Extension/Controllers/ActionHUDController.swift
@@ -21,9 +21,9 @@ final class ActionHUDController: HUDInterfaceController {
     @IBOutlet var overrideButtonImage: WKInterfaceImage!
     @IBOutlet var overrideButtonBackground: WKInterfaceGroup!
 
-    private lazy var preMealButtonGroup = ButtonGroup(button: preMealButton, image: preMealButtonImage, background: preMealButtonBackground, onBackgroundColor: .carbsColor, offBackgroundColor: .darkCarbsColor)
+    private lazy var preMealButtonGroup = ButtonGroup(button: preMealButton, image: preMealButtonImage, background: preMealButtonBackground, onBackgroundColor: .carbsColor, offBackgroundColor: .darkCarbsColor, onIconColor: .black, offIconColor: .carbsColor)
 
-    private lazy var overrideButtonGroup = ButtonGroup(button: overrideButton, image: overrideButtonImage, background: overrideButtonBackground, onBackgroundColor: .overrideColor, offBackgroundColor: .darkOverrideColor)
+    private lazy var overrideButtonGroup = ButtonGroup(button: overrideButton, image: overrideButtonImage, background: overrideButtonBackground, onBackgroundColor: .overrideColor, offBackgroundColor: .darkOverrideColor, onIconColor: .black, offIconColor: .overrideColor)
 
     @IBOutlet var overrideButtonLabel: WKInterfaceLabel! {
         didSet {

--- a/WatchApp Extension/Controllers/ActionHUDController.swift
+++ b/WatchApp Extension/Controllers/ActionHUDController.swift
@@ -21,9 +21,9 @@ final class ActionHUDController: HUDInterfaceController {
     @IBOutlet var overrideButtonImage: WKInterfaceImage!
     @IBOutlet var overrideButtonBackground: WKInterfaceGroup!
 
-    private lazy var preMealButtonGroup = ButtonGroup(button: preMealButton, image: preMealButtonImage, background: preMealButtonBackground, onBackgroundColor: .carbsColor, offBackgroundColor: .darkCarbsColor, onIconColor: .black, offIconColor: .carbsColor)
+    private lazy var preMealButtonGroup = ButtonGroup(button: preMealButton, image: preMealButtonImage, background: preMealButtonBackground, onBackgroundColor: .carbsColor, offBackgroundColor: .darkCarbsColor, onIconColor: .darkCarbsColor, offIconColor: .carbsColor)
 
-    private lazy var overrideButtonGroup = ButtonGroup(button: overrideButton, image: overrideButtonImage, background: overrideButtonBackground, onBackgroundColor: .overrideColor, offBackgroundColor: .darkOverrideColor, onIconColor: .black, offIconColor: .overrideColor)
+    private lazy var overrideButtonGroup = ButtonGroup(button: overrideButton, image: overrideButtonImage, background: overrideButtonBackground, onBackgroundColor: .overrideColor, offBackgroundColor: .darkOverrideColor, onIconColor: .darkOverrideColor, offIconColor: .overrideColor)
 
     @IBOutlet var overrideButtonLabel: WKInterfaceLabel! {
         didSet {

--- a/WatchApp Extension/Extensions/ButtonGroup.swift
+++ b/WatchApp Extension/Extensions/ButtonGroup.swift
@@ -14,6 +14,8 @@ class ButtonGroup {
     private let background: WKInterfaceGroup
     private let onBackgroundColor: UIColor
     private let offBackgroundColor: UIColor
+    private let onIconColor: UIColor
+    private let offIconColor: UIColor
 
     enum State {
         case on
@@ -27,10 +29,10 @@ class ButtonGroup {
             let backgroundColor: UIColor
             switch state {
             case .on:
-                imageTintColor = .black
+                imageTintColor = onIconColor
                 backgroundColor = onBackgroundColor
             case .off:
-                imageTintColor = onBackgroundColor
+                imageTintColor = offIconColor
                 backgroundColor = offBackgroundColor
             case .disabled:
                 imageTintColor = .disabledButtonColor
@@ -43,12 +45,21 @@ class ButtonGroup {
         }
     }
 
-    init(button: WKInterfaceButton, image: WKInterfaceImage, background: WKInterfaceGroup, onBackgroundColor: UIColor, offBackgroundColor: UIColor) {
+    init(button: WKInterfaceButton,
+         image: WKInterfaceImage,
+         background: WKInterfaceGroup,
+         onBackgroundColor: UIColor,
+         offBackgroundColor: UIColor,
+         onIconColor: UIColor,
+         offIconColor: UIColor)
+    {
         self.button = button
         self.image = image
         self.background = background
         self.onBackgroundColor = onBackgroundColor
         self.offBackgroundColor = offBackgroundColor
+        self.onIconColor = onIconColor
+        self.offIconColor = offIconColor
     }
 
     func turnOff() {

--- a/WatchApp Extension/Extensions/ButtonGroup.swift
+++ b/WatchApp Extension/Extensions/ButtonGroup.swift
@@ -27,7 +27,7 @@ class ButtonGroup {
             let backgroundColor: UIColor
             switch state {
             case .on:
-                imageTintColor = offBackgroundColor
+                imageTintColor = .black
                 backgroundColor = onBackgroundColor
             case .off:
                 imageTintColor = onBackgroundColor


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1890

Both the `offBackgroundColor` and the `onBackgroundColor` are the same colour just the `off` has transparency. When laying `off` on top of `on`, you cannot see the icon. This changes just makes the icon colours configurable. The colours will be updated in the LoopWorkspace such that they look like a 20% alpha over black but actually have 100% alpha.

<img width="180" alt="Screen Shot 2020-09-04 at 11 57 16" src="https://user-images.githubusercontent.com/152359/92253369-caf09380-eea5-11ea-948b-270c78ef86f5.png">