### PR TITLE
[LOOP-2390] Block Pre-Meal or Workout Preset editing screen

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1091,10 +1091,15 @@ final class StatusTableViewController: LoopChartsTableViewController {
                         }
                     }
                 case .scheduleOverrideEnabled(let override):
-                    let vc = AddEditOverrideTableViewController(glucoseUnit: statusCharts.glucose.glucoseUnit)
-                    vc.inputMode = .editOverride(override)
-                    vc.delegate = self
-                    show(vc, sender: tableView.cellForRow(at: indexPath))
+                    switch override.context {
+                    case .preMeal, .legacyWorkout:
+                        break
+                    default:
+                        let vc = AddEditOverrideTableViewController(glucoseUnit: statusCharts.glucose.glucoseUnit)
+                        vc.inputMode = .editOverride(override)
+                        vc.delegate = self
+                        show(vc, sender: tableView.cellForRow(at: indexPath))
+                    }
                 case .bolusing:
                     self.updateHUDandStatusRows(statusRowMode: .cancelingBolus, newSize: nil, animated: true)
                     self.deviceManager.pumpManager?.cancelBolus() { (result) in


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2390

blocking taps on premeal and workout status row

Note that `.premeal` and `.legacyWorkout` were previously being blocked from being displayed in the status row. As such, this will not have any impact on DIY builds.