### PR TITLE
LOOP-2211: Workout and Premeal target overrides splits glucose graph

### DIFF
--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -41,25 +41,19 @@ public class PredictedGlucoseChart: GlucoseChart, ChartProviding {
 
     public var preMealOverride: TemporaryScheduleOverride? {
         didSet {
-            preMealOverridePoints = []
             preMealOverrideDurationPoints = []
         }
     }
 
     public var scheduleOverride: TemporaryScheduleOverride? {
         didSet {
-            targetOverridePoints = []
             targetOverrideDurationPoints = []
         }
     }
 
     private var targetGlucosePoints = [[ChartPoint]]()
 
-    private var preMealOverridePoints: [ChartPoint] = []
-
     private var preMealOverrideDurationPoints: [ChartPoint] = []
-
-    private var targetOverridePoints: [ChartPoint] = []
 
     private var targetOverrideDurationPoints: [ChartPoint] = []
 
@@ -96,7 +90,6 @@ extension PredictedGlucoseChart {
         predictedGlucosePoints = []
         alternatePredictedGlucosePoints = nil
         targetGlucosePoints = [[ChartPoint]]()
-        targetOverridePoints = []
         targetOverrideDurationPoints = []
 
         glucoseChartCache = nil
@@ -110,7 +103,6 @@ extension PredictedGlucoseChart {
 
             var displayedScheduleOverride = scheduleOverride
             if let preMealOverride = preMealOverride, preMealOverride.isActive() {
-//                preMealOverridePoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(preMealOverride, unit: glucoseUnit, xAxisValues: xAxisValues, extendEndDateToChart: true)
                 preMealOverrideDurationPoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(preMealOverride, unit: glucoseUnit, xAxisValues: xAxisValues)
 
                 if displayedScheduleOverride != nil {
@@ -121,15 +113,12 @@ extension PredictedGlucoseChart {
                     }
                 }
             } else {
-                preMealOverridePoints = []
                 preMealOverrideDurationPoints = []
             }
 
             if let override = displayedScheduleOverride, override.isActive() || override.startDate > Date() {
-//                targetOverridePoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: glucoseUnit, xAxisValues: xAxisValues, extendEndDateToChart: true)
                 targetOverrideDurationPoints = ChartPoint.pointsForGlucoseRangeScheduleOverride(override, unit: glucoseUnit, xAxisValues: xAxisValues)
             } else {
-                targetOverridePoints = []
                 targetOverrideDurationPoints = []
             }
         }
@@ -142,43 +131,26 @@ extension PredictedGlucoseChart {
         let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
         // The glucose targets
-        let targetFillAlpha: CGFloat = preMealOverridePoints.count > 1 || preMealOverrideDurationPoints.count > 1 || targetOverridePoints.count > 1 || targetOverrideDurationPoints.count > 1 ? 0.15 : 0.3
-        var fills: [ChartPointsFill?] = []
-        targetGlucosePoints.forEach {
-            fills.append(ChartPointsFill(
-                chartPoints: $0,
-                fillColor: colors.glucoseTint.withAlphaComponent(targetFillAlpha),
-                createContainerPoints: false
-            ))
-        }
-        fills.append(contentsOf: [
-            ChartPointsFill(
-                chartPoints: preMealOverridePoints,
-                fillColor: colors.glucoseTint.withAlphaComponent(0.3),
-                createContainerPoints: false
-            ),
-            ChartPointsFill(
-                chartPoints: preMealOverrideDurationPoints,
-                fillColor: colors.glucoseTint.withAlphaComponent(0.3),
-                createContainerPoints: false
-            ),
-            ChartPointsFill(
-                chartPoints: targetOverrideDurationPoints,
-                fillColor: colors.glucoseTint.withAlphaComponent(0.3),
-                createContainerPoints: false
-            )
-        ])
-
-        if preMealOverridePoints.isEmpty {
-            fills.append(
+        let targetFillAlpha: CGFloat = preMealOverrideDurationPoints.count > 1 || targetOverrideDurationPoints.count > 1 ? 0.15 : 0.3
+        let fills =
+            targetGlucosePoints.map {
                 ChartPointsFill(
-                    chartPoints: targetOverridePoints,
-                    fillColor: colors.glucoseTint.withAlphaComponent(0.3),
+                    chartPoints: $0,
+                    fillColor: colors.glucoseTint.withAlphaComponent(targetFillAlpha),
                     createContainerPoints: false
                 )
-            )
-        }
-
+            } + [
+                ChartPointsFill(
+                    chartPoints: preMealOverrideDurationPoints,
+                    fillColor: colors.glucoseTint.withAlphaComponent(0.45),
+                    createContainerPoints: false
+                ),
+                ChartPointsFill(
+                    chartPoints: targetOverrideDurationPoints,
+                    fillColor: colors.glucoseTint.withAlphaComponent(0.45),
+                    createContainerPoints: false
+                )]
+        
         let targetsLayer = ChartPointsFillsLayer(
             xAxis: xAxisLayer.axis,
             yAxis: yAxisLayer.axis,
@@ -246,8 +218,8 @@ extension PredictedGlucoseChart {
     private func determineYAxisValues(axisLabelSettings: ChartLabelSettings? = nil) -> [ChartAxisValue] {
         let points = [
             glucosePoints, predictedGlucosePoints,
-            preMealOverridePoints, preMealOverrideDurationPoints,
-            targetGlucosePoints.flatMap { $0 }, targetOverridePoints,
+            preMealOverrideDurationPoints,
+            targetGlucosePoints.flatMap { $0 },
             glucoseDisplayRangePoints
         ].flatMap { $0 }
 

--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -218,7 +218,7 @@ extension PredictedGlucoseChart {
     private func determineYAxisValues(axisLabelSettings: ChartLabelSettings? = nil) -> [ChartAxisValue] {
         let points = [
             glucosePoints, predictedGlucosePoints,
-            preMealOverrideDurationPoints,
+            preMealOverrideDurationPoints, targetOverrideDurationPoints,
             targetGlucosePoints.flatMap { $0 },
             glucoseDisplayRangePoints
         ].flatMap { $0 }

--- a/LoopUI/Charts/PredictedGlucoseChart.swift
+++ b/LoopUI/Charts/PredictedGlucoseChart.swift
@@ -105,9 +105,8 @@ extension PredictedGlucoseChart {
     public func generate(withFrame frame: CGRect, xAxisModel: ChartAxisModel, xAxisValues: [ChartAxisValue], axisLabelSettings: ChartLabelSettings, guideLinesLayerSettings: ChartGuideLinesLayerSettings, colors: ChartColorPalette, chartSettings: ChartSettings, labelsWidthY: CGFloat, gestureRecognizer: UIGestureRecognizer?, traitCollection: UITraitCollection) -> Chart
     {
         if targetGlucosePoints.isEmpty, xAxisValues.count > 1, let schedule = targetGlucoseSchedule {
-            targetGlucosePoints = ChartPoint.pointsForGlucoseRangeSchedule(schedule, unit: glucoseUnit, xAxisValues: xAxisValues,
-                                                                           considering: (preMealOverride?.isActive() ?? false) ? preMealOverride : (scheduleOverride?.isActive() ?? false) ? scheduleOverride : nil
-                                                                           )
+            let potentialOverride = (preMealOverride?.isActive() ?? false) ? preMealOverride : (scheduleOverride?.isActive() ?? false) ? scheduleOverride : nil
+            targetGlucosePoints = ChartPoint.pointsForGlucoseRangeSchedule(schedule, unit: glucoseUnit, xAxisValues: xAxisValues, considering: potentialOverride)
 
             var displayedScheduleOverride = scheduleOverride
             if let preMealOverride = preMealOverride, preMealOverride.isActive() {

--- a/LoopUI/Extensions/ChartPoint.swift
+++ b/LoopUI/Extensions/ChartPoint.swift
@@ -48,6 +48,8 @@ extension ChartPoint {
                     maxPoints = []
                     minPoints = []
                     addBar(value: range.value, unit: unit, startDate: ChartAxisValueDate(date: override.endDate, formatter: dateFormatter), endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
+                } else {
+                    addBar(value: range.value, unit: unit, startDate: startDate, endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
                 }
             } else {
                 addBar(value: range.value, unit: unit, startDate: startDate, endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)

--- a/LoopUI/Extensions/ChartPoint.swift
+++ b/LoopUI/Extensions/ChartPoint.swift
@@ -13,7 +13,7 @@ import SwiftCharts
 
 
 extension ChartPoint {
-    static func pointsForGlucoseRangeSchedule(_ glucoseRangeSchedule: GlucoseRangeSchedule, unit: HKUnit, xAxisValues: [ChartAxisValue], considering override: TemporaryScheduleOverride? = nil) -> [[ChartPoint]] {
+    static func pointsForGlucoseRangeSchedule(_ glucoseRangeSchedule: GlucoseRangeSchedule, unit: HKUnit, xAxisValues: [ChartAxisValue], considering potentialOverride: TemporaryScheduleOverride? = nil) -> [[ChartPoint]] {
         let targetRanges = glucoseRangeSchedule.quantityBetween(
             start: ChartAxisValueDate.dateFromScalar(xAxisValues.first!.scalar),
             end: ChartAxisValueDate.dateFromScalar(xAxisValues.last!.scalar)
@@ -39,15 +39,15 @@ extension ChartPoint {
                 endDate = ChartAxisValueDate(date: targetRanges[index + 1].startDate, formatter: dateFormatter)
             }
 
-            if let override = override, startDate.date < endDate.date {
+            if let potentialOverride = potentialOverride, startDate.date < endDate.date {
                 let chartRange = startDate.date...endDate.date
-                let overrideRange = override.startDate...override.endDate
+                let overrideRange = potentialOverride.startDate...potentialOverride.endDate
                 if overrideRange.overlaps(chartRange) {
-                    addBar(value: range.value, unit: unit, startDate: startDate, endDate: ChartAxisValueDate(date: override.startDate, formatter: dateFormatter), maxPoints: &maxPoints, minPoints: &minPoints)
+                    addBar(value: range.value, unit: unit, startDate: startDate, endDate: ChartAxisValueDate(date: potentialOverride.startDate, formatter: dateFormatter), maxPoints: &maxPoints, minPoints: &minPoints)
                     result += [maxPoints + minPoints.reversed()]
                     maxPoints = []
                     minPoints = []
-                    addBar(value: range.value, unit: unit, startDate: ChartAxisValueDate(date: override.endDate, formatter: dateFormatter), endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
+                    addBar(value: range.value, unit: unit, startDate: ChartAxisValueDate(date: potentialOverride.endDate, formatter: dateFormatter), endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
                 } else {
                     addBar(value: range.value, unit: unit, startDate: startDate, endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
                 }

--- a/LoopUI/Extensions/ChartPoint.swift
+++ b/LoopUI/Extensions/ChartPoint.swift
@@ -13,7 +13,7 @@ import SwiftCharts
 
 
 extension ChartPoint {
-    static func pointsForGlucoseRangeSchedule(_ glucoseRangeSchedule: GlucoseRangeSchedule, unit: HKUnit, xAxisValues: [ChartAxisValue]) -> [ChartPoint] {
+    static func pointsForGlucoseRangeSchedule(_ glucoseRangeSchedule: GlucoseRangeSchedule, unit: HKUnit, xAxisValues: [ChartAxisValue], considering override: TemporaryScheduleOverride? = nil) -> [[ChartPoint]] {
         let targetRanges = glucoseRangeSchedule.quantityBetween(
             start: ChartAxisValueDate.dateFromScalar(xAxisValues.first!.scalar),
             end: ChartAxisValueDate.dateFromScalar(xAxisValues.last!.scalar)
@@ -21,6 +21,7 @@ extension ChartPoint {
 
         let dateFormatter = DateFormatter()
 
+        var result = [[ChartPoint]]()
         var maxPoints: [ChartPoint] = []
         var minPoints: [ChartPoint] = []
 
@@ -38,22 +39,42 @@ extension ChartPoint {
                 endDate = ChartAxisValueDate(date: targetRanges[index + 1].startDate, formatter: dateFormatter)
             }
 
-            let value = range.value.doubleRangeWithMinimumIncrement(in: unit)
-            let minValue = ChartAxisValueDouble(value.minValue)
-            let maxValue = ChartAxisValueDouble(value.maxValue)
-
-            maxPoints += [
-                ChartPoint(x: startDate, y: maxValue),
-                ChartPoint(x: endDate, y: maxValue)
-            ]
-
-            minPoints += [
-                ChartPoint(x: startDate, y: minValue),
-                ChartPoint(x: endDate, y: minValue)
-            ]
+            if let override = override, startDate.date < endDate.date {
+                let chartRange = startDate.date...endDate.date
+                let overrideRange = override.startDate...override.endDate
+                if overrideRange.overlaps(chartRange) {
+                    addBar(value: range.value, unit: unit, startDate: startDate, endDate: ChartAxisValueDate(date: override.startDate, formatter: dateFormatter), maxPoints: &maxPoints, minPoints: &minPoints)
+                    result += [maxPoints + minPoints.reversed()]
+                    maxPoints = []
+                    minPoints = []
+                    addBar(value: range.value, unit: unit, startDate: ChartAxisValueDate(date: override.endDate, formatter: dateFormatter), endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
+                }
+            } else {
+                addBar(value: range.value, unit: unit, startDate: startDate, endDate: endDate, maxPoints: &maxPoints, minPoints: &minPoints)
+            }
         }
-
-        return maxPoints + minPoints.reversed()
+        result += [maxPoints + minPoints.reversed()]
+        
+        return result
+    }
+    
+    static fileprivate func addBar(value: ClosedRange<HKQuantity>, unit: HKUnit, startDate: ChartAxisValueDate, endDate: ChartAxisValueDate,
+                                   maxPoints: inout [ChartPoint], minPoints: inout [ChartPoint]) {
+        guard startDate.date < endDate.date else { return }
+        
+        let value = value.doubleRangeWithMinimumIncrement(in: unit)
+        let minValue = ChartAxisValueDouble(value.minValue)
+        let maxValue = ChartAxisValueDouble(value.maxValue)
+        
+        maxPoints += [
+            ChartPoint(x: startDate, y: maxValue),
+            ChartPoint(x: endDate, y: maxValue)
+        ]
+        
+        minPoints += [
+            ChartPoint(x: startDate, y: minValue),
+            ChartPoint(x: endDate, y: minValue)
+        ]
     }
 
     static func pointsForGlucoseRangeScheduleOverride(_ override: TemporaryScheduleOverride, unit: HKUnit, xAxisValues: [ChartAxisValue], extendEndDateToChart: Bool = false) -> [ChartPoint] {


### PR DESCRIPTION
If pre-meal or workout is active, this splits or clamps any glucose target override bars that might span their time interval.  
It's easier to show the before and after...

Before:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-11-03 at 17 05 15](https://user-images.githubusercontent.com/308993/98057304-d81ef580-1df6-11eb-90f1-bf0842dd8a78.png)

After:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-11-03 at 17 06 13](https://user-images.githubusercontent.com/308993/98057341-e836d500-1df6-11eb-8646-1660222d34f3.png)


[LOOP-2211](https://tidepool.atlassian.net/browse/LOOP-2211)