### PR TITLE
[LOOP-HOTFIX] True Time debug logging

### DIFF
--- a/Loop/Managers/TrustedTimeChecker.swift
+++ b/Loop/Managers/TrustedTimeChecker.swift
@@ -36,9 +36,11 @@ class TrustedTimeChecker {
 
     init(_ alertManager: AlertManager) {
         ntpClient = TrueTimeClient.sharedInstance
+        #if DEBUG
         if ntpClient.responds(to: #selector(setter: TrueTimeClient.logCallback)) {
             ntpClient.logCallback = { _ in }    // TrueTimeClient is a bit chatty in DEBUG build. This squelches all of its logging.
         }
+        #endif
         ntpClient.start()
         self.alertManager = alertManager
         NotificationCenter.default.addObserver(forName: UIApplication.significantTimeChangeNotification,


### PR DESCRIPTION
no need to block true time client logging when in release builds