### PR TITLE
LOOP-1146 Capture recommended bolus with actual user-entered bolus

### DIFF
--- a/Common/Models/SetBolusUserInfo.swift
+++ b/Common/Models/SetBolusUserInfo.swift
@@ -13,6 +13,7 @@ import LoopKit
 struct SetBolusUserInfo {
     let value: Double
     let startDate: Date
+    let contextDate: Date?
     let carbEntry: NewCarbEntry?
 }
 
@@ -34,6 +35,7 @@ extension SetBolusUserInfo: RawRepresentable {
 
         self.value = value
         self.startDate = startDate
+        self.contextDate = rawValue["cd"] as? Date
         self.carbEntry = (rawValue["ce"] as? NewCarbEntry.RawValue).flatMap(NewCarbEntry.init(rawValue:))
     }
 
@@ -45,9 +47,8 @@ extension SetBolusUserInfo: RawRepresentable {
             "sd": startDate
         ]
 
-        if let carbEntry = carbEntry {
-            raw["ce"] = carbEntry.rawValue
-        }
+        raw["cd"] = contextDate
+        raw["ce"] = carbEntry?.rawValue
 
         return raw
     }

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		A9347F3124E7521800C99C34 /* CarbBackfillRequestUserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9347F3024E7521800C99C34 /* CarbBackfillRequestUserInfo.swift */; };
 		A9347F3224E7522400C99C34 /* CarbBackfillRequestUserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9347F3024E7521800C99C34 /* CarbBackfillRequestUserInfo.swift */; };
 		A9347F3324E7522900C99C34 /* WatchHistoricalCarbs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9347F2E24E7508A00C99C34 /* WatchHistoricalCarbs.swift */; };
+		A963B27A252CEBAE0062AA12 /* SetBolusUserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A963B279252CEBAE0062AA12 /* SetBolusUserInfoTests.swift */; };
 		A966152623EA5A26005D8B29 /* DefaultAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152423EA5A25005D8B29 /* DefaultAssets.xcassets */; };
 		A966152723EA5A26005D8B29 /* DerivedAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152523EA5A25005D8B29 /* DerivedAssets.xcassets */; };
 		A966152A23EA5A37005D8B29 /* DefaultAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152823EA5A37005D8B29 /* DefaultAssets.xcassets */; };
@@ -418,6 +419,7 @@
 		A9F703732489BC8500C98AD8 /* CarbStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F703722489BC8500C98AD8 /* CarbStore+SimulatedCoreData.swift */; };
 		A9F703752489C9A000C98AD8 /* GlucoseStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F703742489C9A000C98AD8 /* GlucoseStore+SimulatedCoreData.swift */; };
 		A9F703772489D8AA00C98AD8 /* PersistentDeviceLog+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F703762489D8AA00C98AD8 /* PersistentDeviceLog+SimulatedCoreData.swift */; };
+		A9FB75F1252BE320004C7D3F /* BolusDosingDecision.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FB75F0252BE320004C7D3F /* BolusDosingDecision.swift */; };
 		B405E35924D2A75B00DD058D /* DerivedAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A966152923EA5A37005D8B29 /* DerivedAssets.xcassets */; };
 		B405E35A24D2B1A400DD058D /* HUDAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F2C15961E09E94E00E160D4 /* HUDAssets.xcassets */; };
 		B405E35B24D2E05600DD058D /* HUDAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4F2C15961E09E94E00E160D4 /* HUDAssets.xcassets */; };
