### PR TITLE
[LOOP-2352] Display COB accurately

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -866,9 +866,14 @@ extension LoopDataManager {
             updateGroup.enter()
             carbStore.carbsOnBoard(at: now(), effectVelocities: settings.dynamicCarbAbsorptionEnabled ? insulinCounteractionEffects : nil) { (result) in
                 switch result {
-                case .failure:
-                    // Failure is expected when there is no carb data
-                    self.carbsOnBoard = nil
+                case .failure(let error):
+                    switch error {
+                    case .noData:
+                        // when there is no data, carbs on board is set to 0
+                        self.carbsOnBoard = CarbValue(startDate: Date(), quantity: HKQuantity(unit: .gram(), doubleValue: 0))
+                    default:
+                        self.carbsOnBoard = nil
+                    }
                 case .success(let value):
                     self.carbsOnBoard = value
                 }

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -331,6 +331,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         var doseEntries: [DoseEntry]?
         var totalDelivery: Double?
         var cobValues: [CarbValue]?
+        var carbsOnBoard: HKQuantity?
         let startDate = charts.startDate
         let basalDeliveryState = self.basalDeliveryState
 
@@ -386,6 +387,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                     }
                     reloadGroup.leave()
                 }
+                carbsOnBoard = state.carbsOnBoard?.quantity
             }
 
             reloadGroup.leave()
@@ -519,6 +521,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
             }
             if let index = charts.cob.cobPoints.closestIndex(priorTo: Date()) {
                 self.currentCOBDescription = String(describing: charts.cob.cobPoints[index].y)
+            } else if let carbsOnBoard = carbsOnBoard {
+                self.currentCOBDescription = self.quantityFormatter.string(from: carbsOnBoard, for: .gram())
             } else {
                 self.currentCOBDescription = nil
             }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2352

includes:
- Interpret carbs on board `noData` error.
- use LoopState carbsOnBoard for displaying COB on charts when no chart data.