### PR TITLE
LOOP-1870: Use selected default emoji even if user hasn't chosen a custom emoji to store

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -129,7 +129,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
                 date: lastEntryDate,
                 quantity: quantity,
                 startDate: date,
-                foodType: foodType,
+                foodType: foodType ?? selectedDefaultAbsorptionTimeEmoji,
                 absorptionTime: absorptionTime
             )
         } else {


### PR DESCRIPTION
This is that "one line fix" I proposed putting into a build to make sure an emoji is stored in `NewCarbEntry`.  All this does is fall back to the selected "default emoji" if a custom `foodType` is not chosen.

[LOOP-1870](https://tidepool.atlassian.net/browse/LOOP-1870)