@@ -1239,6 +1241,7 @@
 		A9347F2E24E7508A00C99C34 /* WatchHistoricalCarbs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHistoricalCarbs.swift; sourceTree = "<group>"; };
 		A9347F3024E7521800C99C34 /* CarbBackfillRequestUserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbBackfillRequestUserInfo.swift; sourceTree = "<group>"; };
 		A951C5FF23E8AB51003E26DC /* Version.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		A963B279252CEBAE0062AA12 /* SetBolusUserInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetBolusUserInfoTests.swift; sourceTree = "<group>"; };
 		A966152423EA5A25005D8B29 /* DefaultAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DefaultAssets.xcassets; sourceTree = "<group>"; };
 		A966152523EA5A25005D8B29 /* DerivedAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DerivedAssets.xcassets; sourceTree = "<group>"; };
 		A966152823EA5A37005D8B29 /* DefaultAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = DefaultAssets.xcassets; sourceTree = "<group>"; };
@@ -1278,6 +1281,7 @@
 		A9F703722489BC8500C98AD8 /* CarbStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarbStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A9F703742489C9A000C98AD8 /* GlucoseStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GlucoseStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A9F703762489D8AA00C98AD8 /* PersistentDeviceLog+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistentDeviceLog+SimulatedCoreData.swift"; sourceTree = "<group>"; };
+		A9FB75F0252BE320004C7D3F /* BolusDosingDecision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusDosingDecision.swift; sourceTree = "<group>"; };
 		B40D07C6251A89D500C1C6D7 /* GlucoseDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseDisplay.swift; sourceTree = "<group>"; };
 		B42C951324A3C76000857C73 /* CGMStatusHUDViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGMStatusHUDViewModel.swift; sourceTree = "<group>"; };
 		B42C951624A3CAF200857C73 /* NotificationsCriticalAlertPermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationsCriticalAlertPermissionsViewModel.swift; sourceTree = "<group>"; };
@@ -1605,6 +1609,7 @@
 			isa = PBXGroup;
 			children = (
 				43511CDD21FD80AD00566C63 /* RetrospectiveCorrection */,
+				A9FB75F0252BE320004C7D3F /* BolusDosingDecision.swift */,
 				C17824A41E1AD4D100D9D25C /* BolusRecommendation.swift */,
 				B40D07C6251A89D500C1C6D7 /* GlucoseDisplay.swift */,
 				43C2FAE01EB656A500364AFF /* GlucoseEffectVelocity.swift */,
@@ -2323,6 +2328,7 @@
 			children = (
 				A9DFAFB224F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift */,
 				A9E6DFEE246A0474005B1A1C /* LoopErrorTests.swift */,
+				A963B279252CEBAE0062AA12 /* SetBolusUserInfoTests.swift */,
 				A9DFAFB424F048A000950D1E /* WatchHistoricalCarbsTests.swift */,
 			);
 			path = Models;
@@ -3377,6 +3383,7 @@
 				4F70C2101DE8FAC5006380B7 /* StatusExtensionDataManager.swift in Sources */,
 				43DFB62320D4CAE7008A7BAE /* PumpManager.swift in Sources */,
 				B45E704D25275023000C0E68 /* AdverseEventReportViewModel.swift in Sources */,
+				A9FB75F1252BE320004C7D3F /* BolusDosingDecision.swift in Sources */,
 				892A5D59222F0A27008961AB /* Debug.swift in Sources */,
 				1DD0B76724EC77AC008A2DC3 /* SupportScreenView.swift in Sources */,
 				431A8C401EC6E8AB00823B9C /* CircleMaskView.swift in Sources */,
@@ -3580,6 +3587,7 @@
 				1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */,
 				A9A63F8E246B271600588D5B /* NSTimeInterval.swift in Sources */,
 				A9DFAFB324F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift in Sources */,
+				A963B27A252CEBAE0062AA12 /* SetBolusUserInfoTests.swift in Sources */,
 				A985464D251448300099C1A6 /* OutputStreamTests.swift in Sources */,
 				A9A63F8D246B261100588D5B /* DosingDecisionStoreTests.swift in Sources */,
 				A9E6DFEF246A0474005B1A1C /* LoopErrorTests.swift in Sources */,

--- a/Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift
+++ b/Loop/Extensions/DeviceDataManager+BolusEntryViewModelDelegate.swift
@@ -20,8 +20,12 @@ extension DeviceDataManager: BolusEntryViewModelDelegate {
         loopManager.addGlucose(samples, completion: completion)
     }
     
