### PR TITLE
Only set ntpClient's logCallback if you actually can

### DIFF
--- a/Loop/Managers/TrustedTimeChecker.swift
+++ b/Loop/Managers/TrustedTimeChecker.swift
@@ -36,9 +36,9 @@ class TrustedTimeChecker {
 
     init(_ alertManager: AlertManager) {
         ntpClient = TrueTimeClient.sharedInstance
-        #if DEBUG
-        ntpClient.logCallback = { _ in }    // TrueTimeClient is a bit chatty in DEBUG build. This squelches all of its logging.
-        #endif
+        if ntpClient.responds(to: #selector(setter: TrueTimeClient.logCallback)) {
+            ntpClient.logCallback = { _ in }    // TrueTimeClient is a bit chatty in DEBUG build. This squelches all of its logging.
+        }
         ntpClient.start()
         self.alertManager = alertManager
         NotificationCenter.default.addObserver(forName: UIApplication.significantTimeChangeNotification,


### PR DESCRIPTION
Sometimes, I'm not sure how, you can get into a situation where the TrueTime framework is compiled without `logCallback` in place, even in DEBUG builds (it uses DEBUG_LOGGING as its compile flag, but it is not in our scope).  This results in the app crashing on startup (but only debug builds, so it is only a developer issue)
This is a safer route: checking to see if it actually can be set before trying to set it.