### PR TITLE
LOOP-XXXX: Changes pumpSupportedIncrements and syncPumpSchedule to getters

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1253,10 +1253,15 @@ final class StatusTableViewController: LoopChartsTableViewController {
             didTapAddDevice: { [weak self] in
                 self?.setupCGMManager($0.identifier)
         })
-        let pumpSupportedIncrements = deviceManager.pumpManager.map {
-            PumpSupportedIncrements(basalRates: $0.supportedBasalRates,
-                                    bolusVolumes: $0.supportedBolusVolumes,
-                                    maximumBasalScheduleEntryCount: $0.maximumBasalScheduleEntryCount)
+        let pumpSupportedIncrements = { [weak self] in
+            self?.deviceManager.pumpManager.map {
+                PumpSupportedIncrements(basalRates: $0.supportedBasalRates,
+                                        bolusVolumes: $0.supportedBolusVolumes,
+                                        maximumBasalScheduleEntryCount: $0.maximumBasalScheduleEntryCount)
+            }
+        }
+        let syncBasalRateSchedule = { [weak self] in
+            self?.deviceManager.pumpManager?.syncBasalRateSchedule
         }
         let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: { [weak self] in self?.deviceManager.servicesManager.availableServices ?? [] },
@@ -1270,7 +1275,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           therapySettings: deviceManager.loopManager.therapySettings,
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
-                                          syncPumpSchedule: deviceManager.pumpManager?.syncBasalRateSchedule,
+                                          syncPumpSchedule: syncBasalRateSchedule,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
                                           delegate: self

--- a/Loop/Views/SettingsViewModel.swift
+++ b/Loop/Views/SettingsViewModel.swift
@@ -81,8 +81,8 @@ public class SettingsViewModel: ObservableObject {
     var servicesViewModel: ServicesViewModel
     var therapySettings: TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
-    let pumpSupportedIncrements: PumpSupportedIncrements?
-    let syncPumpSchedule: PumpManager.SyncSchedule?
+    let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
+    let syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?
     let sensitivityOverridesEnabled: Bool
 
     lazy private var cancellables = Set<AnyCancellable>()
@@ -94,8 +94,8 @@ public class SettingsViewModel: ObservableObject {
                 servicesViewModel: ServicesViewModel,
                 therapySettings: TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
-                pumpSupportedIncrements: PumpSupportedIncrements?,
-                syncPumpSchedule: PumpManager.SyncSchedule?,
+                pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
+                syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 delegate: SettingsViewModelDelegate?


### PR DESCRIPTION
Instead of passing in `pumpSupportedIncrements` and `syncPumpSchedule` once upon creation of a `TherapySettingsViewModel`, pass in "getters" instead.

(Side note: this has been a common refrain for solving "refresh" problems...)

See also https://github.com/tidepool-org/LoopKit/pull/241 