### PR TITLE
[LOOP1992] Do not allow a value of -0 on the y-axis (dosing chart)

### DIFF
--- a/LoopUI/Charts/DoseChart.swift
+++ b/LoopUI/Charts/DoseChart.swift
@@ -65,8 +65,14 @@ public extension DoseChart {
         
         let points = generateDosePoints(startDate: startDate)
 
-        let yAxisValues = ChartAxisValuesStaticGenerator.generateYAxisValuesWithChartPoints(points.basal + points.bolus + doseDisplayRangePoints, minSegmentCount: 2, maxSegmentCount: 3, multiple: log(2) / 2, axisValueGenerator: { ChartAxisValueDoubleLog(screenLocDouble: $0, formatter: integerFormatter, labelSettings: axisLabelSettings) }, addPaddingSegmentIfEdge: true)
-
+        let yAxisValues = ChartAxisValuesStaticGenerator.generateYAxisValuesUsingLinearSegmentStep(
+            chartPoints: points.basal + points.bolus + doseDisplayRangePoints,
+            minSegmentCount: 2,
+            maxSegmentCount: 3,
+            multiple: log(2) / 2,
+            axisValueGenerator: { ChartAxisValueDoubleLog(screenLocDouble: $0, formatter: integerFormatter, labelSettings: axisLabelSettings) },
+            addPaddingSegmentIfEdge: true)
+        
         let yAxisModel = ChartAxisModel(axisValues: yAxisValues, lineColor: colors.axisLine, labelSpaceReservationMode: .fixed(labelsWidthY))
 
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: frame, xModel: xAxisModel, yModel: yAxisModel)

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -40,7 +40,10 @@ extension ChartAxisValuesStaticGenerator {
             
             /// If there should be a padding segment added when a scalar value falls on the first or last axis value, adjust the first and last axis values
             if firstValue =~ first && addPaddingSegmentIfEdge {
-                firstValue = firstValue - segmentSize
+                // do not allow a value of -0 on the axis
+                repeat {
+                    firstValue = firstValue - segmentSize
+                } while firstValue < 0 && firstValue.rounded() == -0
             }
             if lastValue =~ last && addPaddingSegmentIfEdge {
                 lastValue = lastValue + segmentSize

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -40,11 +40,14 @@ extension ChartAxisValuesStaticGenerator {
             
             /// If there should be a padding segment added when a scalar value falls on the first or last axis value, adjust the first and last axis values
             if firstValue =~ first && addPaddingSegmentIfEdge {
-                // do not allow a value of -0 on the axis
-                repeat {
-                    firstValue = firstValue - segmentSize
-                } while firstValue < 0 && firstValue.rounded() == -0
+               firstValue = firstValue - segmentSize
             }
+            
+            // do not allow a value of -0 on the axis
+            while firstValue < 0 && firstValue.rounded() == -0 {
+                firstValue = firstValue - segmentSize
+            }
+            
             if lastValue =~ last && addPaddingSegmentIfEdge {
                 lastValue = lastValue + segmentSize
             }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1992

do not allow a value of -0 on the y-axis

@ps2 I only added you for review, since I believe you have the most knowledge of the charts. My testing shows that this works as expected, but I need your keen eyes and knowledge to ensure it wouldn't cause any additional issue.

Note that I'm using the extension to the `ChartAxisValuesStaticGenerator` that was made for the glucose chart.