### PR TITLE
[LOOP-2422] Replace dash with en-dash

### DIFF
--- a/Loop/View Models/SimpleBolusViewModel.swift
+++ b/Loop/View Models/SimpleBolusViewModel.swift
@@ -61,7 +61,7 @@ class SimpleBolusViewModel: ObservableObject {
 
     var isNoticeVisible: Bool { return activeNotice != nil }    
 
-    @Published var recommendedBolus: String = "0"
+    @Published var recommendedBolus: String = "–"
     
     @Published var activeInsulin: String?
 
@@ -116,7 +116,7 @@ class SimpleBolusViewModel: ObservableObject {
                 recommendedBolus = recommendationString
                 enteredBolusAmount = recommendationString
             } else {
-                recommendedBolus = NSLocalizedString("-", comment: "String denoting lack of a recommended bolus amount in the simple bolus calculator")
+                recommendedBolus = NSLocalizedString("–", comment: "String denoting lack of a recommended bolus amount in the simple bolus calculator")
                 enteredBolusAmount = Self.doseAmountFormatter.string(from: 0.0)!
             }
         }

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -190,7 +190,7 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                 HStack(alignment: .firstTextBaseline) {
                     DismissibleKeyboardTextField(
                         text: typedManualGlucoseEntry,
-                        placeholder: NSLocalizedString("---", comment: "No glucose value representation (3 dashes for mg/dL)"),
+                        placeholder: NSLocalizedString("– – –", comment: "No glucose value representation (3 dashes for mg/dL)"),
                         // The heavy title is ending up clipped due to a bug that is fixed in iOS 14.  Uncomment the following when we can build for iOS 14.
                         font: .preferredFont(forTextStyle: .title1), // .heavy(.title1),
                         textAlignment: .right,
@@ -461,7 +461,7 @@ struct LabeledQuantity: View {
 
     var valueText: Text {
         guard let quantity = quantity else {
-            return Text("--")
+            return Text("– –")
         }
         
         let formatter = QuantityFormatter()

--- a/Loop/Views/SimpleBolusView.swift
+++ b/Loop/Views/SimpleBolusView.swift
@@ -137,7 +137,7 @@ struct SimpleBolusView: View, HorizontalSizeClassOverride {
             HStack(alignment: .firstTextBaseline) {
                 DismissibleKeyboardTextField(
                     text: $viewModel.enteredGlucoseAmount,
-                    placeholder: NSLocalizedString("---", comment: "No glucose value representation (3 dashes for mg/dL)"),
+                    placeholder: NSLocalizedString("– – –", comment: "No glucose value representation (3 dashes for mg/dL)"),
                     // The heavy title is ending up clipped due to a bug that is fixed in iOS 14.  Uncomment the following when we can build for iOS 14.
                     font: .preferredFont(forTextStyle: .title1), // .heavy(.title1),
                     textAlignment: .right,

--- a/LoopTests/ViewModels/CGMStatusHUDViewModelTests.swift
+++ b/LoopTests/ViewModels/CGMStatusHUDViewModelTests.swift
@@ -26,10 +26,10 @@ class CGMStatusHUDViewModelTests: XCTestCase {
     }
 
     func testInitialization() throws {
-        XCTAssertEqual(CGMStatusHUDViewModel.staleGlucoseRepresentation, "---")
+        XCTAssertEqual(CGMStatusHUDViewModel.staleGlucoseRepresentation, "– – –")
         XCTAssertNil(viewModel.trend)
         XCTAssertEqual(viewModel.unitsString, "–")
-        XCTAssertEqual(viewModel.glucoseValueString, "---")
+        XCTAssertEqual(viewModel.glucoseValueString, "– – –")
         XCTAssertTrue(viewModel.accessibilityString.isEmpty)
         XCTAssertEqual(viewModel.glucoseValueTintColor, .label)
         XCTAssertEqual(viewModel.glucoseTrendTintColor, .glucoseTintColor)
@@ -76,7 +76,7 @@ class CGMStatusHUDViewModelTests: XCTestCase {
         
         XCTAssertNil(viewModel.manualGlucoseTrendIconOverride)
         XCTAssertNil(viewModel.statusHighlight)
-        XCTAssertEqual(viewModel.glucoseValueString, "---")
+        XCTAssertEqual(viewModel.glucoseValueString, "– – –")
         XCTAssertNil(viewModel.trend)
         XCTAssertNotEqual(viewModel.glucoseTrendTintColor, glucoseDisplay.glucoseRangeCategory?.trendColor)
         XCTAssertEqual(viewModel.glucoseTrendTintColor, .glucoseTintColor)
@@ -103,7 +103,7 @@ class CGMStatusHUDViewModelTests: XCTestCase {
         XCTAssertTrue(staleGlucoseValueHandlerWasCalled)
         XCTAssertNil(viewModel.manualGlucoseTrendIconOverride)
         XCTAssertNil(viewModel.statusHighlight)
-        XCTAssertEqual(viewModel.glucoseValueString, "---")
+        XCTAssertEqual(viewModel.glucoseValueString, "– – –")
         XCTAssertNil(viewModel.trend)
         XCTAssertNotEqual(viewModel.glucoseTrendTintColor, glucoseDisplay.glucoseRangeCategory?.trendColor)
         XCTAssertEqual(viewModel.glucoseTrendTintColor, .glucoseTintColor)

--- a/LoopTests/ViewModels/SimpleBolusViewModelTests.swift
+++ b/LoopTests/ViewModels/SimpleBolusViewModelTests.swift
@@ -157,7 +157,7 @@ class SimpleBolusViewModelTests: XCTestCase {
 
         viewModel.enteredCarbAmount = ""
 
-        XCTAssertEqual("-", viewModel.recommendedBolus)
+        XCTAssertEqual("–", viewModel.recommendedBolus)
         XCTAssertEqual("0", viewModel.enteredBolusAmount)
     }
 
@@ -176,7 +176,7 @@ class SimpleBolusViewModelTests: XCTestCase {
 
         viewModel.enteredGlucoseAmount = ""
 
-        XCTAssertEqual("-", viewModel.recommendedBolus)
+        XCTAssertEqual("–", viewModel.recommendedBolus)
         XCTAssertEqual("0", viewModel.enteredBolusAmount)
     }
 

--- a/LoopUI/ViewModel/CGMStatusHUDViewModel.swift
+++ b/LoopUI/ViewModel/CGMStatusHUDViewModel.swift
@@ -11,7 +11,7 @@ import LoopKit
 
 public class CGMStatusHUDViewModel {
     
-    static let staleGlucoseRepresentation: String = NSLocalizedString("---", comment: "No glucose value representation (3 dashes for mg/dL)")
+    static let staleGlucoseRepresentation: String = NSLocalizedString("– – –", comment: "No glucose value representation (3 dashes for mg/dL)")
     
     var trend: GlucoseTrend?
     

--- a/LoopUI/Views/GlucoseHUDView.swift
+++ b/LoopUI/Views/GlucoseHUDView.swift
@@ -13,7 +13,7 @@ import LoopKitUI
 
 public final class GlucoseHUDView: BaseHUDView {
     
-    static let staleGlucoseRepresentation: String = NSLocalizedString("---", comment: "No glucose value representation (3 dashes for mg/dL)")
+    static let staleGlucoseRepresentation: String = NSLocalizedString("– – –", comment: "No glucose value representation (3 dashes for mg/dL)")
     
     private var stalenessTimer: Timer?
     

--- a/WatchApp Extension/Controllers/HUDInterfaceController.swift
+++ b/WatchApp Extension/Controllers/HUDInterfaceController.swift
@@ -68,7 +68,7 @@ class HUDInterfaceController: WKInterfaceController {
         }())
 
         if date != nil {
-            glucoseLabel.setText("---")
+            glucoseLabel.setText("– – –")
             glucoseLabel.setHidden(false)
             if let glucose = activeContext.glucose, let glucoseDate = activeContext.glucoseDate, let unit = activeContext.preferredGlucoseUnit, glucoseDate.timeIntervalSinceNow > -LoopCoreConstants.inputDataRecencyInterval {
                 let formatter = NumberFormatter.glucoseFormatter(for: unit)

--- a/WatchApp Extension/Controllers/HUDInterfaceController.swift
+++ b/WatchApp Extension/Controllers/HUDInterfaceController.swift
@@ -68,7 +68,7 @@ class HUDInterfaceController: WKInterfaceController {
         }())
 
         if date != nil {
-            glucoseLabel.setText("– – –")
+            glucoseLabel.setText(NSLocalizedString("– – –", comment: "No glucose value representation (3 dashes for mg/dL)"))
             glucoseLabel.setHidden(false)
             if let glucose = activeContext.glucose, let glucoseDate = activeContext.glucoseDate, let unit = activeContext.preferredGlucoseUnit, glucoseDate.timeIntervalSinceNow > -LoopCoreConstants.inputDataRecencyInterval {
                 let formatter = NumberFormatter.glucoseFormatter(for: unit)

--- a/WatchApp Extension/Extensions/CLKComplicationTemplate.swift
+++ b/WatchApp Extension/Extensions/CLKComplicationTemplate.swift
@@ -62,7 +62,7 @@ extension CLKComplicationTemplate {
         let isGlucoseStale = date.timeIntervalSince(glucoseDate) > recencyInterval
 
         if isGlucoseStale {
-            glucoseString = "---"
+            glucoseString = "– – –"
             trendString = ""
         } else {
             guard let formattedGlucose = formatter.string(from: glucose.doubleValue(for: unit)) else {

--- a/WatchApp Extension/Extensions/CLKComplicationTemplate.swift
+++ b/WatchApp Extension/Extensions/CLKComplicationTemplate.swift
@@ -62,7 +62,7 @@ extension CLKComplicationTemplate {
         let isGlucoseStale = date.timeIntervalSince(glucoseDate) > recencyInterval
 
         if isGlucoseStale {
-            glucoseString = "– – –"
+            glucoseString = NSLocalizedString("---", comment: "No glucose value representation (3 dashes for mg/dL; no spaces as this will get truncated in the watch complication)")
             trendString = ""
         } else {
             guard let formattedGlucose = formatter.string(from: glucose.doubleValue(for: unit)) else {

--- a/WatchApp/Base.lproj/Interface.storyboard
+++ b/WatchApp/Base.lproj/Interface.storyboard
@@ -184,10 +184,10 @@
                                     <items>
                                         <group width="1" height="26" alignment="left" id="pYI-3J-lxs">
                                             <items>
-                                                <label height="1" alignment="left" hidden="YES" text="---" textAlignment="center" id="Dt1-kz-jMZ">
+                                                <label height="1" alignment="left" hidden="YES" text="– – –" textAlignment="center" id="Dt1-kz-jMZ">
                                                     <fontDescription key="font" type="system" weight="light" pointSize="24"/>
                                                 </label>
-                                                <label height="1" alignment="right" hidden="YES" text="---" textAlignment="center" id="yl8-ZP-c3l">
+                                                <label height="1" alignment="right" hidden="YES" text="– – –" textAlignment="center" id="yl8-ZP-c3l">
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <fontDescription key="font" type="system" weight="light" pointSize="24"/>
                                                 </label>


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-2242

Now changing dash to en-dash.

Also, the recommended bolus default string was changed to en-dash. Those spaces between the en-dashes look suspect, but they display well. Without them, it would look like just a line. However, the watch complication doesn't use spaces as this would truncate the string.