### PR TITLE
Limit max characters on bolus input fields

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -194,7 +194,8 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                         font: typedManualGlucoseEntry.wrappedValue == "" ? .preferredFont(forTextStyle: .title1) : .heavy(.title1),
                         textAlignment: .right,
                         keyboardType: .decimalPad,
-                        shouldBecomeFirstResponder: isManualGlucoseEntryRowVisible
+                        shouldBecomeFirstResponder: isManualGlucoseEntryRowVisible,
+                        maxLength: 3
                     )
 
                     Text(QuantityFormatter().string(from: viewModel.glucoseUnit))
@@ -283,7 +284,8 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                     textColor: .loopAccent,
                     textAlignment: .right,
                     keyboardType: .decimalPad,
-                    shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder
+                    shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
+                    maxLength: 5
                 )
                 
                 bolusUnitsLabel

--- a/Loop/Views/SimpleBolusView.swift
+++ b/Loop/Views/SimpleBolusView.swift
@@ -119,7 +119,8 @@ struct SimpleBolusView: View, HorizontalSizeClassOverride {
                     text: $viewModel.enteredCarbAmount,
                     placeholder: viewModel.carbPlaceholder,
                     textAlignment: .right,
-                    keyboardType: .decimalPad
+                    keyboardType: .decimalPad,
+                    maxLength: 5
                 )
                 carbUnitsLabel
             }
@@ -140,7 +141,8 @@ struct SimpleBolusView: View, HorizontalSizeClassOverride {
                     // The heavy title is ending up clipped due to a bug that is fixed in iOS 14.  Uncomment the following when we can build for iOS 14.
                     font: .preferredFont(forTextStyle: .title1), // viewModel.enteredGlucoseAmount == "" ? .preferredFont(forTextStyle: .title1) : .heavy(.title1),
                     textAlignment: .right,
-                    keyboardType: .decimalPad
+                    keyboardType: .decimalPad,
+                    maxLength: 3
                 )
 
                 glucoseUnitsLabel
@@ -196,7 +198,8 @@ struct SimpleBolusView: View, HorizontalSizeClassOverride {
                     textColor: .loopAccent,
                     textAlignment: .right,
                     keyboardType: .decimalPad,
-                    shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder
+                    shouldBecomeFirstResponder: shouldBolusEntryBecomeFirstResponder,
+                    maxLength: 5
                 )
                 
                 bolusUnitsLabel


### PR DESCRIPTION
Adds limits to input fields on both Simple Bolus and normal Bolus entry interfaces, responding to design review comments on https://tidepool.atlassian.net/browse/LOOP-1869