### PR TITLE
[LOOP-2433] Mock pump reservoir display in widget

### DIFF
--- a/Common/Models/PumpManager.swift
+++ b/Common/Models/PumpManager.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 import LoopKit
+import LoopKitUI
 import MockKit
+import MockKitUI
 
 public struct AvailableDevice {
     let identifier: String
@@ -15,11 +17,11 @@ public struct AvailableDevice {
 }
 
 
-let staticPumpManagers: [PumpManager.Type] = [
+let staticPumpManagers: [PumpManagerUI.Type] = [
     MockPumpManager.self,
 ]
 
-let staticPumpManagersByIdentifier: [String: PumpManager.Type] = staticPumpManagers.reduce(into: [:]) { (map, Type) in
+let staticPumpManagersByIdentifier: [String: PumpManagerUI.Type] = staticPumpManagers.reduce(into: [:]) { (map, Type) in
     map[Type.managerIdentifier] = Type
 }
 

--- a/Common/Models/PumpManagerUI.swift
+++ b/Common/Models/PumpManagerUI.swift
@@ -9,10 +9,8 @@
 import Foundation
 import LoopKit
 import LoopKitUI
-import MockKit
-import MockKitUI
 
-private let managersByIdentifier: [String: PumpManagerUI.Type] = staticPumpManagers.compactMap{ $0 as? PumpManagerUI.Type}.reduce(into: [:]) { (map, Type) in
+private let managersByIdentifier: [String: PumpManagerUI.Type] = staticPumpManagers.compactMap{ $0 }.reduce(into: [:]) { (map, Type) in
     map[Type.managerIdentifier] = Type
 }
 
@@ -22,14 +20,9 @@ func PumpManagerHUDViewFromRawValue(_ rawValue: PumpManagerHUDViewRawValue, plug
     guard
         let identifier = rawValue["managerIdentifier"] as? String,
         let rawState = rawValue["hudProviderView"] as? HUDProvider.HUDViewRawState,
-        let manager = pluginManager.getPumpManagerTypeByIdentifier(identifier) ?? staticPumpManagersByIdentifier[identifier] as? PumpManagerUI.Type else
+        let manager = pluginManager.getPumpManagerTypeByIdentifier(identifier) ?? staticPumpManagersByIdentifier[identifier] else
     {
         return nil
-    }
-
-    // this type casting is needed to have the mock pump HUD view display in the widget
-    if let mockPumpManager = manager as? MockPumpManager.Type {
-        return mockPumpManager.createHUDView(rawValue: rawState)
     }
 
     return manager.createHUDView(rawValue: rawState)

--- a/Common/Models/PumpManagerUI.swift
+++ b/Common/Models/PumpManagerUI.swift
@@ -10,10 +10,6 @@ import Foundation
 import LoopKit
 import LoopKitUI
 
-private let managersByIdentifier: [String: PumpManagerUI.Type] = staticPumpManagers.compactMap{ $0 }.reduce(into: [:]) { (map, Type) in
-    map[Type.managerIdentifier] = Type
-}
-
 typealias PumpManagerHUDViewRawValue = [String: Any]
 
 func PumpManagerHUDViewFromRawValue(_ rawValue: PumpManagerHUDViewRawValue, pluginManager: PluginManager) -> LevelHUDView? {

--- a/Common/Models/PumpManagerUI.swift
+++ b/Common/Models/PumpManagerUI.swift
@@ -9,6 +9,7 @@
 import Foundation
 import LoopKit
 import LoopKitUI
+import MockKit
 import MockKitUI
 
 private let managersByIdentifier: [String: PumpManagerUI.Type] = staticPumpManagers.compactMap{ $0 as? PumpManagerUI.Type}.reduce(into: [:]) { (map, Type) in
@@ -25,6 +26,12 @@ func PumpManagerHUDViewFromRawValue(_ rawValue: PumpManagerHUDViewRawValue, plug
     {
         return nil
     }
+
+    // this type casting is needed to have the mock pump HUD view display in the widget
+    if let mockPumpManager = manager as? MockPumpManager.Type {
+        return mockPumpManager.createHUDView(rawValue: rawState)
+    }
+
     return manager.createHUDView(rawValue: rawState)
 }
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2433

type casting to display the mock pump HUD view

Note: To me, this is a strange fix to this problem. I don't fully understand the root issue, but this definitely allows the mock pump reservoir to display in the widget.