### PR TITLE
LOOP-2325: iOS14: use InsetGroupedListStyle for iOS 14

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -14,7 +14,7 @@ import LoopKitUI
 import LoopUI
 
 
-struct BolusEntryView: View, HorizontalSizeClassOverride {
+struct BolusEntryView: View {
     @ObservedObject var viewModel: BolusEntryViewModel
 
     @State private var enteredBolusAmount = ""
@@ -40,8 +40,7 @@ struct BolusEntryView: View, HorizontalSizeClassOverride {
                 // Unfortunately, after entry, the field scoots back down and remains hidden.  So this is not a great solution.
                 // TODO: Fix this in Xcode 12 when we're building for iOS 14.
                 .padding(.top, self.shouldAutoScroll(basedOn: geometry) ? -200 : -28)
-                .listStyle(GroupedListStyle())
-                .environment(\.horizontalSizeClass, self.horizontalOverride)
+                .insetGroupedListStyle()
                 
                 self.actionArea
                     .frame(height: self.isKeyboardVisible ? 0 : nil)

--- a/Loop/Views/NotificationsCriticalAlertPermissionsView.swift
+++ b/Loop/Views/NotificationsCriticalAlertPermissionsView.swift
@@ -9,7 +9,7 @@
 import LoopKitUI
 import SwiftUI
 
-public struct NotificationsCriticalAlertPermissionsView: View, HorizontalSizeClassOverride {
+public struct NotificationsCriticalAlertPermissionsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appName) private var appName
 
@@ -49,10 +49,9 @@ public struct NotificationsCriticalAlertPermissionsView: View, HorizontalSizeCla
             manageCriticalAlertsSection
             notificationAndCriticalAlertPermissionSupportSection
         }
-        .listStyle(GroupedListStyle())
+        .insetGroupedListStyle()
         .navigationBarTitle(Text(NSLocalizedString("Alert Permissions", comment: "Notification & Critical Alert Permissions screen title")))
         .navigationBarItems(leading: dismissButton)
-        .environment(\.horizontalSizeClass, horizontalOverride)
     }
 }
 

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -11,7 +11,7 @@ import LoopKitUI
 import MockKit
 import SwiftUI
 
-public struct SettingsView: View, HorizontalSizeClassOverride {
+public struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.appName) private var appName
     @Environment(\.carbTintColor) private var carbTintColor
@@ -49,10 +49,9 @@ public struct SettingsView: View, HorizontalSizeClassOverride {
                 }
                 supportSection
             }
-            .listStyle(GroupedListStyle())
+            .insetGroupedListStyle()
             .navigationBarTitle(Text(NSLocalizedString("Settings", comment: "Settings screen title")))
             .navigationBarItems(trailing: dismissButton)
-            .environment(\.horizontalSizeClass, horizontalOverride)
         }
     }
     
@@ -201,7 +200,7 @@ extension SettingsView {
             ForEach(viewModel.servicesViewModel.activeServices().indices, id: \.self) { index in
                 LargeButton(action: { self.viewModel.servicesViewModel.didTapService(index) },
                             includeArrow: true,
-                            imageView: self.serviceImage(uiImage: (self.viewModel.servicesViewModel.activeServices()[index] as! ServiceUI).image),
+                            imageView: self.serviceImage(uiImage: (self.viewModel.servicesViewModel.activeServices()[index] as? ServiceUI)?.image),
                             label: self.viewModel.servicesViewModel.activeServices()[index].localizedTitle,
                             descriptiveText: "")
             }

--- a/Loop/Views/SimpleBolusView.swift
+++ b/Loop/Views/SimpleBolusView.swift
@@ -12,7 +12,7 @@ import LoopKitUI
 import HealthKit
 import LoopCore
 
-struct SimpleBolusView: View, HorizontalSizeClassOverride {
+struct SimpleBolusView: View {
 
     @Environment(\.dismiss) var dismiss
     
@@ -48,8 +48,7 @@ struct SimpleBolusView: View, HorizontalSizeClassOverride {
                 // Unfortunately, after entry, the field scoots back down and remains hidden.  So this is not a great solution.
                 // TODO: Fix this in Xcode 12 when we're building for iOS 14.
                 .padding(.top, self.shouldAutoScroll(basedOn: geometry) ? -200 : 0)
-                .listStyle(GroupedListStyle()) // In iOS 14, this should be InsetGroupedListStyle()
-                .environment(\.horizontalSizeClass, .regular)
+                .insetGroupedListStyle()
                 .navigationBarTitle(Text(self.title), displayMode: .inline)
                 
                 self.actionArea

--- a/Loop/Views/SupportScreenView.swift
+++ b/Loop/Views/SupportScreenView.swift
@@ -10,7 +10,7 @@ import LoopKit
 import LoopKitUI
 import SwiftUI
 
-struct SupportScreenView: View, HorizontalSizeClassOverride {
+struct SupportScreenView: View {
     @Environment(\.dismiss) private var dismiss
     
     var didTapIssueReport: ((_ title: String) -> Void)?
@@ -35,9 +35,8 @@ struct SupportScreenView: View, HorizontalSizeClassOverride {
                 }
             }
         }
-        .listStyle(GroupedListStyle())
+        .insetGroupedListStyle()
         .navigationBarTitle(Text("Support", comment: "Support screen title"))
-        .environment(\.horizontalSizeClass, horizontalOverride)
     }
     
     private var adverseEventReport: some View {


### PR DESCRIPTION
This adds a View modifier that will use InsetGroupedListStyle for iOS 14, but fall back to the old GroupedListStyle with horizontalSizeClass override hack for prior iOS versions.

[LOOP-2325](https://tidepool.atlassian.net/browse/LOOP-2325)