### PR TITLE
[LOOP-1992] No -0 on y-axis

### DIFF
--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -43,7 +43,7 @@ extension ChartAxisValuesStaticGenerator {
                firstValue = firstValue - segmentSize
             }
             
-            // do not allow the first axis label to be -0
+            // do not allow the first label to be displayed as -0
             while firstValue < 0 && firstValue.rounded() == -0 {
                 firstValue = firstValue - segmentSize
             }
@@ -59,7 +59,7 @@ extension ChartAxisValuesStaticGenerator {
 
             /// Find the optimal number of segments and segment width
             /// If the number of segments is greater than desired, make each segment wider
-            /// ensure no label of -0 is display on the axis
+            /// ensure no label of -0 will be displayed on the axis
             while segmentCount > maxSegmentCount ||
                 !potentialSegmentValues.filter({ $0 < 0 && $0.rounded() == -0 }).isEmpty
             {
@@ -74,7 +74,7 @@ extension ChartAxisValuesStaticGenerator {
                 segmentCount += 1
             }
             segmentSize = currentMultiple
-                        
+            
             /// Generate axis values from the first value, segment size and number of segments
             let offset = firstValue
             return (0...Int(segmentCount)).map {segment in

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -43,7 +43,7 @@ extension ChartAxisValuesStaticGenerator {
                firstValue = firstValue - segmentSize
             }
             
-            // do not allow a value of -0 on the axis
+            // do not allow the first axis label to be -0
             while firstValue < 0 && firstValue.rounded() == -0 {
                 firstValue = firstValue - segmentSize
             }
@@ -55,14 +55,17 @@ extension ChartAxisValuesStaticGenerator {
             let distance = lastValue - firstValue
             var currentMultiple = multiple
             var segmentCount = distance / currentMultiple
-            
+            var potentialSegmentValues = stride(from: firstValue, to: lastValue, by: currentMultiple)
+
             /// Find the optimal number of segments and segment width
-            
             /// If the number of segments is greater than desired, make each segment wider
-            while segmentCount > maxSegmentCount {
-                // This is the only difference from SwiftCharts (i.e., currentMultiple *= 2)
+            /// ensure no label of -0 is display on the axis
+            while segmentCount > maxSegmentCount ||
+                !potentialSegmentValues.filter({ $0 < 0 && $0.rounded() == -0 }).isEmpty
+            {
                 currentMultiple += multiple
                 segmentCount = distance / currentMultiple
+                potentialSegmentValues = stride(from: firstValue, to: lastValue, by: currentMultiple)
             }
             segmentCount = ceil(segmentCount)
             
@@ -71,7 +74,7 @@ extension ChartAxisValuesStaticGenerator {
                 segmentCount += 1
             }
             segmentSize = currentMultiple
-            
+                        
             /// Generate axis values from the first value, segment size and number of segments
             let offset = firstValue
             return (0...Int(segmentCount)).map {segment in

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -78,7 +78,14 @@ extension ChartAxisValuesStaticGenerator {
             /// Generate axis values from the first value, segment size and number of segments
             let offset = firstValue
             return (0...Int(segmentCount)).map {segment in
-                let scalar = offset + (Double(segment) * segmentSize)
+                var scalar = offset + (Double(segment) * segmentSize)
+                // a value that could be displayed as 0 should truly be 0 to have the zero-line drawn correctly.
+                if scalar != 0,
+                    (scalar < 1 && scalar > -1),
+                    scalar.rounded() == 0
+                {
+                    scalar = 0
+                }
                 return axisValueGenerator(scalar)
             }
         } else {

--- a/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
+++ b/LoopUI/Extensions/ChartAxisValuesStaticGenerator.swift
@@ -81,7 +81,6 @@ extension ChartAxisValuesStaticGenerator {
                 var scalar = offset + (Double(segment) * segmentSize)
                 // a value that could be displayed as 0 should truly be 0 to have the zero-line drawn correctly.
                 if scalar != 0,
-                    (scalar < 1 && scalar > -1),
                     scalar.rounded() == 0
                 {
                     scalar = 0


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1992

ensuring any potential y-axis label will not be displayed as -0

Some examples of what this may look like:
<img width="382" alt="Screen Shot 2020-10-14 at 09 46 02" src="https://user-images.githubusercontent.com/152359/95990697-37927280-0e02-11eb-99e5-38515d6e7634.png">
<img width="384" alt="Screen Shot 2020-10-14 at 09 45 10" src="https://user-images.githubusercontent.com/152359/95990533-06b23d80-0e02-11eb-9c4c-059f7646b137.png">
<img width="387" alt="Screen Shot 2020-10-14 at 09 48 32" src="https://user-images.githubusercontent.com/152359/95990886-71fc0f80-0e02-11eb-90e8-09ccabe2e96c.png">