### PR TITLE
Nate/feature/LOOP-232/specific y axis behaviour

### DIFF
--- a/Loop Status Extension/StatusChartsManager.swift
+++ b/Loop Status Extension/StatusChartsManager.swift
@@ -12,7 +12,8 @@ import SwiftCharts
 import UIKit
 
 class StatusChartsManager: ChartsManager {
-    let predictedGlucose = PredictedGlucoseChart(predictedGlucoseBounds: FeatureFlags.predictedGlucoseChartClampEnabled ? .default : nil)
+    let predictedGlucose = PredictedGlucoseChart(predictedGlucoseBounds: FeatureFlags.predictedGlucoseChartClampEnabled ? .default : nil,
+                                                 yAxisStepSizeMGDLOverride: FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil)
 
     init(colors: ChartColorPalette, settings: ChartSettings, traitCollection: UITraitCollection) {
         super.init(colors: colors, settings: settings, charts: [predictedGlucose], traitCollection: traitCollection)

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -58,7 +58,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             traitCollection: traitCollection
         )
 
-        charts.predictedGlucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 240)
+        let glucoseMGDLDisplayBound: (lower: Double, upper: Double) = FeatureFlags.predictedGlucoseChartClampEnabled ? (80, 240) : (100, 175)
+        charts.predictedGlucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: glucoseMGDLDisplayBound.lower)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: glucoseMGDLDisplayBound.upper)
 
         return charts
     }()

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -58,7 +58,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             traitCollection: traitCollection
         )
 
-        charts.predictedGlucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 160)
+        charts.predictedGlucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 240)
 
         return charts
     }()

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -58,7 +58,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             traitCollection: traitCollection
         )
 
-        charts.predictedGlucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 100)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 175)
+        charts.predictedGlucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 160)
 
         return charts
     }()

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -413,6 +413,7 @@
 		B405E35B24D2E05600DD058D /* HUDAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F2C15961E09E94E00E160D4 /* HUDAssets.xcassets */; };
 		B42C951424A3C76000857C73 /* CGMStatusHUDViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42C951324A3C76000857C73 /* CGMStatusHUDViewModel.swift */; };
 		B43DA44124D9C12100CAFF4E /* DismissibleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43DA44024D9C12100CAFF4E /* DismissibleHostingController.swift */; };
+		B47A791C2508009E006C0E11 /* ChartAxisValuesStaticGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47A791B2508009E006C0E11 /* ChartAxisValuesStaticGenerator.swift */; };
 		B48B0BAC24900093009A48DE /* PumpStatusHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48B0BAB24900093009A48DE /* PumpStatusHUDView.swift */; };
 		B490A03F24D0550F00F509FA /* GlucoseValueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B490A03E24D0550F00F509FA /* GlucoseValueType.swift */; };
 		B490A04124D0559D00F509FA /* DeviceLifecycleProgressState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B490A04024D0559D00F509FA /* DeviceLifecycleProgressState.swift */; };
@@ -1196,6 +1197,7 @@
 		B42C951324A3C76000857C73 /* CGMStatusHUDViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGMStatusHUDViewModel.swift; sourceTree = "<group>"; };
 		B42C951624A3CAF200857C73 /* NotificationsCriticalAlertPermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsCriticalAlertPermissionsViewModel.swift; sourceTree = "<group>"; };
 		B43DA44024D9C12100CAFF4E /* DismissibleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissibleHostingController.swift; sourceTree = "<group>"; };
+		B47A791B2508009E006C0E11 /* ChartAxisValuesStaticGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartAxisValuesStaticGenerator.swift; sourceTree = "<group>"; };
 		B48B0BAB24900093009A48DE /* PumpStatusHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpStatusHUDView.swift; sourceTree = "<group>"; };
 		B490A03C24D04F9400F509FA /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		B490A03E24D0550F00F509FA /* GlucoseValueType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseValueType.swift; sourceTree = "<group>"; };
@@ -1987,6 +1989,7 @@
 			children = (
 				A9C62D8D2331708700535612 /* AuthenticationTableViewCell+NibLoadable.swift */,
 				4F08DE801E7BB6F1006741EA /* CGPoint.swift */,
