### PR TITLE
Open the debug menu if you rotate the phone 6 times

### DIFF
--- a/Loop/DerivedAssets.xcassets/Contents.json
+++ b/Loop/DerivedAssets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -184,6 +184,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         refreshContext.update(with: .size(size))
 
+        maybeOpenDebugMenu()
+        
         super.viewWillTransition(to: size, with: coordinator)
     }
 
@@ -1577,6 +1579,32 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
 
     // MARK: - Debug Scenarios and Simulated Core Data
+    
+    var lastOrientation: UIDeviceOrientation?
+    var rotateCount = 0
+    let maxRotationsToTrigger = 6
+    var rotateTimer: Timer?
+    let rotateTimerTimeout = TimeInterval.seconds(2)
+    private func maybeOpenDebugMenu() {
+        // Opens the debug menu if you rotate the phone 6 times (or back & forth 3 times), each rotation within 2 secs.
+        if lastOrientation != UIDevice.current.orientation {
+            if UIDevice.current.orientation == .portrait && rotateCount >= maxRotationsToTrigger-1 {
+                presentDebugMenu()
+                rotateCount = 0
+                rotateTimer?.invalidate()
+                rotateTimer = nil
+            } else {
+                rotateTimer?.invalidate()
+                rotateTimer = Timer.scheduledTimer(withTimeInterval: rotateTimerTimeout, repeats: false) { [weak self] _ in
+                    self?.rotateCount = 0
+                    self?.rotateTimer?.invalidate()
+                    self?.rotateTimer = nil
+                }
+                rotateCount += 1
+            }
+        }
+        lastOrientation = UIDevice.current.orientation
+    }
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         if FeatureFlags.scenariosEnabled || FeatureFlags.simulatedCoreDataEnabled || FeatureFlags.mockTherapySettingsEnabled {

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1586,6 +1586,9 @@ final class StatusTableViewController: LoopChartsTableViewController {
     var rotateTimer: Timer?
     let rotateTimerTimeout = TimeInterval.seconds(2)
     private func maybeOpenDebugMenu() {
+        guard FeatureFlags.scenariosEnabled || FeatureFlags.simulatedCoreDataEnabled || FeatureFlags.mockTherapySettingsEnabled else {
+            return
+        }
         // Opens the debug menu if you rotate the phone 6 times (or back & forth 3 times), each rotation within 2 secs.
         if lastOrientation != UIDevice.current.orientation {
             if UIDevice.current.orientation == .portrait && rotateCount >= maxRotationsToTrigger-1 {


### PR DESCRIPTION
This is a workaround for browserstack not supporting "shake" (to open the debug menu).  This is a second method for opening the debug menu: if you rotate the phone 6 times (or back & forth 3 times) with each rotation within 2 seconds, it will bring up the debug menu.
