### PR TITLE
LOOP-1935: Fix duplicate health carb data

### DIFF
--- a/WatchApp Extension/Managers/LoopDataManager.swift
+++ b/WatchApp Extension/Managers/LoopDataManager.swift
@@ -98,17 +98,6 @@ extension LoopDataManager {
         }
     }
 
-    func addConfirmedCarbEntry(_ entry: NewCarbEntry) {
-        carbStore.addCarbEntry(entry) { (result) in
-            switch result {
-            case .success:
-                break
-            case .failure(let error):
-                self.log.error("Error adding entry to carbStore: %{public}@", String(describing: error))
-            }
-        }
-    }
-
     func sendDidUpdateContextNotificationIfNecessary() {
         dispatchPrecondition(condition: .onQueue(.main))
 

--- a/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
+++ b/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
@@ -212,8 +212,6 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
 
                         let loopManager = ExtensionDelegate.shared().loopManager
                         if let carbEntry = bolus.carbEntry {
-                            loopManager.addConfirmedCarbEntry(carbEntry)
-
                             if bolus.value == 0 {
                                 // Notify for a successful carb entry (sans bolus)
                                 WKInterfaceDevice.current().play(.success)


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1935
- Do not enter carbs directly into HealthKit from watch

Note: Carbs entered on the watch are send directly to the phone where they are stored in both Core Data and then HealthKit. The code removed was leftover from the previous incarnation when carb data was stored in HealthKit and then Core Data.