### PR TITLE
LOOP-2034: Only show iob when glucose is entered

### DIFF
--- a/Loop/View Models/SimpleBolusViewModel.swift
+++ b/Loop/View Models/SimpleBolusViewModel.swift
@@ -122,21 +122,7 @@ class SimpleBolusViewModel: ObservableObject {
         }
     }
     
-    private var dosingDecision: BolusDosingDecision? {
-        didSet {
-            if let decision = dosingDecision, let bolusRecommendation = decision.recommendedBolus {
-                recommendation = bolusRecommendation.amount
-            } else {
-                recommendation = nil
-            }
-            
-            if let decision = dosingDecision, let insulinOnBoard = decision.insulinOnBoard, insulinOnBoard.value > 0, glucose != nil {
-                activeInsulin = Self.doseAmountFormatter.string(from: insulinOnBoard.value)
-            } else {
-                activeInsulin = nil
-            }
-        }
-    }
+    private var dosingDecision: BolusDosingDecision?
     
     private var recommendationDate: Date?
 
@@ -205,6 +191,17 @@ class SimpleBolusViewModel: ObservableObject {
         let recommendationDate = Date()
         if carbs != nil || glucose != nil {
             dosingDecision = delegate.computeSimpleBolusRecommendation(at: recommendationDate, mealCarbs: carbs, manualGlucose: glucose)
+            if let decision = dosingDecision, let bolusRecommendation = decision.recommendedBolus {
+                recommendation = bolusRecommendation.amount
+            } else {
+                recommendation = nil
+            }
+            
+            if let decision = dosingDecision, let insulinOnBoard = decision.insulinOnBoard, insulinOnBoard.value > 0, glucose != nil {
+                activeInsulin = Self.doseAmountFormatter.string(from: insulinOnBoard.value)
+            } else {
+                activeInsulin = nil
+            }
             self.recommendationDate = recommendationDate
         } else {
             dosingDecision = nil

--- a/Loop/View Models/SimpleBolusViewModel.swift
+++ b/Loop/View Models/SimpleBolusViewModel.swift
@@ -130,7 +130,7 @@ class SimpleBolusViewModel: ObservableObject {
                 recommendation = nil
             }
             
-            if let decision = dosingDecision, let insulinOnBoard = decision.insulinOnBoard, insulinOnBoard.value > 0 {
+            if let decision = dosingDecision, let insulinOnBoard = decision.insulinOnBoard, insulinOnBoard.value > 0, glucose != nil {
                 activeInsulin = Self.doseAmountFormatter.string(from: insulinOnBoard.value)
             } else {
                 activeInsulin = nil


### PR DESCRIPTION
Simple bolus calculator should not show active insulin when no glucose value is entered, as it does not affect the calculation. Also, adding the carb entry to the local `dosingRecommendation` was triggering the `didSet` code incorrectly, causing the bolus amount to be set again, even if the user had deleted or edited it, causing delivery of the recommended amount instead of the user entered amount. This would only happen when carbs were entered.

https://tidepool.atlassian.net/browse/LOOP-2034