### PR TITLE
(Temporarily?) Remove `com.apple.developer.healthkit.access` key to fix TestFlight uploads

### DIFF
--- a/Loop/Loop.entitlements
+++ b/Loop/Loop.entitlements
@@ -6,8 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 	<key>com.apple.developer.siri</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/WatchApp Extension/WatchApp Extension.entitlements
+++ b/WatchApp Extension/WatchApp Extension.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 	<key>com.apple.developer.siri</key>
 	<true/>
 </dict>


### PR DESCRIPTION
…ix TestFlight uploads

Uploads to ASC (TestFlight) are failing.
See https://developer.apple.com/forums/thread/671352

Hopefully this is a temporary workaround.

(Take 2...retrying this again)