+				B47A791B2508009E006C0E11 /* ChartAxisValuesStaticGenerator.swift */,
 				438991661E91B563000EEF90 /* ChartPoint.swift */,
 				43649A621C7A347F00523D7F /* CollectionType.swift */,
 				B490A03C24D04F9400F509FA /* Color.swift */,
@@ -3480,6 +3483,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4FB76FB91E8C42B000B39636 /* CollectionType.swift in Sources */,
+				B47A791C2508009E006C0E11 /* ChartAxisValuesStaticGenerator.swift in Sources */,
 				7D23667D21250C7E0028B67D /* LocalizedString.swift in Sources */,
 				43FCEEBD22212DD50013DD30 /* PredictedGlucoseChart.swift in Sources */,
 				436961911F19D11E00447E89 /* ChartPointsContextFillLayer.swift in Sources */,

--- a/Loop/Managers/StatusChartsManager.swift
+++ b/Loop/Managers/StatusChartsManager.swift
@@ -26,7 +26,8 @@ class StatusChartsManager: ChartsManager {
     let cob: COBChart
 
     init(colors: ChartColorPalette, settings: ChartSettings, traitCollection: UITraitCollection) {
-        let glucose = PredictedGlucoseChart(predictedGlucoseBounds: FeatureFlags.predictedGlucoseChartClampEnabled ? .default : nil)
+        let glucose = PredictedGlucoseChart(predictedGlucoseBounds: FeatureFlags.predictedGlucoseChartClampEnabled ? .default : nil,
+                                            yAxisStepSizeMGDLOverride: FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil)
         let iob = IOBChart()
         let dose = DoseChart()
         let cob = COBChart()

--- a/Loop/View Controllers/PredictionTableViewController.swift
+++ b/Loop/View Controllers/PredictionTableViewController.swift
@@ -94,7 +94,7 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         }
     }
 
-    let glucoseChart = PredictedGlucoseChart(predictedGlucoseBounds: nil)
+    let glucoseChart = PredictedGlucoseChart()
 
     override func createChartsManager() -> ChartsManager {
         return ChartsManager(colors: .primary, settings: .default, charts: [glucoseChart], traitCollection: traitCollection)

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -35,7 +35,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        statusCharts.glucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 100)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 175)
+        statusCharts.glucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 160)
 
         registerPumpManager()
 

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -35,7 +35,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        statusCharts.glucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 40)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 160)
+        statusCharts.glucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 240)
 
         registerPumpManager()
 

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -35,7 +35,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        statusCharts.glucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 80)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 240)
+        let glucoseMGDLDisplayBound: (lower: Double, upper: Double) = FeatureFlags.predictedGlucoseChartClampEnabled ? (80, 240) : (100, 175)
+        statusCharts.glucose.glucoseDisplayRange = HKQuantity(unit: .milligramsPerDeciliter, doubleValue: glucoseMGDLDisplayBound.lower)...HKQuantity(unit: .milligramsPerDeciliter, doubleValue: glucoseMGDLDisplayBound.upper)
 
         registerPumpManager()
 

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -79,7 +79,8 @@ final class BolusEntryViewModel: ObservableObject {
     }
     
     let chartManager: ChartsManager = {
-        let predictedGlucoseChart = PredictedGlucoseChart(predictedGlucoseBounds: FeatureFlags.predictedGlucoseChartClampEnabled ? .default : nil)
+        let predictedGlucoseChart = PredictedGlucoseChart(predictedGlucoseBounds: FeatureFlags.predictedGlucoseChartClampEnabled ? .default : nil,
+                                                          yAxisStepSizeMGDLOverride: FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil)
         predictedGlucoseChart.glucoseDisplayRange = BolusEntryViewModel.defaultGlucoseDisplayRange
         return ChartsManager(colors: .primary, settings: .default, charts: [predictedGlucoseChart], traitCollection: .current)
     }()

