### PR TITLE
Final cleanup of carb updates

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -402,6 +402,8 @@
 		A9CBE45A248ACBE1008E7BA2 /* DosingDecisionStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CBE459248ACBE1008E7BA2 /* DosingDecisionStore+SimulatedCoreData.swift */; };
 		A9CBE45C248ACC03008E7BA2 /* SettingsStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CBE45B248ACC03008E7BA2 /* SettingsStore+SimulatedCoreData.swift */; };
 		A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAE7CF2332D77F006AE942 /* LoopTests.swift */; };
+		A9DFAFB324F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFAFB224F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift */; };
+		A9DFAFB524F048A000950D1E /* WatchHistoricalCarbsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFAFB424F048A000950D1E /* WatchHistoricalCarbsTests.swift */; };
 		A9E6DFE6246A042E005B1A1C /* CarbStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E6DFE5246A042E005B1A1C /* CarbStoreTests.swift */; };
 		A9E6DFE8246A043D005B1A1C /* DoseStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E6DFE7246A043C005B1A1C /* DoseStoreTests.swift */; };
 		A9E6DFEA246A0448005B1A1C /* PumpManagerErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E6DFE9246A0448005B1A1C /* PumpManagerErrorTests.swift */; };
@@ -1188,6 +1190,8 @@
 		A9CBE459248ACBE1008E7BA2 /* DosingDecisionStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DosingDecisionStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A9CBE45B248ACC03008E7BA2 /* SettingsStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A9DAE7CF2332D77F006AE942 /* LoopTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoopTests.swift; sourceTree = "<group>"; };
+		A9DFAFB224F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbBackfillRequestUserInfoTests.swift; sourceTree = "<group>"; };
+		A9DFAFB424F048A000950D1E /* WatchHistoricalCarbsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHistoricalCarbsTests.swift; sourceTree = "<group>"; };
 		A9E6DFE5246A042E005B1A1C /* CarbStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbStoreTests.swift; sourceTree = "<group>"; };
 		A9E6DFE7246A043C005B1A1C /* DoseStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoseStoreTests.swift; sourceTree = "<group>"; };
 		A9E6DFE9246A0448005B1A1C /* PumpManagerErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpManagerErrorTests.swift; sourceTree = "<group>"; };
@@ -2216,7 +2220,9 @@
 		A9E6DFED246A0460005B1A1C /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				A9DFAFB224F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift */,
 				A9E6DFEE246A0474005B1A1C /* LoopErrorTests.swift */,
+				A9DFAFB424F048A000950D1E /* WatchHistoricalCarbsTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3438,8 +3444,10 @@
 			files = (
 				1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */,
 				A9A63F8E246B271600588D5B /* NSTimeInterval.swift in Sources */,
+				A9DFAFB324F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift in Sources */,
 				A9A63F8D246B261100588D5B /* DosingDecisionStoreTests.swift in Sources */,
 				A9E6DFEF246A0474005B1A1C /* LoopErrorTests.swift in Sources */,
+				A9DFAFB524F048A000950D1E /* WatchHistoricalCarbsTests.swift in Sources */,
 				A9E6DFEA246A0448005B1A1C /* PumpManagerErrorTests.swift in Sources */,
 				1DA7A84424477698008257F0 /* InAppModalAlertPresenterTests.swift in Sources */,
 				E93E86A824DDCC4400FF40C8 /* MockDoseStore.swift in Sources */,

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -50,10 +50,19 @@ extension StoredAlert {
     public var identifier: Alert.Identifier {
         return Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: alertIdentifier)
     }
