### PR TITLE
Nate/fix/LOOP-1962/chart update when active

### DIFF
--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -121,17 +121,16 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
         let size = currentContext.newSize ?? self.tableView.bounds.size
         let availableWidth = size.width - self.charts.fixedHorizontalMargin
         let totalHours = floor(Double(availableWidth / minimumSegmentWidth))
-        let pastHours = totalHours - 1 // keep 1 hour for presenting current data and looking into the future
 
         var components = DateComponents()
         components.minute = 0
-        let date = Date(timeIntervalSinceNow: -TimeInterval(hours: max(1, pastHours)))
+        let date = Date(timeIntervalSinceNow: -TimeInterval(hours: max(1, totalHours)))
         let chartStartDate = Calendar.current.nextDate(after: date, matching: components, matchingPolicy: .strict, direction: .backward) ?? date
         if charts.startDate != chartStartDate {
             currentContext.formUnion(RefreshContext.all)
         }
         charts.startDate = chartStartDate
-        charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours)))
+        charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours+1))) // allow 1 hour for presenting current data and looking into the future
 
         let midnight = Calendar.current.startOfDay(for: Date())
         let listStart = min(midnight, chartStartDate, Date(timeIntervalSinceNow: -deviceManager.carbStore.maximumAbsorptionTimeInterval))

--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -130,7 +130,7 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
             currentContext.formUnion(RefreshContext.all)
         }
         charts.startDate = chartStartDate
-        charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours+1))) // allow 1 hour for presenting current data and looking into the future
+        charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours+1))) // When there is no data, this allows presenting current hour + 1
 
         let midnight = Calendar.current.startOfDay(for: Date())
         let listStart = min(midnight, chartStartDate, Date(timeIntervalSinceNow: -deviceManager.carbStore.maximumAbsorptionTimeInterval))

--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -121,15 +121,17 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
         let size = currentContext.newSize ?? self.tableView.bounds.size
         let availableWidth = size.width - self.charts.fixedHorizontalMargin
         let totalHours = floor(Double(availableWidth / minimumSegmentWidth))
+        let pastHours = totalHours - 1 // keep 1 hour for presenting current data and looking into the future
 
         var components = DateComponents()
         components.minute = 0
-        let date = Date(timeIntervalSinceNow: -TimeInterval(hours: max(1, totalHours)))
+        let date = Date(timeIntervalSinceNow: -TimeInterval(hours: max(1, pastHours)))
         let chartStartDate = Calendar.current.nextDate(after: date, matching: components, matchingPolicy: .strict, direction: .backward) ?? date
         if charts.startDate != chartStartDate {
             currentContext.formUnion(RefreshContext.all)
         }
         charts.startDate = chartStartDate
+        charts.updateEndDate(chartStartDate.addingTimeInterval(.hours(totalHours)))
 
         let midnight = Calendar.current.startOfDay(for: Date())
         let listStart = min(midnight, chartStartDate, Date(timeIntervalSinceNow: -deviceManager.carbStore.maximumAbsorptionTimeInterval))

--- a/Loop/View Controllers/PredictionTableViewController.swift
+++ b/Loop/View Controllers/PredictionTableViewController.swift
@@ -94,7 +94,7 @@ class PredictionTableViewController: LoopChartsTableViewController, Identifiable
         }
     }
 
-    let glucoseChart = PredictedGlucoseChart()
+    let glucoseChart = PredictedGlucoseChart(yAxisStepSizeMGDLOverride: FeatureFlags.predictedGlucoseChartClampEnabled ? 40 : nil)
 
     override func createChartsManager() -> ChartsManager {
         return ChartsManager(colors: .primary, settings: .default, charts: [glucoseChart], traitCollection: traitCollection)

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -103,7 +103,7 @@ final class BolusEntryViewModel: ObservableObject {
         self.originalCarbEntry = originalCarbEntry
         self.potentialCarbEntry = potentialCarbEntry
         self.selectedCarbAbsorptionTimeEmoji = selectedCarbAbsorptionTimeEmoji
-        
+
         observeLoopUpdates()
         observeEnteredBolusChanges()
         observeEnteredManualGlucoseChanges()

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -103,12 +103,6 @@ final class BolusEntryViewModel: ObservableObject {
         self.originalCarbEntry = originalCarbEntry
         self.potentialCarbEntry = potentialCarbEntry
         self.selectedCarbAbsorptionTimeEmoji = selectedCarbAbsorptionTimeEmoji
-
-        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.updateChartDateInterval()
-            }
-        }
         
         observeLoopUpdates()
         observeEnteredBolusChanges()

--- a/Loop/View Models/BolusEntryViewModel.swift
+++ b/Loop/View Models/BolusEntryViewModel.swift
@@ -104,6 +104,12 @@ final class BolusEntryViewModel: ObservableObject {
         self.potentialCarbEntry = potentialCarbEntry
         self.selectedCarbAbsorptionTimeEmoji = selectedCarbAbsorptionTimeEmoji
 
+        NotificationCenter.default.addObserver(forName: UIApplication.didBecomeActiveNotification, object: nil, queue: nil) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.updateChartDateInterval()
+            }
+        }
+        
         observeLoopUpdates()
         observeEnteredBolusChanges()
         observeEnteredManualGlucoseChanges()


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1962

includes:
- default state of the carb absorption chart shows up to 1 hour into the future. 
- tap through chart for the glucose chart should have the same segment step size