--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -68,7 +68,16 @@ public class PredictedGlucoseChart: GlucoseChart, ChartProviding {
     public private(set) var endDate: Date?
 
     private var predictedGlucoseSoftBounds: PredictedGlucoseBounds?
-
+    
+    private var maxYAxisValue: ChartAxisValue?
+    
+    private var minYAxisValue: ChartAxisValue?
+    
+    private var maxYAxisSegmentCount: Double {
+        // when a glucose value is below the predicted glucose minimum soft bound, allow for more y-axis segments
+        return glucoseValueBelowSoftBoundsMinimum() ? 5 : 4
+    }
+    
     private func updateEndDate(_ date: Date) {
         if endDate == nil || date > endDate! {
             self.endDate = date
@@ -131,16 +140,19 @@ extension PredictedGlucoseChart {
             glucoseDisplayRangePoints
         ].flatMap { $0 }
 
-        let yAxisValues = ChartAxisValuesStaticGenerator.generateYAxisValuesWithChartPoints(points,
+        let yAxisValues = ChartAxisValuesStaticGenerator.generateYAxisValuesUsingLinearSegmentStep(chartPoints: points,
             minSegmentCount: 2,
-            maxSegmentCount: 4,
-            multiple: glucoseUnit.chartableIncrement * 25,
+            maxSegmentCount: maxYAxisSegmentCount,
+            multiple: glucoseUnit == .milligramsPerDeciliter ? 40 : 1,
             axisValueGenerator: {
                 ChartAxisValueDouble($0, labelSettings: axisLabelSettings)
             },
             addPaddingSegmentIfEdge: false
         )
 
+        minYAxisValue = yAxisValues.first
+        maxYAxisValue = yAxisValues.last
+        
         let yAxisModel = ChartAxisModel(axisValues: yAxisValues, lineColor: colors.axisLine, labelSpaceReservationMode: .fixed(labelsWidthY))
 
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: frame, xModel: xAxisModel, yModel: yAxisModel)
@@ -265,17 +277,31 @@ extension PredictedGlucoseChart {
 
 // MARK: - Clamping the predicted glucose values
 extension PredictedGlucoseChart {
-    var chartedGlucoseValueMaximum: HKQuantity? {
+    var chartMaximumValue: HKQuantity? {
         guard let glucosePointMaximum = glucosePoints.max(by: { point1, point2 in point1.y.scalar < point2.y.scalar }) else {
             return nil
         }
+        
+        if let maxYAxisValue = maxYAxisValue,
+            maxYAxisValue.scalar > glucosePointMaximum.y.scalar
+        {
+            return HKQuantity(unit: glucoseUnit, doubleValue: maxYAxisValue.scalar)
+        }
+        
         return HKQuantity(unit: glucoseUnit, doubleValue: glucosePointMaximum.y.scalar)
     }
-    
-    var chartedGlucoseValueMinimum: HKQuantity? {
+        
+    var chartMinimumValue: HKQuantity? {
         guard let glucosePointMinimum = glucosePoints.min(by: { point1, point2 in point1.y.scalar < point2.y.scalar }) else {
             return nil
         }
+        
+        if let minYAxisValue = minYAxisValue,
+            minYAxisValue.scalar < glucosePointMinimum.y.scalar
+        {
+            return HKQuantity(unit: glucoseUnit, doubleValue: minYAxisValue.scalar)
+        }
+        
         return HKQuantity(unit: glucoseUnit, doubleValue: glucosePointMinimum.y.scalar)
     }
     
@@ -284,9 +310,9 @@ extension PredictedGlucoseChart {
             return glucoseValues
         }
         
-        let predictedGlucoseValueMaximum = chartedGlucoseValueMaximum != nil ? max(predictedGlucoseBounds.maximum, chartedGlucoseValueMaximum!) : predictedGlucoseBounds.maximum
+        let predictedGlucoseValueMaximum = chartMaximumValue != nil ? max(predictedGlucoseBounds.maximum, chartMaximumValue!) : predictedGlucoseBounds.maximum
         
-        let predictedGlucoseValueMinimum = chartedGlucoseValueMinimum != nil ? min(predictedGlucoseBounds.minimum, chartedGlucoseValueMinimum!) : predictedGlucoseBounds.minimum
+        let predictedGlucoseValueMinimum = chartMinimumValue != nil ? min(predictedGlucoseBounds.minimum, chartMinimumValue!) : predictedGlucoseBounds.minimum
         
         return glucoseValues.map {
             if $0.quantity > predictedGlucoseValueMaximum {
@@ -297,6 +323,24 @@ extension PredictedGlucoseChart {
                 return $0
             }
         }
+    }
+    
+    var chartedGlucoseValueMinimum: HKQuantity? {
+        guard let glucosePointMinimum = glucosePoints.min(by: { point1, point2 in point1.y.scalar < point2.y.scalar }) else {
+            return nil
+        }
+        
+        return HKQuantity(unit: glucoseUnit, doubleValue: glucosePointMinimum.y.scalar)
+    }
+    
+    func glucoseValueBelowSoftBoundsMinimum() -> Bool {
+        guard let predictedGlucoseSoftBounds = predictedGlucoseSoftBounds,
+            let chartedGlucoseValueMinimum = chartedGlucoseValueMinimum else
+        {
+            return false
+        }
+            
+        return chartedGlucoseValueMinimum < predictedGlucoseSoftBounds.minimum
     }
     
     public struct PredictedGlucoseBounds {

--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -69,6 +69,8 @@ public class PredictedGlucoseChart: GlucoseChart, ChartProviding {
 
     private var predictedGlucoseSoftBounds: PredictedGlucoseBounds?
     
+    private let yAxisStepSizeMGDLOverride: Double?
+    
     private var maxYAxisValue: ChartAxisValue?
     
     private var minYAxisValue: ChartAxisValue?
@@ -84,8 +86,10 @@ public class PredictedGlucoseChart: GlucoseChart, ChartProviding {
         }
     }
     
-    public init(predictedGlucoseBounds: PredictedGlucoseBounds?) {
+    public init(predictedGlucoseBounds: PredictedGlucoseBounds? = nil,
+                yAxisStepSizeMGDLOverride: Double? = nil) {
         self.predictedGlucoseSoftBounds = predictedGlucoseBounds
+        self.yAxisStepSizeMGDLOverride = yAxisStepSizeMGDLOverride
         super.init()
     }
 }
@@ -143,7 +147,7 @@ extension PredictedGlucoseChart {
         let yAxisValues = ChartAxisValuesStaticGenerator.generateYAxisValuesUsingLinearSegmentStep(chartPoints: points,
             minSegmentCount: 2,
             maxSegmentCount: maxYAxisSegmentCount,
-            multiple: glucoseUnit == .milligramsPerDeciliter ? 40 : 1,
+            multiple: glucoseUnit == .milligramsPerDeciliter ? (yAxisStepSizeMGDLOverride ?? 25) : 1,
             axisValueGenerator: {
                 ChartAxisValueDouble($0, labelSettings: axisLabelSettings)
             },

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -1,0 +1,87 @@
+//
+//  ChartAxisValuesStaticGenerator.swift
+//  LoopUI
+//
+//  Created by Nathaniel Hamming on 2020-09-08.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import SwiftCharts
+
+extension ChartAxisValuesStaticGenerator {
+    // This is the same as SwiftChart ChartAxisValuesStaticGenerator.generateAxisValuesWithChartPoints(...) with the exception that the `currentMultiple` is calculated linearly instead of quadratically
+    static func generateYAxisValuesUsingLinearSegmentStep(chartPoints: [ChartPoint],
+                                                          minSegmentCount: Double,
+                                                          maxSegmentCount: Double,
+                                                          multiple: Double,
+                                                          axisValueGenerator: ChartAxisValueStaticGenerator,
+                                                          addPaddingSegmentIfEdge: Bool) -> [ChartAxisValue]
+    {
+        precondition(multiple > 0, "Invalid multiple: \(multiple)")
+        
+        let sortedChartPoints = chartPoints.sorted {(obj1, obj2) in
+            return obj1.y.scalar < obj2.y.scalar
+        }
+        
+        if let firstChartPoint = sortedChartPoints.first, let lastChartPoint = sortedChartPoints.last {
+            let first = firstChartPoint.y.scalar
+            let lastPar = lastChartPoint.y.scalar
+            
+            guard lastPar >=~ first else {fatalError("Invalid range generating axis values")}
+            
+            let last = lastPar =~ first ? lastPar + 1 : lastPar
+            
+            /// The first axis value will be less than or equal to the first scalar value, aligned with the desired multiple
+            var firstValue = first - (first.truncatingRemainder(dividingBy: multiple))
+            /// The last axis value will be greater than or equal to the first scalar value, aligned with the desired multiple
+            var lastValue = last + (abs(multiple - last).truncatingRemainder(dividingBy: multiple))
+            var segmentSize = multiple
+            
+            /// If there should be a padding segment added when a scalar value falls on the first or last axis value, adjust the first and last axis values
+            if firstValue =~ first && addPaddingSegmentIfEdge {
+                firstValue = firstValue - segmentSize
+            }
+            if lastValue =~ last && addPaddingSegmentIfEdge {
+                lastValue = lastValue + segmentSize
+            }
+            
+            let distance = lastValue - firstValue
+            var currentMultiple = multiple
+            var segmentCount = distance / currentMultiple
+            
+            /// Find the optimal number of segments and segment width
+            
+            /// If the number of segments is greater than desired, make each segment wider
+            while segmentCount > maxSegmentCount {
+                // This is the only difference from SwiftCharts (i.e., currentMultiple *= multiple)
+                currentMultiple += multiple
+                segmentCount = distance / currentMultiple
+            }
+            segmentCount = ceil(segmentCount)
+            
+            /// Increase the number of segments until there are enough as desired
+            while segmentCount < minSegmentCount {
+                segmentCount += 1
+            }
+            segmentSize = currentMultiple
+            
+            /// Generate axis values from the first value, segment size and number of segments
+            let offset = firstValue
+            return (0...Int(segmentCount)).map {segment in
+                let scalar = offset + (Double(segment) * segmentSize)
+                return axisValueGenerator(scalar)
+            }
+        } else {
+            print("Trying to generate Y axis without datapoints, returning empty array")
+            return []
+        }
+    }
+}
+
+fileprivate func =~ (a: Double, b: Double) -> Bool {
+    return fabs(a - b) < Double.ulpOfOne
+}
+
+fileprivate func >=~ (a: Double, b: Double) -> Bool {
+    return a =~ b || a > b
+}

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -53,7 +53,7 @@ extension ChartAxisValuesStaticGenerator {
             
             /// If the number of segments is greater than desired, make each segment wider
             while segmentCount > maxSegmentCount {
-                // This is the only difference from SwiftCharts (i.e., currentMultiple *= multiple)
+                // This is the only difference from SwiftCharts (i.e., currentMultiple *= 2)
                 currentMultiple += multiple
                 segmentCount = distance / currentMultiple
             }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-232

This provides specific y-axis behaviour as defined in `1.` in the ticket.

@ps2 Please note that the extension to `ChartAxisValuesStaticGenerator` was added since I didn't find a way to override `fileprivate static func generateAxisValuesWithChartPoints(...)`. This is an alternative to pointing at a `SwiftCharts` fork, which I'm not against and happy to do if that is preferred. 

The only difference from `SwiftChart` are lines `56-57`:
```
// This is the only difference from SwiftCharts (i.e., currentMultiple *= 2)
currentMultiple += multiple
```

@ps2 Also, let me know if any of these changes should be blocked from DIY builds (i.e., change in the glucose chart default y-axis from 100 - 175 to 80 - 240, change in the base segment step size from 25 to 40, using a linear growth to the segment step size instead of quadratic growth)