-    
+
+    var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
+
+    func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }
+
+    public override func awakeFromInsert() {
+        super.awakeFromInsert()
+        updateModificationCounter()
+    }
+
     public override func willSave() {
-        if isInserted || isUpdated {
-            setPrimitiveValue(managedObjectContext!.modificationCounter ?? 0, forKey: "modificationCounter")
+        if isUpdated && !hasUpdatedModificationCounter {
+            updateModificationCounter()
         }
         super.willSave()
     }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -74,7 +74,7 @@ class AlertStoreTests: XCTestCase {
         XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier.value)
         XCTAssertEqual(true, object.isCritical)
         XCTAssertEqual(Self.historicDate, object.issuedDate)
-        XCTAssertEqual(0, object.modificationCounter)
+        XCTAssertEqual(1, object.modificationCounter)
         XCTAssertEqual("{\"sound\":{\"name\":\"soundName\"}}", object.sound)
         XCTAssertEqual(Alert.Trigger.immediate, object.trigger)
     }

--- a/LoopTests/Models/CarbBackfillRequestUserInfoTests.swift
+++ b/LoopTests/Models/CarbBackfillRequestUserInfoTests.swift
@@ -1,0 +1,72 @@
+//
+//  CarbBackfillRequestUserInfoTests.swift
+//  LoopTests
+//
+//  Created by Darin Krauss on 8/21/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+
+@testable import Loop
+
+class CarbBackfillRequestUserInfoTests: XCTestCase {
+    private lazy var startDate: Date = { Date(timeIntervalSinceReferenceDate: 0) }()
+    private lazy var rawValue: CarbBackfillRequestUserInfo.RawValue = {
+        return [
+            "v": 1,
+            "name": "CarbBackfillRequestUserInfo",
+            "sd": startDate,
+        ]
+    }()
+
+    func testDefaultInitializer() {
+        let info = CarbBackfillRequestUserInfo(startDate: self.startDate)
+        XCTAssertEqual(info.version, 1)
+        XCTAssertEqual(info.startDate, self.startDate)
+    }
+
+    func testRawValueInitializer() {
+        let info = CarbBackfillRequestUserInfo(rawValue: self.rawValue)
+        XCTAssertEqual(info?.version, 1)
+        XCTAssertEqual(info?.startDate, self.startDate)
+    }
+
+    func testRawValueInitializerMissingVersion() {
+        var rawValue = self.rawValue
+        rawValue["v"] = nil
+        XCTAssertNil(CarbBackfillRequestUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerInvalidVersion() {
+        var rawValue = self.rawValue
+        rawValue["v"] = 2
+        XCTAssertNil(CarbBackfillRequestUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerMissingName() {
+        var rawValue = self.rawValue
+        rawValue["name"] = nil
+        XCTAssertNil(CarbBackfillRequestUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerInvalidName() {
+        var rawValue = self.rawValue
+        rawValue["name"] = "Invalid"
+        XCTAssertNil(CarbBackfillRequestUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerMissingStartDate() {
+        var rawValue = self.rawValue
+        rawValue["sd"] = nil
+        XCTAssertNil(CarbBackfillRequestUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValue() {
+        let rawValue = CarbBackfillRequestUserInfo(startDate: self.startDate).rawValue
+        XCTAssertEqual(rawValue.count, 3)
+        XCTAssertEqual(rawValue["v"] as? Int, 1)
+        XCTAssertEqual(rawValue["name"] as? String, "CarbBackfillRequestUserInfo")
+        XCTAssertEqual(rawValue["sd"] as? Date, self.startDate)
+    }
+}

--- a/LoopTests/Models/WatchHistoricalCarbsTests.swift
+++ b/LoopTests/Models/WatchHistoricalCarbsTests.swift
@@ -1,0 +1,101 @@
+//
+//  WatchHistoricalCarbs.swift
+//  LoopTests
+//
+//  Created by Darin Krauss on 8/21/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import LoopKit
+
+@testable import Loop
+
+class WatchHistoricalCarbsTests: XCTestCase {
+    private lazy var objects: [SyncCarbObject] = {
+        return [SyncCarbObject(absorptionTime: .hours(5),
+                               createdByCurrentApp: true,
+                               foodType: "Pizza",
+                               grams: 45,
+                               startDate: Date(timeIntervalSinceReferenceDate: .hours(100)),
+                               uuid: UUID(),
+                               provenanceIdentifier: "com.loopkit.Loop",
+                               syncIdentifier: UUID().uuidString,
+                               syncVersion: 4,
+                               userCreatedDate: Date(timeIntervalSinceReferenceDate: .hours(98)),
+                               userUpdatedDate: Date(timeIntervalSinceReferenceDate: .hours(99)),
+                               userDeletedDate: nil,
+                               operation: .update,
+                               addedDate: Date(timeIntervalSinceReferenceDate: .hours(97)),
+                               supercededDate: nil),
+                SyncCarbObject(absorptionTime: .hours(3),
+                               createdByCurrentApp: false,
+                               foodType: "Pasta",
+                               grams: 25,
+                               startDate: Date(timeIntervalSinceReferenceDate: .hours(110)),
+                               uuid: UUID(),
+                               provenanceIdentifier: "com.abc.Example",
+                               syncIdentifier: UUID().uuidString,
+                               syncVersion: 1,
+                               userCreatedDate: Date(timeIntervalSinceReferenceDate: .hours(108)),
+                               userUpdatedDate: nil,
+                               userDeletedDate: nil,
+                               operation: .create,
+                               addedDate: Date(timeIntervalSinceReferenceDate: .hours(107)),
+                               supercededDate: nil),
+                SyncCarbObject(absorptionTime: .minutes(30),
+                               createdByCurrentApp: true,
+                               foodType: "Sugar",
+                               grams: 15,
+                               startDate: Date(timeIntervalSinceReferenceDate: .hours(120)),
+                               uuid: UUID(),
+                               provenanceIdentifier: "com.loopkit.Loop",
+                               syncIdentifier: UUID().uuidString,
+                               syncVersion: 1,
+                               userCreatedDate: Date(timeIntervalSinceReferenceDate: .hours(118)),
+                               userUpdatedDate: nil,
+                               userDeletedDate: nil,
+                               operation: .create,
+                               addedDate: Date(timeIntervalSinceReferenceDate: .hours(117)),
+                               supercededDate: nil)
+        ]
+    }()
+    private lazy var objectsEncoded: Data = {
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        return try! encoder.encode(self.objects)
+    }()
+    private lazy var rawValue: WatchHistoricalCarbs.RawValue = {
+        return [
+            "o": objectsEncoded
+        ]
+    }()
+
+    func testDefaultInitializer() {
+        let carbs = WatchHistoricalCarbs(objects: self.objects)
+        XCTAssertEqual(carbs.objects, self.objects)
+    }
+
+    func testRawValueInitializer() {
+        let carbs = WatchHistoricalCarbs(rawValue: self.rawValue)
+        XCTAssertEqual(carbs?.objects, self.objects)
+    }
+
+    func testRawValueInitializerMissingObjects() {
+        var rawValue = self.rawValue
+        rawValue["o"] = nil
+        XCTAssertNil(WatchHistoricalCarbs(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerInvalidObjects() {
+        var rawValue = self.rawValue
+        rawValue["o"] = Data()
+        XCTAssertNil(WatchHistoricalCarbs(rawValue: rawValue))
+    }
+
+    func testRawValue() {
+        let rawValue = WatchHistoricalCarbs(objects: self.objects).rawValue
+        XCTAssertEqual(rawValue.count, 1)
+        XCTAssertEqual(rawValue["o"] as? Data, self.objectsEncoded)
+    }
+}


### PR DESCRIPTION
- Fix modification counter and anchor key based upon insert and update order
- Add tests for new carb related code

Note: The next few PRs will be against the primary feature branch darinkrauss/LOOP-1417-capture-carbohydrate-entries.v2.ALL, not dev. My intention is to break the large overall feature into smaller, more easily reviewable PRs, and then merge the primary feature branch into dev after a final "summary" PR. (Several of the smaller PRs cannot be merged directly into dev because they would partially break existing functionality without a full replacement.)