-    func addCarbEntry(_ carbEntry: NewCarbEntry, replacing replacingEntry: StoredCarbEntry?, completion: @escaping (Result<Void>) -> Void) {
+    func addCarbEntry(_ carbEntry: NewCarbEntry, replacing replacingEntry: StoredCarbEntry?, completion: @escaping (Result<StoredCarbEntry>) -> Void) {
         loopManager.addCarbEntry(carbEntry, replacing: replacingEntry, completion: completion)
+    }
+
+    func storeBolusDosingDecision(_ bolusDosingDecision: BolusDosingDecision, withDate date: Date) {
+        loopManager.storeBolusDosingDecision(bolusDosingDecision, withDate: date)
     }
 
     /// func enactBolus(units: Double, at startDate: Date, completion: @escaping (_ error: Error?) -> Void)

--- a/Loop/Models/BolusDosingDecision.swift
+++ b/Loop/Models/BolusDosingDecision.swift
@@ -1,0 +1,25 @@
+//
+//  BolusDosingDecision.swift
+//  Loop
+//
+//  Created by Darin Krauss on 10/1/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import LoopKit
+
+struct BolusDosingDecision {
+    var insulinOnBoard: InsulinValue?
+    var carbsOnBoard: CarbValue?
+    var scheduleOverride: TemporaryScheduleOverride?
+    var glucoseTargetRangeSchedule: GlucoseRangeSchedule?
+    var glucoseTargetRangeScheduleApplyingOverrideIfActive: GlucoseRangeSchedule?
+    var predictedGlucoseIncludingPendingInsulin: [PredictedGlucoseValue]?
+    var manualGlucose: GlucoseValue?
+    var originalCarbEntry: StoredCarbEntry?
+    var carbEntry: StoredCarbEntry?
+    var recommendedBolus: BolusRecommendation?
+    var requestedBolus: Double?
+    
+    init() {}
+}

--- a/Loop/Stores/DosingDecisionStore.swift
+++ b/Loop/Stores/DosingDecisionStore.swift
@@ -74,8 +74,12 @@ extension StoredDosingDecision: Codable {
                   predictedGlucose: try container.decodeIfPresent([PredictedGlucoseValue].self, forKey: .predictedGlucose),
                   predictedGlucoseIncludingPendingInsulin: try container.decodeIfPresent([PredictedGlucoseValue].self, forKey: .predictedGlucoseIncludingPendingInsulin),
                   lastReservoirValue: try container.decodeIfPresent(LastReservoirValue.self, forKey: .lastReservoirValue),
+                  manualGlucose: try container.decodeIfPresent(SimpleGlucoseValue.self, forKey: .manualGlucose),
+                  originalCarbEntry: try container.decodeIfPresent(StoredCarbEntry.self, forKey: .originalCarbEntry),
+                  carbEntry: try container.decodeIfPresent(StoredCarbEntry.self, forKey: .carbEntry),
                   recommendedTempBasal: try container.decodeIfPresent(TempBasalRecommendationWithDate.self, forKey: .recommendedTempBasal),
                   recommendedBolus: try container.decodeIfPresent(BolusRecommendationWithDate.self, forKey: .recommendedBolus),
+                  requestedBolus: try container.decodeIfPresent(Double.self, forKey: .requestedBolus),
                   pumpManagerStatus: try container.decodeIfPresent(PumpManagerStatus.self, forKey: .pumpManagerStatus),
                   notificationSettings: try container.decodeIfPresent(NotificationSettings.self, forKey: .notificationSettings),
                   deviceSettings: try container.decodeIfPresent(DeviceSettings.self, forKey: .deviceSettings),
@@ -94,8 +98,12 @@ extension StoredDosingDecision: Codable {
         try container.encodeIfPresent(predictedGlucose, forKey: .predictedGlucose)
         try container.encodeIfPresent(predictedGlucoseIncludingPendingInsulin, forKey: .predictedGlucoseIncludingPendingInsulin)
         try container.encodeIfPresent(lastReservoirValue, forKey: .lastReservoirValue)
+        try container.encodeIfPresent(manualGlucose, forKey: .manualGlucose)
+        try container.encodeIfPresent(originalCarbEntry, forKey: .originalCarbEntry)
+        try container.encodeIfPresent(carbEntry, forKey: .carbEntry)
         try container.encodeIfPresent(recommendedTempBasal, forKey: .recommendedTempBasal)
         try container.encodeIfPresent(recommendedBolus, forKey: .recommendedBolus)
+        try container.encodeIfPresent(requestedBolus, forKey: .requestedBolus)
         try container.encodeIfPresent(pumpManagerStatus, forKey: .pumpManagerStatus)
         try container.encodeIfPresent(notificationSettings, forKey: .notificationSettings)
         try container.encodeIfPresent(deviceSettings, forKey: .deviceSettings)
@@ -192,8 +200,12 @@ extension StoredDosingDecision: Codable {
         case predictedGlucose
         case predictedGlucoseIncludingPendingInsulin
         case lastReservoirValue
+        case manualGlucose
+        case originalCarbEntry
+        case carbEntry
         case recommendedTempBasal
         case recommendedBolus
+        case requestedBolus
         case pumpManagerStatus
         case notificationSettings
         case deviceSettings

--- a/LoopTests/Extensions/DosingDecisionStoreTests.swift
+++ b/LoopTests/Extensions/DosingDecisionStoreTests.swift
@@ -23,6 +23,19 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase {
                 try assertDosingDecisionObjectEncodable(object, encodesJSON: """
 {
   "data" : {
+    "carbEntry" : {
+      "absorptionTime" : 18000,
+      "createdByCurrentApp" : true,
+      "foodType" : "Pizza",
+      "provenanceIdentifier" : "org.tidepool.Loop",
+      "quantity" : 29,
+      "startDate" : "2020-01-02T03:00:23Z",
+      "syncIdentifier" : "2B03D96C-6F5D-4140-99CD-80C3E64D6010",
+      "syncVersion" : 2,
+      "userCreatedDate" : "2020-05-14T22:06:12Z",
+      "userUpdatedDate" : "2020-05-14T22:07:32Z",
+      "uuid" : "135CDABE-9343-7242-4233-1020384789AE"
+    },
     "carbsOnBoard" : {
       "endDate" : "2020-05-14T23:18:41Z",
       "quantity" : 45.5,
@@ -159,6 +172,12 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase {
       "startDate" : "2020-05-14T22:07:19Z",
       "unitVolume" : 113.3
     },
+    "manualGlucose" : {
+      "endDate" : "2020-05-14T22:09:00Z",
+      "quantity" : 153,
+      "quantityUnit" : "mg/dL",
+      "startDate" : "2020-05-14T22:09:00Z"
+    },
     "notificationSettings" : {
       "alertSetting" : "disabled",
       "alertStyle" : "banner",
@@ -172,6 +191,18 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase {
       "providesAppNotificationSettings" : true,
       "showPreviewsSetting" : "whenAuthenticated",
       "soundSetting" : "enabled"
+    },
+    "originalCarbEntry" : {
+      "absorptionTime" : 18000,
+      "createdByCurrentApp" : true,
+      "foodType" : "Pizza",
+      "provenanceIdentifier" : "org.tidepool.Loop",
+      "quantity" : 19,
+      "startDate" : "2020-01-02T03:00:23Z",
+      "syncIdentifier" : "2B03D96C-6F5D-4140-99CD-80C3E64D6010",
+      "syncVersion" : 1,
+      "userCreatedDate" : "2020-05-14T22:06:12Z",
+      "uuid" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784"
     },
     "predictedGlucose" : [
       {
@@ -259,6 +290,7 @@ class DosingDecisionStorePersistenceTests: PersistenceControllerTestCase {
         "unitsPerHour" : 0.75
       }
     },
+    "requestedBolus" : 0.80000000000000004,
     "scheduleOverride" : {
       "context" : "custom",
       "duration" : {
@@ -399,6 +431,19 @@ class StoredDosingDecisionCodableTests: XCTestCase {
     func testCodable() throws {
         try assertStoredDosingDecisionCodable(StoredDosingDecision.test, encodesJSON: """
 {
+  "carbEntry" : {
+    "absorptionTime" : 18000,
+    "createdByCurrentApp" : true,
+    "foodType" : "Pizza",
+    "provenanceIdentifier" : "org.tidepool.Loop",
+    "quantity" : 29,
+    "startDate" : "2020-01-02T03:00:23Z",
+    "syncIdentifier" : "2B03D96C-6F5D-4140-99CD-80C3E64D6010",
+    "syncVersion" : 2,
+    "userCreatedDate" : "2020-05-14T22:06:12Z",
+    "userUpdatedDate" : "2020-05-14T22:07:32Z",
+    "uuid" : "135CDABE-9343-7242-4233-1020384789AE"
+  },
   "carbsOnBoard" : {
     "endDate" : "2020-05-14T23:18:41Z",
     "quantity" : 45.5,
@@ -535,6 +580,12 @@ class StoredDosingDecisionCodableTests: XCTestCase {
     "startDate" : "2020-05-14T22:07:19Z",
     "unitVolume" : 113.3
   },
+  "manualGlucose" : {
+    "endDate" : "2020-05-14T22:09:00Z",
+    "quantity" : 153,
+    "quantityUnit" : "mg/dL",
+    "startDate" : "2020-05-14T22:09:00Z"
+  },
   "notificationSettings" : {
     "alertSetting" : "disabled",
     "alertStyle" : "banner",
@@ -548,6 +599,18 @@ class StoredDosingDecisionCodableTests: XCTestCase {
     "providesAppNotificationSettings" : true,
     "showPreviewsSetting" : "whenAuthenticated",
     "soundSetting" : "enabled"
+  },
+  "originalCarbEntry" : {
+    "absorptionTime" : 18000,
+    "createdByCurrentApp" : true,
+    "foodType" : "Pizza",
+    "provenanceIdentifier" : "org.tidepool.Loop",
+    "quantity" : 19,
+    "startDate" : "2020-01-02T03:00:23Z",
+    "syncIdentifier" : "2B03D96C-6F5D-4140-99CD-80C3E64D6010",
+    "syncVersion" : 1,
+    "userCreatedDate" : "2020-05-14T22:06:12Z",
+    "uuid" : "18CF3948-0B3D-4B12-8BFE-14986B0E6784"
   },
   "predictedGlucose" : [
     {
@@ -635,6 +698,7 @@ class StoredDosingDecisionCodableTests: XCTestCase {
       "unitsPerHour" : 0.75
     }
   },
+  "requestedBolus" : 0.80000000000000004,
   "scheduleOverride" : {
     "context" : "custom",
     "duration" : {
@@ -800,6 +864,30 @@ fileprivate extension StoredDosingDecision {
                                                                              quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 117.8))]
         let lastReservoirValue = StoredDosingDecision.LastReservoirValue(startDate: dateFormatter.date(from: "2020-05-14T22:07:19Z")!,
                                                                          unitVolume: 113.3)
+        let manualGlucose = SimpleGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T22:09:00Z")!,
+                                               quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 153))
+        let originalCarbEntry = StoredCarbEntry(uuid: UUID(uuidString: "18CF3948-0B3D-4B12-8BFE-14986B0E6784")!,
+                                                provenanceIdentifier: "org.tidepool.Loop",
+                                                syncIdentifier: "2B03D96C-6F5D-4140-99CD-80C3E64D6010",
+                                                syncVersion: 1,
+                                                startDate: dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
+                                                quantity: HKQuantity(unit: .gram(), doubleValue: 19),
+                                                foodType: "Pizza",
+                                                absorptionTime: .hours(5),
+                                                createdByCurrentApp: true,
+                                                userCreatedDate: dateFormatter.date(from: "2020-05-14T22:06:12Z")!,
+                                                userUpdatedDate: nil)
+        let carbEntry = StoredCarbEntry(uuid: UUID(uuidString: "135CDABE-9343-7242-4233-1020384789AE")!,
+                                        provenanceIdentifier: "org.tidepool.Loop",
+                                        syncIdentifier: "2B03D96C-6F5D-4140-99CD-80C3E64D6010",
+                                        syncVersion: 2,
+                                        startDate: dateFormatter.date(from: "2020-01-02T03:00:23Z")!,
+                                        quantity: HKQuantity(unit: .gram(), doubleValue: 29),
+                                        foodType: "Pizza",
+                                        absorptionTime: .hours(5),
+                                        createdByCurrentApp: true,
+                                        userCreatedDate: dateFormatter.date(from: "2020-05-14T22:06:12Z")!,
+                                        userUpdatedDate: dateFormatter.date(from: "2020-05-14T22:07:32Z")!)
         let recommendedTempBasal = StoredDosingDecision.TempBasalRecommendationWithDate(recommendation: TempBasalRecommendation(unitsPerHour: 0.75,
                                                                                                                                 duration: .minutes(30)),
                                                                                         date: dateFormatter.date(from: "2020-05-14T22:38:15Z")!)
@@ -808,6 +896,7 @@ fileprivate extension StoredDosingDecision {
                                                                                                                     notice: .predictedGlucoseBelowTarget(minGlucose: PredictedGlucoseValue(startDate: dateFormatter.date(from: "2020-05-14T23:03:15Z")!,
                                                                                                                                                                                            quantity: HKQuantity(unit: .milligramsPerDeciliter, doubleValue: 75.5)))),
                                                                                 date: dateFormatter.date(from: "2020-05-14T22:38:16Z")!)
+        let requestedBolus = 0.8
         let pumpManagerStatus = PumpManagerStatus(timeZone: TimeZone(identifier: "America/Los_Angeles")!,
                                                   device: HKDevice(name: "Device Name",
                                                                    manufacturer: "Device Manufacturer",
@@ -861,8 +950,12 @@ fileprivate extension StoredDosingDecision {
                                     predictedGlucose: predictedGlucose,
                                     predictedGlucoseIncludingPendingInsulin: predictedGlucoseIncludingPendingInsulin,
                                     lastReservoirValue: lastReservoirValue,
+                                    manualGlucose: manualGlucose,
+                                    originalCarbEntry: originalCarbEntry,
+                                    carbEntry: carbEntry,
                                     recommendedTempBasal: recommendedTempBasal,
                                     recommendedBolus: recommendedBolus,
+                                    requestedBolus: requestedBolus,
                                     pumpManagerStatus: pumpManagerStatus,
                                     notificationSettings: notificationSettings,
                                     deviceSettings: deviceSettings,

--- a/LoopTests/Models/SetBolusUserInfoTests.swift
+++ b/LoopTests/Models/SetBolusUserInfoTests.swift
@@ -1,0 +1,104 @@
+//
+//  SetBolusUserInfoTests.swift
+//  LoopTests
+//
+//  Created by Darin Krauss on 10/6/20.
+//  Copyright © 2020 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import HealthKit
+import LoopKit
+@testable import Loop
+
+class SetBolusUserInfoTests: XCTestCase {
+    private var value = 4.56
+    private var startDate = dateFormatter.date(from: "2020-05-14T22:45:00Z")!
+    private var contextDate = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+    private var carbEntry = NewCarbEntry(date: dateFormatter.date(from: "2020-05-14T22:39:34Z")!,
+                                         quantity: HKQuantity(unit: .gram(), doubleValue: 17),
+                                         startDate: dateFormatter.date(from: "2020-05-14T22:00:00Z")!,
+                                         foodType: "Pizza",
+                                         absorptionTime: .hours(5))
+    private lazy var rawValue: SetBolusUserInfo.RawValue = {
+        return [
+            "v": 1,
+            "name": "SetBolusUserInfo",
+            "bv": value,
+            "sd": startDate,
+            "cd": contextDate,
+            "ce": carbEntry.rawValue,
+        ]
+    }()
+
+    func testDefaultInitializer() {
+        let info = SetBolusUserInfo(value: value, startDate: startDate, contextDate: contextDate, carbEntry: carbEntry)
+        XCTAssertEqual(info.value, value)
+        XCTAssertEqual(info.startDate, startDate)
+        XCTAssertEqual(info.contextDate, contextDate)
+        XCTAssertEqual(info.carbEntry, carbEntry)
+    }
+
+    func testRawValueInitializer() {
+        let info = SetBolusUserInfo(rawValue: rawValue)
+        XCTAssertEqual(info?.value, value)
+        XCTAssertEqual(info?.startDate, startDate)
+        XCTAssertEqual(info?.contextDate, contextDate)
+        XCTAssertEqual(info?.carbEntry, carbEntry)
+    }
+
+    func testRawValueInitializerMissingVersion() {
+        var rawValue = self.rawValue
+        rawValue["v"] = nil
+        XCTAssertNil(SetBolusUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerInvalidVersion() {
+        var rawValue = self.rawValue
+        rawValue["v"] = 2
+        XCTAssertNil(SetBolusUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerMissingName() {
+        var rawValue = self.rawValue
+        rawValue["name"] = nil
+        XCTAssertNil(SetBolusUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerInvalidName() {
+        var rawValue = self.rawValue
+        rawValue["name"] = "Invalid"
+        XCTAssertNil(SetBolusUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerMissingValue() {
+        var rawValue = self.rawValue
+        rawValue["bv"] = nil
+        XCTAssertNil(SetBolusUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValueInitializerMissingStartDate() {
+        var rawValue = self.rawValue
+        rawValue["sd"] = nil
+        XCTAssertNil(SetBolusUserInfo(rawValue: rawValue))
+    }
+
+    func testRawValue() {
+        let info = SetBolusUserInfo(value: value, startDate: startDate, contextDate: contextDate, carbEntry: carbEntry)
+        let rawValue = info.rawValue
+        XCTAssertEqual(rawValue.count, 6)
+        XCTAssertEqual(rawValue["v"] as? Int, 1)
+        XCTAssertEqual(rawValue["name"] as? String, "SetBolusUserInfo")
+        XCTAssertEqual(rawValue["bv"] as? Double, value)
+        XCTAssertEqual(rawValue["sd"] as? Date, startDate)
+        XCTAssertEqual(rawValue["cd"] as? Date, contextDate)
+        let carbEntryRawValue = rawValue["ce"] as? NewCarbEntry.RawValue
+        XCTAssertEqual(carbEntryRawValue?["date"] as? Date, carbEntry.date)
+        XCTAssertEqual(carbEntryRawValue?["grams"] as? Double, carbEntry.quantity.doubleValue(for: .gram()))
+        XCTAssertEqual(carbEntryRawValue?["startDate"] as? Date, carbEntry.startDate)
+        XCTAssertEqual(carbEntryRawValue?["foodType"] as? String, carbEntry.foodType)
+        XCTAssertEqual(carbEntryRawValue?["absorptionTime"] as? TimeInterval, carbEntry.absorptionTime)
+    }
+
+    private static let dateFormatter = ISO8601DateFormatter()
+}

--- a/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
+++ b/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
@@ -32,6 +32,7 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
     private var carbEntryUnderConsideration: NewCarbEntry?
     private var contextUpdateObservation: AnyObject?
     private var hasSentConfirmationMessage = false
+    private var contextDate: Date?
 
     // MARK: - Constants
     private static let defaultSupportedBolusVolumes = (0...600).map { 0.05 * Double($0) } // U
@@ -50,7 +51,9 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
         case .carbEntry:
             break
         case .manualBolus:
-            self._recommendedBolusAmount = Published(initialValue: loopManager.activeContext?.recommendedBolusDose)
+            let activeContext = loopManager.activeContext
+            self.contextDate = activeContext?.creationDate
+            self._recommendedBolusAmount = Published(initialValue: activeContext?.recommendedBolusDose)
         }
 
         self._bolusPickerValues = Published(
@@ -89,8 +92,10 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
                     self.recommendBolus(for: entry)
                 }
             case .manualBolus:
-                if self.recommendedBolusAmount != loopManager.activeContext?.recommendedBolusDose {
-                    self.recommendedBolusAmount = loopManager.activeContext?.recommendedBolusDose
+                let activeContext = loopManager.activeContext
+                self.contextDate = activeContext?.creationDate
+                if self.recommendedBolusAmount != activeContext?.recommendedBolusDose {
+                    self.recommendedBolusAmount = activeContext?.recommendedBolusDose
                 }
             }
         }
@@ -147,6 +152,8 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
                             self.isComputingRecommendedBolus = false
                         }
 
+                        self.contextDate = context.creationDate
+
                         // Don't publish a new value if the recommendation has not changed.
                         guard self.recommendedBolusAmount != context.recommendedBolusDoseConsideringPotentialCarbEntry else {
                             return
@@ -201,7 +208,7 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
             return
         }
 
-        let bolus = SetBolusUserInfo(value: bolus, startDate: Date(), carbEntry: carbEntry)
+        let bolus = SetBolusUserInfo(value: bolus, startDate: Date(), contextDate: self.contextDate, carbEntry: carbEntry)
         do {
             try WCSession.default.sendBolusMessage(bolus) { [weak self] (error) in
                 DispatchQueue.main.async {


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-1146
- Add context date to SetBolusUserInfo
- Store bolus dosing decision in LoopDataManager
- Associate bolus dosing decision with current context in WatchDataManager
- Add BolusDosingDecision
- Update StoredDosingDecision Codable conformance
- Capture bolus dosing decision in carb and bolus workflows
- Additional tests