### PR TITLE
[LOOP-1838] Display correct active carbs widget is updated (even if added via the watch)

### DIFF
--- a/Common/Models/StatusExtensionContext.swift
+++ b/Common/Models/StatusExtensionContext.swift
@@ -293,6 +293,7 @@ struct StatusExtensionContext: RawRepresentable {
     var pumpLifecycleProgressContext: DeviceLifecycleProgressContext?
     var cgmStatusHighlightContext: DeviceStatusHighlightContext?
     var cgmLifecycleProgressContext: DeviceLifecycleProgressContext?
+    var carbsOnBoardValue: Double?
     
     init() { }
     
@@ -312,6 +313,7 @@ struct StatusExtensionContext: RawRepresentable {
         lastLoopCompleted = rawValue["lastLoopCompleted"] as? Date
         batteryPercentage = rawValue["batteryPercentage"] as? Double
         reservoirCapacity = rawValue["reservoirCapacity"] as? Double
+        carbsOnBoardValue = rawValue["carbsOnBoardValue"] as? Double
 
         if let rawValue = rawValue["glucoseDisplay"] as? GlucoseDisplayableContext.RawValue {
             glucoseDisplay = GlucoseDisplayableContext(rawValue: rawValue)
@@ -354,6 +356,7 @@ struct StatusExtensionContext: RawRepresentable {
         raw["pumpLifecycleProgressContext"] = pumpLifecycleProgressContext?.rawValue
         raw["cgmStatusHighlightContext"] = cgmStatusHighlightContext?.rawValue
         raw["cgmLifecycleProgressContext"] = cgmLifecycleProgressContext?.rawValue
+        raw["carbsOnBoardValue"] = carbsOnBoardValue
         
         return raw
     }

--- a/Common/Models/StatusExtensionContext.swift
+++ b/Common/Models/StatusExtensionContext.swift
@@ -293,7 +293,7 @@ struct StatusExtensionContext: RawRepresentable {
     var pumpLifecycleProgressContext: DeviceLifecycleProgressContext?
     var cgmStatusHighlightContext: DeviceStatusHighlightContext?
     var cgmLifecycleProgressContext: DeviceLifecycleProgressContext?
-    var carbsOnBoardValue: Double?
+    var carbsOnBoard: Double?
     
     init() { }
     
@@ -313,7 +313,7 @@ struct StatusExtensionContext: RawRepresentable {
         lastLoopCompleted = rawValue["lastLoopCompleted"] as? Date
         batteryPercentage = rawValue["batteryPercentage"] as? Double
         reservoirCapacity = rawValue["reservoirCapacity"] as? Double
-        carbsOnBoardValue = rawValue["carbsOnBoardValue"] as? Double
+        carbsOnBoard = rawValue["carbsOnBoard"] as? Double
 
         if let rawValue = rawValue["glucoseDisplay"] as? GlucoseDisplayableContext.RawValue {
             glucoseDisplay = GlucoseDisplayableContext(rawValue: rawValue)
@@ -356,7 +356,7 @@ struct StatusExtensionContext: RawRepresentable {
         raw["pumpLifecycleProgressContext"] = pumpLifecycleProgressContext?.rawValue
         raw["cgmStatusHighlightContext"] = cgmStatusHighlightContext?.rawValue
         raw["cgmLifecycleProgressContext"] = cgmLifecycleProgressContext?.rawValue
-        raw["carbsOnBoardValue"] = carbsOnBoardValue
+        raw["carbsOnBoard"] = carbsOnBoard
         
         return raw
     }

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -92,15 +92,6 @@ class StatusViewController: UIViewController, NCWidgetProviding {
         insulinSensitivitySchedule: defaults?.insulinSensitivitySchedule
     )
     
-    let absorptionTimes = LoopSettings.defaultCarbAbsorptionTimes
-    lazy var carbStore = CarbStore(healthStore: healthStore,
-                                   observeHealthKitSamplesFromOtherApps: false,
-                                   cacheStore: cacheStore,
-                                   cacheLength: .hours(24),
-                                   defaultAbsorptionTimes: absorptionTimes,
-                                   observationInterval: 0,
-                                   provenanceIdentifier: HKSource.default().bundleIdentifier)
-    
     private var pluginManager: PluginManager = {
         let containingAppFrameworksURL = Bundle.main.privateFrameworksURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("Frameworks")
         return PluginManager(pluginsURL: containingAppFrameworksURL)
@@ -189,7 +180,6 @@ class StatusViewController: UIViewController, NCWidgetProviding {
 
         var activeInsulin: Double?
         let carbUnit = HKUnit.gram()
-        var activeCarbs: HKQuantity?
         var glucose: [StoredGlucoseSample] = []
 
         group.enter()
@@ -202,18 +192,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             }
             group.leave()
         }
-        
-        group.enter()
-        carbStore.carbsOnBoard(at: Date()) { (result) in
-            switch result {
-            case .success(let cobValue):
-                activeCarbs = cobValue.quantity
-            case .failure:
-                activeCarbs = nil
-            }
-            group.leave()
-        }
-
+    
         charts.startDate = Calendar.current.nextDate(after: Date(timeIntervalSinceNow: .minutes(-5)), matching: DateComponents(minute: 0), matchingPolicy: .strict, direction: .backward) ?? Date()
 
         // Showing the whole history plus full prediction in the glucose plot
@@ -263,8 +242,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
                 let numberFormatter = NumberFormatter()
 
                 numberFormatter.numberStyle = .decimal
-                numberFormatter.minimumFractionDigits = 1
-                numberFormatter.maximumFractionDigits = 1
+                numberFormatter.minimumFractionDigits = 2
+                numberFormatter.maximumFractionDigits = 2
                 
                 return numberFormatter
             }()
@@ -284,8 +263,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             let carbsFormatter = QuantityFormatter()
             carbsFormatter.setPreferredNumberFormatter(for: carbUnit)
 
-            if let activeCarbs = activeCarbs,
-                let activeCarbsNumberString = carbsFormatter.string(from: activeCarbs, for: carbUnit)
+            if  let carbsOnBoardValue = context.carbsOnBoardValue,
+                let activeCarbsNumberString = carbsFormatter.string(from: HKQuantity(unit: carbUnit, doubleValue: carbsOnBoardValue), for: carbUnit)
             {
                 self.activeCarbsAmountLabel.text = String(format: NSLocalizedString("%1$@", comment: "The subtitle format describing the grams of active carbs.  (1: localized carb value description)"), activeCarbsNumberString)
             } else {

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -263,8 +263,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             let carbsFormatter = QuantityFormatter()
             carbsFormatter.setPreferredNumberFormatter(for: carbUnit)
 
-            if  let carbsOnBoardValue = context.carbsOnBoardValue,
-                let activeCarbsNumberString = carbsFormatter.string(from: HKQuantity(unit: carbUnit, doubleValue: carbsOnBoardValue), for: carbUnit)
+            if let carbsOnBoardValue = context.carbsOnBoardValue,
+               let activeCarbsNumberString = carbsFormatter.string(from: HKQuantity(unit: carbUnit, doubleValue: carbsOnBoardValue), for: carbUnit)
             {
                 self.activeCarbsAmountLabel.text = String(format: NSLocalizedString("%1$@", comment: "The subtitle format describing the grams of active carbs.  (1: localized carb value description)"), activeCarbsNumberString)
             } else {

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -263,8 +263,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             let carbsFormatter = QuantityFormatter()
             carbsFormatter.setPreferredNumberFormatter(for: carbUnit)
 
-            if let carbsOnBoardValue = context.carbsOnBoardValue,
-               let activeCarbsNumberString = carbsFormatter.string(from: HKQuantity(unit: carbUnit, doubleValue: carbsOnBoardValue), for: carbUnit)
+            if let carbsOnBoard = context.carbsOnBoard,
+               let activeCarbsNumberString = carbsFormatter.string(from: HKQuantity(unit: carbUnit, doubleValue: carbsOnBoard), for: carbUnit)
             {
                 self.activeCarbsAmountLabel.text = String(format: NSLocalizedString("%1$@", comment: "The subtitle format describing the grams of active carbs.  (1: localized carb value description)"), activeCarbsNumberString)
             } else {

--- a/Loop/Managers/StatusExtensionDataManager.swift
+++ b/Loop/Managers/StatusExtensionDataManager.swift
@@ -126,7 +126,7 @@ final class StatusExtensionDataManager {
             context.cgmStatusHighlightContext = DeviceStatusHighlightContext(from: dataManager.cgmStatusHighlight)
             context.cgmLifecycleProgressContext = DeviceLifecycleProgressContext(from: dataManager.cgmLifecycleProgress)
 
-            context.carbsOnBoardValue = state.carbsOnBoard?.quantity.doubleValue(for: .gram())
+            context.carbsOnBoard = state.carbsOnBoard?.quantity.doubleValue(for: .gram())
             
             completionHandler(context)
         }

--- a/Loop/Managers/StatusExtensionDataManager.swift
+++ b/Loop/Managers/StatusExtensionDataManager.swift
@@ -126,6 +126,8 @@ final class StatusExtensionDataManager {
             context.cgmStatusHighlightContext = DeviceStatusHighlightContext(from: dataManager.cgmStatusHighlight)
             context.cgmLifecycleProgressContext = DeviceLifecycleProgressContext(from: dataManager.cgmLifecycleProgress)
 
+            context.carbsOnBoardValue = state.carbsOnBoard?.quantity.doubleValue(for: .gram())
+            
             completionHandler(context)
         }
     }

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -506,7 +506,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             if let cobValues = cobValues {
                 charts.setCOBValues(cobValues)
             }
-            if let index = charts.cob.cobPoints.closestIndex(priorTo: 	Date()) {
+            if let index = charts.cob.cobPoints.closestIndex(priorTo: Date()) {
                 self.currentCOBDescription = String(describing: charts.cob.cobPoints[index].y)
             } else {
                 self.currentCOBDescription = nil


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1838

Instead of pulling cob from the store, use the value provided by the loop state (similar to how other parameters of the status extension context are set).

Note the number of digits used to display the IOB was changed to match how this value is displayed in the app.