### PR TITLE
Add navigation arrows back to settings

### DIFF
--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -94,7 +94,7 @@ extension SettingsView {
     private var therapySettingsSection: some View {
         Section(header: SectionHeader(label: NSLocalizedString("Configuration", comment: "The title of the Configuration section in settings"))) {
             LargeButton(action: { self.therapySettingsIsPresented = true },
-                            includeArrow: false,
+                            includeArrow: true,
                             imageView: AnyView(Image("Therapy Icon")),
                             label: NSLocalizedString("Therapy Settings", comment: "Title text for button to Therapy Settings"),
                             descriptiveText: NSLocalizedString("Diabetes Treatment", comment: "Descriptive text for Therapy Settings"))
@@ -128,7 +128,7 @@ extension SettingsView {
     private var pumpSection: some View {
         if viewModel.pumpManagerSettingsViewModel.isSetUp() {
             LargeButton(action: self.viewModel.pumpManagerSettingsViewModel.didTap,
-                        includeArrow: false,
+                        includeArrow: true,
                         imageView: deviceImage(uiImage: viewModel.pumpManagerSettingsViewModel.image()),
                         label: viewModel.pumpManagerSettingsViewModel.name(),
                         descriptiveText: NSLocalizedString("Insulin Pump", comment: "Descriptive text for Insulin Pump"))
@@ -158,7 +158,7 @@ extension SettingsView {
     private var cgmSection: some View {
         if viewModel.cgmManagerSettingsViewModel.isSetUp() {
             LargeButton(action: self.viewModel.cgmManagerSettingsViewModel.didTap,
-                        includeArrow: false,
+                        includeArrow: true,
                         imageView: deviceImage(uiImage: viewModel.cgmManagerSettingsViewModel.image()),
                         label: viewModel.cgmManagerSettingsViewModel.name(),
                         descriptiveText: NSLocalizedString("Continuous Glucose Monitor", comment: "Descriptive text for Continuous Glucose Monitor"))
@@ -188,7 +188,7 @@ extension SettingsView {
         Section(header: SectionHeader(label: NSLocalizedString("Accounts", comment: "The title of the accounts section in settings"))) {
             ForEach(viewModel.servicesViewModel.activeServices().indices, id: \.self) { index in
                 LargeButton(action: { self.viewModel.servicesViewModel.didTapService(index) },
-                            includeArrow: false,
+                            includeArrow: true,
                             imageView: self.serviceImage(uiImage: (self.viewModel.servicesViewModel.activeServices()[index] as! ServiceUI).image),
                             label: self.viewModel.servicesViewModel.activeServices()[index].localizedTitle,
                             descriptiveText: "")


### PR DESCRIPTION
to:
- Therapy Settings
- Pump section
- CGM section
- Services section

... but not for the case where they are in "add" mode