### PR TITLE
Introduce a "BuildOverride.xcconfig" to change app name to include branch

### DIFF
--- a/Loop.xcconfig
+++ b/Loop.xcconfig
@@ -13,7 +13,7 @@ MAIN_APP_BUNDLE_IDENTIFIER = com.${DEVELOPMENT_TEAM}.loopkit
 // Application name [DEFAULT]
 MAIN_APP_DISPLAY_NAME = Loop
 
-// Appication icon [DEFAULT]
+// Application icon [DEFAULT]
 APPICON_NAME = AppIcon
 
 // Features [DEFAULT]
@@ -44,3 +44,6 @@ LOOP_PROVISIONING_PROFILE_SPECIFIER_WATCHAPP_EXTENSION_RELEASE =
 
 // Optional overrides
 #include? "LoopOverride.xcconfig"
+
+// Build-time overrides
+#include? "BuildOverride.xcconfig"


### PR DESCRIPTION
Introduces a way for the build to add its own overrides to things like `MAIN_APP_DISPLAY_NAME`.  See also https://github.com/tidepool-org/LoopWorkspace/pull/355