### PR TITLE
LOOP-2534 Refactor onboarding and support manager plugins

### DIFF
--- a/Common/Models/PumpManager.swift
+++ b/Common/Models/PumpManager.swift
@@ -20,7 +20,7 @@ let staticPumpManagersByIdentifier: [String: PumpManagerUI.Type] = [
 ]
 
 let availableStaticPumpManagers = [
-    AvailableDevice(identifier: MockPumpManager.managerIdentifier, localizedTitle: MockPumpManager.localizedTitle, providesOnboarding: false)
+    PumpManagerDescriptor(identifier: MockPumpManager.managerIdentifier, localizedTitle: MockPumpManager.localizedTitle)
 ]
 
 extension PumpManager {

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -409,6 +409,7 @@
 		A9CBE45C248ACC03008E7BA2 /* SettingsStore+SimulatedCoreData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CBE45B248ACC03008E7BA2 /* SettingsStore+SimulatedCoreData.swift */; };
 		A9CE912224CA032E00302A40 /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430B29892041F54A00BA9F93 /* NSUserDefaults.swift */; };
 		A9DAE7D02332D77F006AE942 /* LoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DAE7CF2332D77F006AE942 /* LoopTests.swift */; };
+		A9DCF32A25B0FABF00C89088 /* LoopUIColorPalette+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DCF2D525B0F3C500C89088 /* LoopUIColorPalette+Default.swift */; };
 		A9DF02CB24F72B9E00B7C988 /* CriticalEventLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02CA24F72B9E00B7C988 /* CriticalEventLogTests.swift */; };
 		A9DF02CD24F72BC800B7C988 /* PersistenceControllerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DF02CC24F72BC800B7C988 /* PersistenceControllerTestCase.swift */; };
 		A9DFAFB324F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFAFB224F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift */; };
@@ -1290,6 +1291,7 @@
 		A9CBE459248ACBE1008E7BA2 /* DosingDecisionStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DosingDecisionStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A9CBE45B248ACC03008E7BA2 /* SettingsStore+SimulatedCoreData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsStore+SimulatedCoreData.swift"; sourceTree = "<group>"; };
 		A9DAE7CF2332D77F006AE942 /* LoopTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoopTests.swift; sourceTree = "<group>"; };
+		A9DCF2D525B0F3C500C89088 /* LoopUIColorPalette+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoopUIColorPalette+Default.swift"; sourceTree = "<group>"; };
 		A9DF02CA24F72B9E00B7C988 /* CriticalEventLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalEventLogTests.swift; sourceTree = "<group>"; };
 		A9DF02CC24F72BC800B7C988 /* PersistenceControllerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistenceControllerTestCase.swift; sourceTree = "<group>"; };
 		A9DFAFB224F0415E00950D1E /* CarbBackfillRequestUserInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbBackfillRequestUserInfoTests.swift; sourceTree = "<group>"; };
@@ -1930,6 +1932,7 @@
 				A92E557D2464DFFD00DB93BB /* DosingDecisionStore.swift */,
 				A9CBE459248ACBE1008E7BA2 /* DosingDecisionStore+SimulatedCoreData.swift */,
 				A9F703742489C9A000C98AD8 /* GlucoseStore+SimulatedCoreData.swift */,
+				A9DCF2D525B0F3C500C89088 /* LoopUIColorPalette+Default.swift */,
 				438172D81F4E9E37003C3328 /* NewPumpEvent.swift */,
 				89E267FE229267DF00A3F2AF /* Optional.swift */,
 				A967D94B24F99B9300CDDF8A /* OutputStream.swift */,
@@ -3423,6 +3426,7 @@
 				A9F703772489D8AA00C98AD8 /* PersistentDeviceLog+SimulatedCoreData.swift in Sources */,
 				C148CEE724FD91BD00711B3B /* DeliveryUncertaintyAlertManager.swift in Sources */,
 				435400341C9F878D00D5819C /* SetBolusUserInfo.swift in Sources */,
+				A9DCF32A25B0FABF00C89088 /* LoopUIColorPalette+Default.swift in Sources */,
 				1DDE273E24AEA4B000796622 /* SettingsView.swift in Sources */,
 				A9B607B0247F000F00792BE4 /* UserNotifications+Loop.swift in Sources */,
 				43F89CA322BDFBBD006BB54E /* UIActivityIndicatorView.swift in Sources */,

--- a/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
+++ b/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
@@ -72,7 +72,7 @@ extension DeviceDataManager {
         } else if let cgmManagerUI = (cgmManager as? CGMManagerUI),
             let unit = glucoseStore.preferredUnit
         {
-            return .presentViewController(cgmManagerUI.settingsViewController(for: unit, glucoseTintColor: .glucoseTintColor, guidanceColors: .default))
+            return .presentViewController(cgmManagerUI.settingsViewController(for: unit, colorPalette: .default))
         } else {
             return .setupNewCGM
         }
@@ -87,7 +87,7 @@ extension DeviceDataManager {
         {
             return action
         } else if let pumpManager = pumpManager {
-            return .presentViewController(pumpManager.settingsViewController(insulinTintColor: .insulinTintColor, guidanceColors: .default))
+            return .presentViewController(pumpManager.settingsViewController(colorPalette: .default))
         } else {
             return .setupNewPump
         }

--- a/Loop/Extensions/LoopUIColorPalette+Default.swift
+++ b/Loop/Extensions/LoopUIColorPalette+Default.swift
@@ -1,0 +1,19 @@
+//
+//  LoopUIColorPalette+Default.swift
+//  LoopUI
+//
+//  Created by Darin Krauss on 1/14/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import LoopKitUI
+
+extension LoopUIColorPalette {
+    public static var `default`: LoopUIColorPalette {
+        return LoopUIColorPalette(guidanceColors: .default,
+                                  carbTintColor: .carbTintColor,
+                                  glucoseTintColor: .glucoseTintColor,
+                                  insulinTintColor: .insulinTintColor,
+                                  chartColorPalette: .primary)
+    }
+}

--- a/Loop/Extensions/UIAlertController.swift
+++ b/Loop/Extensions/UIAlertController.swift
@@ -69,22 +69,22 @@ extension UIAlertController {
     /// Initializes an action sheet-styled controller for selecting a PumpManager
     ///
     /// - Parameters:
-    ///   - pumpManagers: An array of available PumpManagers
+    ///   - availablePumpManagers: An array of available PumpManagers
     ///   - selectionHandler: A closure to execute when a manager is selected
     ///   - identifier: Identifier of the selected PumpManager
-    internal convenience init(pumpManagers: [AvailableDevice], selectionHandler: @escaping (_ identifier: String) -> Void) {
+    internal convenience init(availablePumpManagers: [PumpManagerDescriptor], selectionHandler: @escaping (_ identifier: String) -> Void) {
         self.init(
             title: NSLocalizedString("Add Pump", comment: "Action sheet title selecting Pump"),
             message: nil,
             preferredStyle: .actionSheet
         )
 
-        for device in pumpManagers {
+        for availablePumpManager in availablePumpManagers {
             addAction(UIAlertAction(
-                title: device.localizedTitle,
+                title: availablePumpManager.localizedTitle,
                 style: .default,
                 handler: { (_) in
-                    selectionHandler(device.identifier)
+                    selectionHandler(availablePumpManager.identifier)
                 }
             ))
         }
@@ -93,22 +93,22 @@ extension UIAlertController {
     /// Initializes an action sheet-styled controller for selecting a CGMManager
     ///
     /// - Parameters:
-    ///   - cgmManagers: An array of available CGMManagers
+    ///   - availableCGMManagers: An array of available CGMManagers
     ///   - selectionHandler: A closure to execute when either a new CGMManager or the current PumpManager is selected
     ///   - identifier: Identifier of the selected CGMManager
-    internal convenience init(cgmManagers: [AvailableDevice], selectionHandler: @escaping (_ identifier: String) -> Void) {
+    internal convenience init(availableCGMManagers: [CGMManagerDescriptor], selectionHandler: @escaping (_ identifier: String) -> Void) {
         self.init(
             title: NSLocalizedString("Add CGM", comment: "Action sheet title selecting CGM"),
             message: nil,
             preferredStyle: .actionSheet
         )
         
-        for manager in cgmManagers {
+        for availableCGMManager in availableCGMManagers {
             addAction(UIAlertAction(
-                title: manager.localizedTitle,
+                title: availableCGMManager.localizedTitle,
                 style: .default,
                 handler: { (_) in
-                    selectionHandler(manager.identifier)
+                    selectionHandler(availableCGMManager.identifier)
             }
             ))
         }
@@ -137,22 +137,22 @@ extension UIAlertController {
     /// Initializes an action sheet-styled controller for selecting a service.
     ///
     /// - Parameters:
-    ///   - services: An array of available services.
+    ///   - availableServices: An array of available services.
     ///   - selectionHandler: A closure to execute when a service is selected.
     ///   - identifier: The identifier of the selected service.
-    internal convenience init(services: [AvailableService], selectionHandler: @escaping (_ identifier: String) -> Void) {
+    internal convenience init(availableServices: [ServiceDescriptor], selectionHandler: @escaping (_ identifier: String) -> Void) {
         self.init(
             title: NSLocalizedString("Add Service", comment: "Action sheet title selecting service"),
             message: nil,
             preferredStyle: .actionSheet
         )
 
-        for service in services {
+        for availableService in availableServices {
             addAction(UIAlertAction(
-                title: service.localizedTitle,
+                title: availableService.localizedTitle,
                 style: .default,
                 handler: { (_) in
-                    selectionHandler(service.identifier)
+                    selectionHandler(availableService.identifier)
                 }
             ))
         }

--- a/Loop/Extensions/UserNotifications+Loop.swift
+++ b/Loop/Extensions/UserNotifications+Loop.swift
@@ -43,6 +43,8 @@ extension UNAuthorizationStatus: CustomStringConvertible {
             return "authorized"
         case .provisional:
             return "provisional"
+        case .ephemeral:
+            return "ephemeral"
         @unknown default:
             return "unknown"
         }

--- a/Loop/Managers/CGMManager.swift
+++ b/Loop/Managers/CGMManager.swift
@@ -16,7 +16,7 @@ let staticCGMManagersByIdentifier: [String: CGMManager.Type] = [
 ]
 
 let availableStaticCGMManagers = [
-    AvailableDevice(identifier: MockCGMManager.managerIdentifier, localizedTitle: MockCGMManager.localizedTitle, providesOnboarding: false)
+    CGMManagerDescriptor(identifier: MockCGMManager.managerIdentifier, localizedTitle: MockCGMManager.localizedTitle)
 ]
 
 func CGMManagerFromRawValue(_ rawValue: [String: Any]) -> CGMManager? {

--- a/Loop/Managers/CGMManager.swift
+++ b/Loop/Managers/CGMManager.swift
@@ -6,6 +6,7 @@
 //
 
 import LoopKit
+import LoopKitUI
 import MockKit
 
 // TODO: Need a flag other than Debug for including MockCGMManager

--- a/Loop/Managers/DeliveryUncertaintyAlertManager.swift
+++ b/Loop/Managers/DeliveryUncertaintyAlertManager.swift
@@ -21,7 +21,7 @@ class DeliveryUncertaintyAlertManager {
     }
 
     private func showUncertainDeliveryRecoveryView() {
-        var controller = pumpManager.deliveryUncertaintyRecoveryViewController(insulinTintColor: .insulinTintColor, guidanceColors: .default)
+        var controller = pumpManager.deliveryUncertaintyRecoveryViewController(colorPalette: .default)
         controller.completionDelegate = self
         self.rootViewController.present(controller, animated: true)
     }

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1352,3 +1352,10 @@ extension DeviceDataManager {
         }
     }
 }
+
+extension DeviceDataManager {
+    var availableSupports: [SupportUI] {
+        let availableSupports = pluginManager.availableSupports + servicesManager.availableSupports + [cgmManager, pumpManager].compactMap { $0 as? SupportUI }
+        return availableSupports.sorted { $0.supportIdentifier < $1.supportIdentifier } // Provide a consistent ordering
+    }
+}

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -293,8 +293,7 @@ final class DeviceDataManager {
             pluginManager: pluginManager,
             analyticsServicesManager: analyticsServicesManager,
             loggingServicesManager: loggingServicesManager,
-            remoteDataServicesManager: remoteDataServicesManager,
-            dataManager: loopManager
+            remoteDataServicesManager: remoteDataServicesManager
         )
 
         let criticalEventLogs: [CriticalEventLog] = [settingsStore, glucoseStore, carbStore, dosingDecisionStore, doseStore, deviceLog, alertManager.alertStore]
@@ -357,12 +356,12 @@ final class DeviceDataManager {
         return pumpManagerTypeFromRawValue(rawValue) != nil
     }
 
-    var availablePumpManagers: [AvailableDevice] {
+    var availablePumpManagers: [PumpManagerDescriptor] {
         return pluginManager.availablePumpManagers + availableStaticPumpManagers
     }
 
     public func pumpManagerTypeByIdentifier(_ identifier: String) -> PumpManagerUI.Type? {
-        return pluginManager.getPumpManagerTypeByIdentifier(identifier) ?? staticPumpManagersByIdentifier[identifier] as? PumpManagerUI.Type
+        return pluginManager.getPumpManagerTypeByIdentifier(identifier) ?? staticPumpManagersByIdentifier[identifier]
     }
 
     private func pumpManagerTypeFromRawValue(_ rawValue: [String: Any]) -> PumpManager.Type? {
@@ -412,10 +411,10 @@ final class DeviceDataManager {
         updatePumpManagerBLEHeartbeatPreference()
     }
 
-    var availableCGMManagers: [AvailableDevice] {
+    var availableCGMManagers: [CGMManagerDescriptor] {
         var availableCGMManagers = pluginManager.availableCGMManagers + availableStaticCGMManagers
         if let pumpManagerAsCGMManager = pumpManager as? CGMManager {
-            availableCGMManagers.append(AvailableDevice(identifier: pumpManagerAsCGMManager.managerIdentifier, localizedTitle: pumpManagerAsCGMManager.localizedTitle, providesOnboarding: false))
+            availableCGMManagers.append(CGMManagerDescriptor(identifier: pumpManagerAsCGMManager.managerIdentifier, localizedTitle: pumpManagerAsCGMManager.localizedTitle))
         }
         return availableCGMManagers
     }
@@ -424,14 +423,14 @@ final class DeviceDataManager {
         return pluginManager.getCGMManagerTypeByIdentifier(identifier) ?? staticCGMManagersByIdentifier[identifier] as? CGMManagerUI.Type
     }
     
-    public typealias SetupCGMCompletion = (CGMManager?) -> Void
-    public func maybeSetupCGMManager(_ identifier: String, setupClosure: (CGMManagerUI.Type) -> Void) {
-        if identifier == pumpManager?.managerIdentifier, let cgmManager = pumpManager as? CGMManager {
-            // We have a pump that is a CGM!
-            self.cgmManager = cgmManager
-        } else if let cgmManagerType = cgmManagerTypeByIdentifier(identifier) {
-            setupClosure(cgmManagerType)
+    public func setupCGMManagerFromPumpManager(withIdentifier identifier: String) -> CGMManager? {
+        guard identifier == pumpManager?.managerIdentifier, let cgmManager = pumpManager as? CGMManager else {
+            return nil
         }
+
+        // We have a pump that is a CGM!
+        self.cgmManager = cgmManager
+        return cgmManager
     }
     
     private func cgmManagerTypeFromRawValue(_ rawValue: [String: Any]) -> CGMManager.Type? {
@@ -560,7 +559,7 @@ private extension DeviceDataManager {
         pumpManager?.delegateQueue = queue
 
         doseStore.device = pumpManager?.status.device
-        pumpManagerHUDProvider = pumpManager?.hudProvider(insulinTintColor: .insulinTintColor, guidanceColors: .default)
+        pumpManagerHUDProvider = pumpManager?.hudProvider(colorPalette: .default)
 
         // Proliferate PumpModel preferences to DoseStore
         if let pumpRecordsBasalProfileStartEvents = pumpManager?.pumpRecordsBasalProfileStartEvents {
@@ -726,6 +725,9 @@ extension DeviceDataManager: AlertPresenter {
 extension DeviceDataManager: CGMManagerDelegate {
     func cgmManagerWantsDeletion(_ manager: CGMManager) {
         dispatchPrecondition(condition: .onQueue(queue))
+
+        log.default("CGM manager with identifier '%{public}@' wants deletion", manager.managerIdentifier)
+
         DispatchQueue.main.async {
             self.cgmManager = nil
         }
@@ -761,10 +763,14 @@ extension DeviceDataManager: CGMManagerDelegate {
     }
 }
 
-extension DeviceDataManager: CGMManagerSetupViewControllerDelegate {
-    func cgmManagerSetupViewController(_ cgmManagerSetupViewController: CGMManagerSetupViewController, didSetUpCGMManager cgmManager: CGMManagerUI) {
+extension DeviceDataManager: CGMManagerCreateDelegate {
+    func cgmManagerCreateNotifying(_ notifying: CGMManagerCreateNotifying, didCreateCGMManager cgmManager: CGMManagerUI) {
         self.cgmManager = cgmManager
     }
+}
+
+extension DeviceDataManager: CGMManagerOnboardDelegate {
+    func cgmManagerOnboardNotifying(_ notifying: CGMManagerOnboardNotifying, didOnboardCGMManager cgmManager: CGMManagerUI) {}
 }
 
 // MARK: - PumpManagerDelegate
@@ -893,7 +899,7 @@ extension DeviceDataManager: PumpManagerDelegate {
     func pumpManagerWillDeactivate(_ pumpManager: PumpManager) {
         dispatchPrecondition(condition: .onQueue(queue))
 
-        log.default("PumpManager:%{public}@ will deactivate", String(describing: type(of: pumpManager)))
+        log.default("Pump manager with identifier '%{public}@' will deactivate", pumpManager.managerIdentifier)
 
         doseStore.resetPumpData(completion: nil)
         DispatchQueue.main.async {
@@ -1165,10 +1171,10 @@ extension DeviceDataManager {
 // MARK: - Critical Event Log Export
 
 extension DeviceDataManager {
-    private static var criticalEventLogHistoricalExportBackgroundTaskIdentifer: String { "com.loopkit.background-task.critical-event-log.historical-export" }
+    private static var criticalEventLogHistoricalExportBackgroundTaskIdentifier: String { "com.loopkit.background-task.critical-event-log.historical-export" }
 
     public static func registerCriticalEventLogHistoricalExportBackgroundTask(_ handler: @escaping (BGProcessingTask) -> Void) -> Bool {
-        return BGTaskScheduler.shared.register(forTaskWithIdentifier: criticalEventLogHistoricalExportBackgroundTaskIdentifer, using: nil) { handler($0 as! BGProcessingTask) }
+        return BGTaskScheduler.shared.register(forTaskWithIdentifier: criticalEventLogHistoricalExportBackgroundTaskIdentifier, using: nil) { handler($0 as! BGProcessingTask) }
     }
 
     public func handleCriticalEventLogHistoricalExportBackgroundTask(_ task: BGProcessingTask) {
@@ -1200,7 +1206,7 @@ extension DeviceDataManager {
     public func scheduleCriticalEventLogHistoricalExportBackgroundTask(isRetry: Bool = false) {
         do {
             let earliestBeginDate = isRetry ? criticalEventLogExportManager.retryExportHistoricalDate() : criticalEventLogExportManager.nextExportHistoricalDate()
-            let request = BGProcessingTaskRequest(identifier: Self.criticalEventLogHistoricalExportBackgroundTaskIdentifer)
+            let request = BGProcessingTaskRequest(identifier: Self.criticalEventLogHistoricalExportBackgroundTaskIdentifier)
             request.earliestBeginDate = earliestBeginDate
             request.requiresExternalPower = true
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -764,13 +764,13 @@ extension DeviceDataManager: CGMManagerDelegate {
 }
 
 extension DeviceDataManager: CGMManagerCreateDelegate {
-    func cgmManagerCreateNotifying(_ notifying: CGMManagerCreateNotifying, didCreateCGMManager cgmManager: CGMManagerUI) {
+    func cgmManagerCreateNotifying(didCreateCGMManager cgmManager: CGMManagerUI) {
         self.cgmManager = cgmManager
     }
 }
 
 extension DeviceDataManager: CGMManagerOnboardDelegate {
-    func cgmManagerOnboardNotifying(_ notifying: CGMManagerOnboardNotifying, didOnboardCGMManager cgmManager: CGMManagerUI) {}
+    func cgmManagerOnboardNotifying(didOnboardCGMManager cgmManager: CGMManagerUI) {}
 }
 
 // MARK: - PumpManagerDelegate

--- a/Loop/Managers/Service.swift
+++ b/Loop/Managers/Service.swift
@@ -7,6 +7,7 @@
 //
 
 import LoopKit
+import LoopKitUI
 import MockKit
 
 let staticServices: [Service.Type] = [MockService.self]

--- a/Loop/Managers/Service.swift
+++ b/Loop/Managers/Service.swift
@@ -15,8 +15,8 @@ let staticServicesByIdentifier: [String: Service.Type] = staticServices.reduce(i
     map[Type.serviceIdentifier] = Type
 }
 
-let availableStaticServices = staticServices.map { (Type) -> AvailableService in
-    return AvailableService(identifier: Type.serviceIdentifier, localizedTitle: Type.localizedTitle, providesOnboarding: false)
+let availableStaticServices = staticServices.map { (Type) -> ServiceDescriptor in
+    return ServiceDescriptor(identifier: Type.serviceIdentifier, localizedTitle: Type.localizedTitle)
 }
 
 func ServiceFromRawValue(_ rawValue: [String: Any]) -> Service? {

--- a/Loop/Managers/ServicesManager.swift
+++ b/Loop/Managers/ServicesManager.swift
@@ -145,3 +145,7 @@ extension ServicesManager: ServiceDelegate {
         removeActiveService(service)
     }
 }
+
+extension ServicesManager {
+    var availableSupports: [SupportUI] { activeServices.compactMap { $0 as? SupportUI } }
+}

--- a/Loop/Managers/ServicesManager.swift
+++ b/Loop/Managers/ServicesManager.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 LoopKit Authors. All rights reserved.
 //
 
+import os.log
 import LoopKit
 import LoopKitUI
 
@@ -23,25 +24,23 @@ class ServicesManager {
 
     private let servicesLock = UnfairLock()
 
-    weak var loopDataManager: LoopDataManager?
+    private let log = OSLog(category: "ServicesManager")
 
     init(
         pluginManager: PluginManager,
         analyticsServicesManager: AnalyticsServicesManager,
         loggingServicesManager: LoggingServicesManager,
-        remoteDataServicesManager: RemoteDataServicesManager,
-        dataManager: LoopDataManager
+        remoteDataServicesManager: RemoteDataServicesManager
     ) {
         self.pluginManager = pluginManager
         self.analyticsServicesManager = analyticsServicesManager
         self.loggingServicesManager = loggingServicesManager
         self.remoteDataServicesManager = remoteDataServicesManager
-        self.loopDataManager = dataManager
         
         restoreState()
     }
 
-    public var availableServices: [AvailableService] {
+    public var availableServices: [ServiceDescriptor] {
         return pluginManager.availableServices + availableStaticServices
     }
 
@@ -114,19 +113,6 @@ class ServicesManager {
     private func saveState() {
         UserDefaults.appGroup?.servicesState = services.compactMap { $0.rawValue }
     }
-    
-    private func storeSettings(settings: TherapySettings) {
-        loopDataManager?.settings.glucoseTargetRangeSchedule = settings.glucoseTargetRangeSchedule
-        loopDataManager?.settings.preMealTargetRange = settings.preMealTargetRange
-        loopDataManager?.settings.legacyWorkoutTargetRange = settings.workoutTargetRange
-        loopDataManager?.settings.suspendThreshold = settings.suspendThreshold
-        loopDataManager?.settings.maximumBolus = settings.maximumBolus
-        loopDataManager?.settings.maximumBasalRatePerHour = settings.maximumBasalRatePerHour
-        loopDataManager?.insulinSensitivitySchedule = settings.insulinSensitivitySchedule
-        loopDataManager?.carbRatioSchedule = settings.carbRatioSchedule
-        loopDataManager?.basalRateSchedule = settings.basalRateSchedule
-        loopDataManager?.insulinModelSettings = settings.insulinModelSettings
-    }
 
     private func restoreState() {
         UserDefaults.appGroup?.servicesState.forEach { rawValue in
@@ -150,18 +136,12 @@ class ServicesManager {
 }
 
 extension ServicesManager: ServiceDelegate {
-
     func serviceDidUpdateState(_ service: Service) {
         saveState()
     }
 
-    func serviceHasNewTherapySettings(_ settings: TherapySettings) {
-        storeSettings(settings: settings)
-    }
-}
-
-extension Array where Element == Service {
-    var supportingOnboarding: [ServiceUI] {
-        return compactMap { $0 as? ServiceUI }.filter { type(of: $0).providesOnboarding }
+    func serviceWasDeleted(_ service: Service) {
+        log.default("Service with identifier '%{public}@' deleted", service.serviceIdentifier)
+        removeActiveService(service)
     }
 }

--- a/Loop/Managers/ServicesManager.swift
+++ b/Loop/Managers/ServicesManager.swift
@@ -140,7 +140,7 @@ extension ServicesManager: ServiceDelegate {
         saveState()
     }
 
-    func serviceWasDeleted(_ service: Service) {
+    func serviceWantsDeletion(_ service: Service) {
         log.default("Service with identifier '%{public}@' deleted", service.serviceIdentifier)
         removeActiveService(service)
     }

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1400,7 +1400,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           isClosedLoopAllowed: deviceManager.$isClosedLoopAllowed,
                                           preferredGlucoseUnit: deviceManager.preferredGlucoseUnit,
                                           supportInfoProvider: deviceManager,
-                                          availableSupports: deviceManager.pluginManager.availableSupports,
+                                          availableSupports: deviceManager.availableSupports,
                                           delegate: self)
         deviceManager.addPreferredGlucoseUnitObserver(viewModel)
         let hostingController = DismissibleHostingController(

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1933,8 +1933,8 @@ extension StatusTableViewController: CGMManagerOnboardDelegate {
 extension StatusTableViewController {
     fileprivate func addPumpManager(withIdentifier identifier: String) {
         let settings = PumpManagerSetupSettings(maxBasalRateUnitsPerHour: deviceManager.loopManager.settings.maximumBasalRatePerHour,
-                                           maxBolusUnits: deviceManager.loopManager.settings.maximumBolus,
-                                           basalSchedule: deviceManager.loopManager.basalRateSchedule)
+                                                maxBolusUnits: deviceManager.loopManager.settings.maximumBolus,
+                                                basalSchedule: deviceManager.loopManager.basalRateSchedule)
         switch setupPumpManagerUI(withIdentifier: identifier, initialSettings: settings) {
         case .failure(let error):
             log.default("Failure to setup pump manager with identifier '%{public}@': %{public}@", identifier, String(describing: error))

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -29,7 +29,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     private let log = OSLog(category: "StatusTableViewController")
 
     lazy var quantityFormatter: QuantityFormatter = QuantityFormatter()
-    
+
     lazy private var cancellables = Set<AnyCancellable>()
 
     private var preferredGlucoseUnitObservers = WeakSynchronizedSet<PreferredGlucoseUnitObserver>()
@@ -134,12 +134,12 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private var isOnboardingComplete: Bool { deviceManager.loopManager.therapySettings.isComplete }
-    
+
+    private var hasOnboarding: Bool { !deviceManager.pluginManager.availableOnboardingIdentifiers.isEmpty }
+
     private func navigateToOnboarding() {
-        if let onboardingService = deviceManager.servicesManager.activeServices.supportingOnboarding.first {
-            showServiceSettings(onboardingService)
-        } else if let firstAvailableService = (deviceManager.pluginManager.availableServices.filter { $0.providesOnboarding }.first) {
-            setupService(withIdentifier: firstAvailableService.identifier)
+        if let identifier = deviceManager.pluginManager.availableOnboardingIdentifiers.first {
+            setupOnboarding(withIdentifier: identifier)
         }
     }
 
@@ -166,7 +166,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
                     self.log.debug("[reloadData] after HealthKit authorization")
                     self.reloadData()
-                    if !self.isOnboardingComplete {
+                    if !self.isOnboardingComplete && self.hasOnboarding {
                         self.navigateToOnboarding()
                     }
                 }
@@ -176,7 +176,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         onscreen = true
 
         deviceManager.analyticsServicesManager.didDisplayStatusScreen()
-        
+
         deviceManager.checkDeliveryUncertaintyState()
     }
 
@@ -194,7 +194,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         refreshContext.update(with: .size(size))
 
         maybeOpenDebugMenu()
-        
+
         super.viewWillTransition(to: size, with: coordinator)
     }
 
@@ -402,7 +402,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             }
             // always check for cob
             carbsOnBoard = state.carbsOnBoard?.quantity
-            
+
             reloadGroup.leave()
         }
 
@@ -460,7 +460,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 reloadGroup.leave()
             }
         }
-        
+
         updatePreMealModeAvailability(allowed: deviceManager.isClosedLoop)
 
         if deviceManager.loopManager.settings.preMealTargetRange == nil {
@@ -778,7 +778,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             updatePreMealModeAvailability(allowed: deviceManager.isClosedLoop)
         }
     }
-    
+
     private func updatePreMealModeAvailability(allowed: Bool) {
         toolbarItems![2] = createPreMealButtonItem(selected: preMealMode ?? false && allowed, isEnabled: allowed)
     }
@@ -830,7 +830,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                     return self?.statusCharts.glucoseChart(withFrame: frame)?.view
                 })
                 cell.setTitleLabelText(label: NSLocalizedString("Glucose", comment: "The title of the glucose and prediction graph"))
-                cell.doesNavigate = self.deviceManager.isClosedLoop 
+                cell.doesNavigate = self.deviceManager.isClosedLoop
             case .iob:
                 cell.setChartGenerator(generator: { [weak self] (frame) in
                     return self?.statusCharts.iobChart(withFrame: frame)?.view
@@ -1207,7 +1207,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let navigationWrapper: UINavigationController
         if deviceManager.isClosedLoop {
             let carbEntryViewController = UIStoryboard(name: "Main", bundle: Bundle(for: AppDelegate.self)).instantiateViewController(withIdentifier: "CarbEntryViewController") as! CarbEntryViewController
-            
+
             carbEntryViewController.deviceManager = deviceManager
             carbEntryViewController.defaultAbsorptionTimes = deviceManager.carbStore.defaultAbsorptionTimes
             carbEntryViewController.preferredCarbUnit = deviceManager.carbStore.preferredUnit
@@ -1247,7 +1247,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         hostingController.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: navigationWrapper, action: #selector(dismissWithAnimation))
         self.present(navigationWrapper, animated: true)
     }
-    
+
     private func createPreMealButtonItem(selected: Bool, isEnabled: Bool) -> UIBarButtonItem {
         let item = UIBarButtonItem(image: UIImage.preMealImage(selected: selected), style: .plain, target: self, action: #selector(togglePreMealMode(_:)))
         item.accessibilityLabel = NSLocalizedString("Pre-Meal Targets", comment: "The label of the pre-meal mode toggle button")
@@ -1287,7 +1287,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         } else {
             let vc = UIAlertController(premealDurationSelectionHandler: { duration in
                 let startDate = Date()
-                
+
                 guard self.workoutMode != true else {
                     // allow cell animation when switching between presets
                     self.deviceManager.loopManager.settings.clearOverride()
@@ -1296,7 +1296,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                     }
                     return
                 }
-                
+
                 self.deviceManager.loopManager.settings.enablePreMealOverride(at: startDate, for: duration)
             })
 
@@ -1313,7 +1313,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             } else {
                 let vc = UIAlertController(workoutDurationSelectionHandler: { duration in
                     let startDate = Date()
-                    
+
                     guard self.preMealMode != true else {
                         // allow cell animation when switching between presets
                         self.deviceManager.loopManager.settings.clearOverride(matching: .preMeal)
@@ -1322,7 +1322,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                         }
                         return
                     }
-                    
+
                     self.deviceManager.loopManager.settings.enableLegacyWorkoutOverride(at: startDate, for: duration)
                 })
 
@@ -1337,17 +1337,17 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
     private func presentSettings() {
         let notificationsCriticalAlertPermissionsViewModel = NotificationsCriticalAlertPermissionsViewModel()
-        let deletePumpDataFunc: () -> DeviceViewModel.DeleteTestingDataFunc? = { [weak self] in
+        let deletePumpDataFunc: () -> PumpManagerViewModel.DeleteTestingDataFunc? = { [weak self] in
             (self?.deviceManager.pumpManager is TestingPumpManager) ? {
                 [weak self] in self?.deviceManager.deleteTestingPumpData()
                 } : nil
         }
-        let deleteCGMDataFunc: () -> DeviceViewModel.DeleteTestingDataFunc? = { [weak self] in
+        let deleteCGMDataFunc: () -> CGMManagerViewModel.DeleteTestingDataFunc? = { [weak self] in
             (self?.deviceManager.cgmManager is TestingCGMManager) ? {
                 [weak self] in self?.deviceManager.deleteTestingCGMData()
                 } : nil
         }
-        let pumpViewModel = DeviceViewModel(
+        let pumpViewModel = PumpManagerViewModel(
             image: { [weak self] in self?.deviceManager.pumpManager?.smallImage },
             name: { [weak self] in self?.deviceManager.pumpManager?.localizedTitle ?? "" },
             isSetUp: { [weak self] in self?.deviceManager.pumpManager != nil },
@@ -1357,12 +1357,10 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 self?.onPumpTapped()
             },
             didTapAddDevice: { [weak self] in
-                if let pumpManagerType = self?.deviceManager.pumpManagerTypeByIdentifier($0.identifier) {
-                    self?.setupPumpManager(for: pumpManagerType)
-                }
+                self?.addPumpManager(withIdentifier: $0.identifier)
         })
 
-        let cgmViewModel = DeviceViewModel(
+        let cgmViewModel = CGMManagerViewModel(
             image: {[weak self] in (self?.deviceManager.cgmManager as? DeviceManagerUI)?.smallImage },
             name: {[weak self] in self?.deviceManager.cgmManager?.localizedTitle ?? "" },
             isSetUp: {[weak self] in self?.deviceManager.cgmManager != nil },
@@ -1372,7 +1370,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 self?.onCGMTapped()
             },
             didTapAddDevice: { [weak self] in
-                self?.setupCGMManager($0.identifier)
+                self?.addCGMManager(withIdentifier: $0.identifier)
         })
         let pumpSupportedIncrements = { [weak self] in
             self?.deviceManager.pumpManager.map {
@@ -1402,7 +1400,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           isClosedLoopAllowed: deviceManager.$isClosedLoopAllowed,
                                           preferredGlucoseUnit: deviceManager.preferredGlucoseUnit,
                                           supportInfoProvider: deviceManager,
-                                          activeServices: deviceManager.servicesManager.activeServices,
+                                          availableSupports: deviceManager.pluginManager.availableSupports,
                                           delegate: self)
         deviceManager.addPreferredGlucoseUnitObserver(viewModel)
         let hostingController = DismissibleHostingController(
@@ -1412,12 +1410,13 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private func onPumpTapped() {
-        guard var settings = deviceManager.pumpManager?.settingsViewController(insulinTintColor: .insulinTintColor, guidanceColors: .default) else {
+        guard var settingsViewController = deviceManager.pumpManager?.settingsViewController(colorPalette: .default) else {
             // assert?
             return
         }
-        settings.completionDelegate = self
-        show(settings, sender: self)
+        settingsViewController.pumpManagerOnboardDelegate = self
+        settingsViewController.completionDelegate = self
+        show(settingsViewController, sender: self)
     }
 
     private func onCGMTapped() {
@@ -1427,12 +1426,13 @@ final class StatusTableViewController: LoopChartsTableViewController {
             return
         }
 
-        var settings = cgmManager.settingsViewController(for: unit, glucoseTintColor: .glucoseTintColor, guidanceColors: .default)
+        var settings = cgmManager.settingsViewController(for: unit, colorPalette: .default)
+        settings.cgmManagerOnboardDelegate = self
         settings.completionDelegate = self
         deviceManager.addPreferredGlucoseUnitObserver(settings)
         show(settings, sender: self)
     }
-    
+
     private func closedLoopStatusChanged(_ isClosedLoop: Bool) {
         self.updatePreMealModeAvailability(allowed: isClosedLoop)
         self.hudView?.loopCompletionHUD.loopIconClosed = isClosedLoop
@@ -1504,7 +1504,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         guard let loopCompletionMessage = hudView?.loopCompletionHUD.loopCompletionMessage else { return }
         presentLoopCompletionMesage(title: loopCompletionMessage.title, message: loopCompletionMessage.message)
     }
-    
+
     private func presentLoopCompletionMesage(title: String, message: String) {
         let action = UIAlertAction(title: NSLocalizedString("Dismiss", comment: "The button label of the action used to dismiss an error alert"),
                                    style: .default)
@@ -1514,7 +1514,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         alertController.addAction(action)
         present(alertController, animated: true)
     }
-    
+
     @objc private func showLastError(_: Any) {
         let error: Error?
         // First, check whether we have a device error after the most recent completion date
@@ -1572,22 +1572,16 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private func addNewPumpManager() {
-        let pumpManagers = deviceManager.availablePumpManagers
+        let availablePumpManagers = deviceManager.availablePumpManagers
 
-        switch pumpManagers.count {
+        switch availablePumpManagers.count {
         case 1:
-            if let pumpManager = pumpManagers.first,
-                let pumpManagerType = deviceManager.pumpManagerTypeByIdentifier(pumpManager.identifier)
-            {
-                setupPumpManager(for: pumpManagerType)
+            if let availablePumpManager = availablePumpManagers.first {
+                addPumpManager(withIdentifier: availablePumpManager.identifier)
             }
         default:
-            let alert = UIAlertController(pumpManagers: pumpManagers) { [weak self] (identifier) in
-                if let strongSelf = self,
-                    let manager = strongSelf.deviceManager.pumpManagerTypeByIdentifier(identifier)
-                {
-                    strongSelf.setupPumpManager(for: manager)
-                }
+            let alert = UIAlertController(availablePumpManagers: availablePumpManagers) { [weak self] (identifier) in
+                self?.addPumpManager(withIdentifier: identifier)
             }
             alert.addCancelAction { _ in }
             present(alert, animated: true, completion: nil)
@@ -1595,14 +1589,16 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private func addNewCGMManager() {
-        let cgmManagers = deviceManager.availableCGMManagers
+        let availableCGMManagers = deviceManager.availableCGMManagers
 
-        switch cgmManagers.count {
+        switch availableCGMManagers.count {
         case 1:
-            setupCGMManager(cgmManagers.first!.identifier)
+            if let availableCGMManager = availableCGMManagers.first {
+                addCGMManager(withIdentifier: availableCGMManager.identifier)
+            }
         default:
-            let alert = UIAlertController(cgmManagers: cgmManagers) { [weak self] identifier in
-                self?.setupCGMManager(identifier)
+            let alert = UIAlertController(availableCGMManagers: availableCGMManagers) { [weak self] identifier in
+                self?.addCGMManager(withIdentifier: identifier)
             }
             alert.addCancelAction { _ in }
             present(alert, animated: true, completion: nil)
@@ -1611,7 +1607,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
 
     // MARK: - Debug Scenarios and Simulated Core Data
-    
+
     var lastOrientation: UIDeviceOrientation?
     var rotateCount = 0
     let maxRotationsToTrigger = 6
@@ -1672,6 +1668,11 @@ final class StatusTableViewController: LoopChartsTableViewController {
                 self.presentError(error)
             }
         })
+        if hasOnboarding {
+            actionSheet.addAction(UIAlertAction(title: "Present Onboarding", style: .default) { _ in
+                self.navigateToOnboarding()
+            })
+        }
         if FeatureFlags.mockTherapySettingsEnabled {
             actionSheet.addAction(UIAlertAction(title: "Mock Therapy Settings", style: .default) { _ in
                 let settings = TherapySettings.mockTherapySettings
@@ -1896,46 +1897,74 @@ extension StatusTableViewController: AddEditOverrideTableViewControllerDelegate 
     }
 }
 
-extension StatusTableViewController: CGMManagerSetupViewControllerDelegate {
-    func cgmManagerSetupViewController(_ cgmManagerSetupViewController: CGMManagerSetupViewController,
-                                       didSetUpCGMManager cgmManager: CGMManagerUI)
-    {
+extension StatusTableViewController {
+    fileprivate func addCGMManager(withIdentifier identifier: String) {
+        switch setupCGMManager(withIdentifier: identifier) {
+        case .failure(let error):
+            log.default("Failure to setup CGM manager with identifier '%{public}@': %{public}@", identifier, String(describing: error))
+        case .userInteractionRequired(var setupViewController):
+            setupViewController.cgmManagerCreateDelegate = self
+            setupViewController.cgmManagerOnboardDelegate = self
+            setupViewController.completionDelegate = self
+            show(setupViewController, sender: self)
+        case .success:
+            log.default("CGM manager with identifier '%{public}@' created and onboarded", identifier)
+        }
+    }
+}
+
+extension StatusTableViewController: CGMManagerCreateDelegate {
+    func cgmManagerCreateNotifying(_ notifying: CGMManagerCreateNotifying, didCreateCGMManager cgmManager: CGMManagerUI) {
+        log.default("CGM manager with identifier '%{public}@' created", cgmManager.managerIdentifier)
         deviceManager.cgmManager = cgmManager
     }
 }
 
-extension StatusTableViewController: PumpManagerSetupViewControllerDelegate {
-    fileprivate func setupPumpManager(for pumpManagerType: PumpManagerUI.Type) {
-        if var setupViewController = pumpManagerType.setupViewController(insulinTintColor: .insulinTintColor, guidanceColors: .default) {
-            setupViewController.setupDelegate = self
+extension StatusTableViewController: CGMManagerOnboardDelegate {
+    func cgmManagerOnboardNotifying(_ notifying: CGMManagerOnboardNotifying, didOnboardCGMManager cgmManager: CGMManagerUI) {
+        precondition(cgmManager.isOnboarded)
+        log.default("CGM manager with identifier '%{public}@' onboarded", cgmManager.managerIdentifier)
+    }
+}
+
+extension StatusTableViewController {
+    fileprivate func addPumpManager(withIdentifier identifier: String) {
+        let settings = PumpManagerSettings(maxBasalRateUnitsPerHour: deviceManager.loopManager.settings.maximumBasalRatePerHour,
+                                           maxBolusUnits: deviceManager.loopManager.settings.maximumBolus,
+                                           basalSchedule: deviceManager.loopManager.basalRateSchedule)
+        switch setupPumpManagerUI(withIdentifier: identifier, initialSettings: settings) {
+        case .failure(let error):
+            log.default("Failure to setup pump manager with identifier '%{public}@': %{public}@", identifier, String(describing: error))
+        case .userInteractionRequired(var setupViewController):
+            setupViewController.pumpManagerCreateDelegate = self
+            setupViewController.pumpManagerOnboardDelegate = self
             setupViewController.completionDelegate = self
-            setupViewController.basalSchedule = deviceManager.loopManager.basalRateSchedule
-            setupViewController.maxBolusUnits = deviceManager.loopManager.settings.maximumBolus
-            setupViewController.maxBasalRateUnitsPerHour = deviceManager.loopManager.settings.maximumBasalRatePerHour
             show(setupViewController, sender: self)
-        } else {
-            let pumpManager = pumpManagerType.init(rawState: [:])
-            if let basalRateSchedule = deviceManager.loopManager.basalRateSchedule {
-                pumpManager?.syncBasalRateSchedule(items: basalRateSchedule.items, completion: { _ in })
-            }
-            deviceManager.pumpManager = pumpManager
+        case .success:
+            log.default("Pump manager with identifier '%{public}@' created and onboarded", identifier)
         }
     }
+}
 
-    func pumpManagerSetupViewController(_ pumpManagerSetupViewController: PumpManagerSetupViewController,
-                                        didSetUpPumpManager pumpManager: PumpManagerUI)
-    {
+extension StatusTableViewController: PumpManagerCreateDelegate {
+    func pumpManagerCreateNotifying(_ notifying: PumpManagerCreateNotifying, didCreatePumpManager pumpManager: PumpManagerUI) {
+        log.default("Pump manager with identifier '%{public}@' created", pumpManager.managerIdentifier)
         deviceManager.pumpManager = pumpManager
+    }
+}
 
-        if let basalRateSchedule = pumpManagerSetupViewController.basalSchedule {
+extension StatusTableViewController: PumpManagerOnboardDelegate {
+    func pumpManagerOnboardNotifying(_ notifying: PumpManagerOnboardNotifying, didOnboardPumpManager pumpManager: PumpManagerUI, withFinalSettings settings: PumpManagerSettings) {
+        precondition(pumpManager.isOnboarded)
+        log.default("Pump manager with identifier '%{public}@' onboarded", pumpManager.managerIdentifier)
+
+        if let basalRateSchedule = settings.basalSchedule {
             deviceManager.loopManager.basalRateSchedule = basalRateSchedule
         }
-
-        if let maxBasalRateUnitsPerHour = pumpManagerSetupViewController.maxBasalRateUnitsPerHour {
+        if let maxBasalRateUnitsPerHour = settings.maxBasalRateUnitsPerHour {
             deviceManager.loopManager.settings.maximumBasalRatePerHour = maxBasalRateUnitsPerHour
         }
-
-        if let maxBolusUnits = pumpManagerSetupViewController.maxBolusUnits {
+        if let maxBolusUnits = settings.maxBolusUnits {
             deviceManager.loopManager.settings.maximumBolus = maxBolusUnits
         }
     }
@@ -1947,21 +1976,6 @@ extension StatusTableViewController: BluetoothStateManagerObserver {
     {
         refreshContext.update(with: .status)
         reloadData(animated: true)
-    }
-}
-
-
-extension StatusTableViewController {
-    fileprivate func setupCGMManager(_ identifier: String) {
-        deviceManager.maybeSetupCGMManager(identifier) { cgmManagerType in
-            if var setupViewController = cgmManagerType.setupViewController(glucoseTintColor: .glucoseTintColor, guidanceColors: .default) {
-                setupViewController.setupDelegate = deviceManager
-                setupViewController.completionDelegate = self
-                show(setupViewController, sender: self)
-            } else {
-                deviceManager.cgmManager = cgmManagerType.init(rawState: [:])
-            }
-        }
     }
 }
 
@@ -2014,23 +2028,22 @@ extension StatusTableViewController: SettingsViewModelDelegate {
 
 // MARK: - Services delegation
 
-extension StatusTableViewController: ServiceSetupDelegate {
-    func serviceSetupNotifying(_ object: ServiceSetupNotifying, didCreateService service: Service) {
-        deviceManager.servicesManager.addActiveService(service)
-    }
-}
-
-extension StatusTableViewController: ServiceSettingsDelegate {
-    func serviceSettingsNotifying(_ object: ServiceSettingsNotifying, didDeleteService service: Service) {
-        deviceManager.servicesManager.removeActiveService(service)
-    }
-}
-
 extension StatusTableViewController: ServicesViewModelDelegate {
-    func addService(identifier: String) {
-        setupService(withIdentifier: identifier)
+    func addService(withIdentifier identifier: String) {
+        switch setupService(withIdentifier: identifier) {
+        case .failure(let error):
+            log.default("Failure to setup service with identifier '%{public}@': %{public}@", identifier, String(describing: error))
+        case .userInteractionRequired(var setupViewController):
+            setupViewController.serviceCreateDelegate = self
+            setupViewController.serviceOnboardDelegate = self
+            setupViewController.completionDelegate = self
+            show(setupViewController, sender: self)
+        case .success:
+            log.default("Service with identifier '%{public}@' created and onboarded", identifier)
+        }
     }
-    func gotoService(identifier: String) {
+
+    func gotoService(withIdentifier identifier: String) {
         guard let serviceUI = deviceManager.servicesManager.activeServices.first(where: { $0.serviceIdentifier == identifier }) as? ServiceUI else {
             return
         }
@@ -2038,32 +2051,150 @@ extension StatusTableViewController: ServicesViewModelDelegate {
     }
 
     fileprivate func showServiceSettings(_ serviceUI: ServiceUI) {
-        var settings = serviceUI.settingsViewController(currentTherapySettings: deviceManager.loopManager.therapySettings, preferredGlucoseUnit: deviceManager.preferredGlucoseUnit, chartColors: .primary, carbTintColor: .carbTintColor, glucoseTintColor: .glucoseTintColor, guidanceColors: .default, insulinTintColor: .insulinTintColor)
-        settings.serviceSettingsDelegate = self
-        settings.completionDelegate = self
-        show(settings, sender: self)
+        var settingsViewController = serviceUI.settingsViewController(colorPalette: .default)
+        settingsViewController.serviceOnboardDelegate = self
+        settingsViewController.completionDelegate = self
+        show(settingsViewController, sender: self)
     }
+}
 
-    fileprivate func setupService(withIdentifier identifier: String) {
-        guard let serviceUIType = deviceManager.servicesManager.serviceUITypeByIdentifier(identifier) else {
+extension StatusTableViewController: ServiceCreateDelegate {
+    func serviceCreateNotifying(_ notifying: ServiceCreateNotifying, didCreateService service: Service) {
+        log.default("Service with identifier '%{public}@' created", service.serviceIdentifier)
+        deviceManager.servicesManager.addActiveService(service)
+    }
+}
+
+extension StatusTableViewController: ServiceOnboardDelegate {
+    func serviceOnboardNotifying(_ notifying: ServiceOnboardNotifying, didOnboardService service: Service) {
+        precondition(service.isOnboarded)
+        log.default("Service with identifier '%{public}@' onboarded", service.serviceIdentifier)
+    }
+}
+
+// MARK: - Onboarding
+
+extension StatusTableViewController {
+    fileprivate func setupOnboarding(withIdentifier identifier: String) {
+        guard let onboardingUIType = deviceManager.pluginManager.getOnboardingTypeByIdentifier(identifier) else {
             return
         }
-        
-        if var setupViewController = serviceUIType.setupViewController(
-            currentTherapySettings: deviceManager.loopManager.therapySettings,
-            preferredGlucoseUnit: deviceManager.preferredGlucoseUnit,
-            chartColors: .primary,
-            carbTintColor: .carbTintColor,
-            glucoseTintColor: .glucoseTintColor,
-            guidanceColors: .default,
-            insulinTintColor: .insulinTintColor)
-        {
-            setupViewController.serviceSetupDelegate = self
-            setupViewController.completionDelegate = self
-            show(setupViewController, sender: self)
-        } else if let service = serviceUIType.init(rawState: [:]) {
-            deviceManager.servicesManager.addActiveService(service)
+
+        let onboarding = onboardingUIType.init()
+        var onboardingViewController = onboarding.onboardingViewController(preferredGlucoseUnit: deviceManager.preferredGlucoseUnit,
+                                                                           cgmManagerProvider: self,
+                                                                           pumpManagerProvider: self,
+                                                                           serviceProvider: self,
+                                                                           colorPalette: .default)
+        onboardingViewController.onboardingDelegate = self
+        onboardingViewController.cgmManagerCreateDelegate = self
+        onboardingViewController.cgmManagerOnboardDelegate = self
+        onboardingViewController.pumpManagerCreateDelegate = self
+        onboardingViewController.pumpManagerOnboardDelegate = self
+        onboardingViewController.serviceCreateDelegate = self
+        onboardingViewController.serviceOnboardDelegate = self
+        onboardingViewController.completionDelegate = self
+
+        show(onboardingViewController, sender: self)
+    }
+}
+
+struct UnknownIdentifierError: Error {}
+
+extension StatusTableViewController: CGMManagerProvider {
+    var activeCGMManager: CGMManager? { deviceManager.cgmManager }
+
+    var availableCGMManagers: [CGMManagerDescriptor] { deviceManager.availableCGMManagers }
+
+    func setupCGMManager(withIdentifier identifier: String) -> UIResult<UIViewController & CGMManagerCreateNotifying & CGMManagerOnboardNotifying & CompletionNotifying, CGMManager, Error> {
+        if let cgmManager = deviceManager.setupCGMManagerFromPumpManager(withIdentifier: identifier) {
+            return .success(cgmManager)
         }
+
+        switch setupCGMManagerUI(withIdentifier: identifier) {
+        case .userInteractionRequired(let viewController):
+            return .userInteractionRequired(viewController)
+        case .success(let cgmManagerUI):
+            return .success(cgmManagerUI)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    fileprivate func setupCGMManagerUI(withIdentifier identifier: String) -> UIResult<UIViewController & CGMManagerCreateNotifying & CGMManagerOnboardNotifying & CompletionNotifying, CGMManagerUI, Error> {
+        guard let cgmManagerUIType = deviceManager.cgmManagerTypeByIdentifier(identifier) else {
+            return .failure(UnknownIdentifierError())
+        }
+
+        let result = cgmManagerUIType.setupViewController(colorPalette: .default)
+        if case .success(let cgmManagerUI) = result {
+            deviceManager.cgmManager = cgmManagerUI
+        }
+
+        return result
+    }
+}
+
+extension StatusTableViewController: PumpManagerProvider {
+    var activePumpManager: PumpManager? { deviceManager.pumpManager }
+
+    var availablePumpManagers: [PumpManagerDescriptor] { deviceManager.availablePumpManagers }
+
+    func setupPumpManager(withIdentifier identifier: String, initialSettings settings: PumpManagerSettings) -> UIResult<UIViewController & PumpManagerCreateNotifying & PumpManagerOnboardNotifying & CompletionNotifying, PumpManager, Error> {
+        switch setupPumpManagerUI(withIdentifier: identifier, initialSettings: settings) {
+        case .userInteractionRequired(let viewController):
+            return .userInteractionRequired(viewController)
+        case .success(let pumpManagerUI):
+            return .success(pumpManagerUI)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    fileprivate func setupPumpManagerUI(withIdentifier identifier: String, initialSettings settings: PumpManagerSettings) -> UIResult<UIViewController & PumpManagerCreateNotifying & PumpManagerOnboardNotifying & CompletionNotifying, PumpManagerUI, Error> {
+        guard let pumpManagerUIType = deviceManager.pumpManagerTypeByIdentifier(identifier) else {
+            return .failure(UnknownIdentifierError())
+        }
+
+        let result = pumpManagerUIType.setupViewController(initialSettings: settings, colorPalette: .default)
+        if case .success(let pumpManagerUI) = result {
+            if let basalRateSchedule = deviceManager.loopManager.basalRateSchedule {
+                pumpManagerUI.syncBasalRateSchedule(items: basalRateSchedule.items, completion: { _ in })
+            }
+            deviceManager.pumpManager = pumpManagerUI
+        }
+
+        return result
+    }
+}
+
+extension StatusTableViewController: ServiceProvider {
+    var activeServices: [Service] { deviceManager.servicesManager.activeServices }
+
+    var availableServices: [ServiceDescriptor] { deviceManager.servicesManager.availableServices }
+
+    func setupService(withIdentifier identifier: String) -> UIResult<UIViewController & ServiceCreateNotifying & ServiceOnboardNotifying & CompletionNotifying, Service, Error> {
+        switch setupServiceUI(withIdentifier: identifier) {
+        case .userInteractionRequired(let viewController):
+            return .userInteractionRequired(viewController)
+        case .success(let serviceUI):
+            return .success(serviceUI)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    fileprivate func setupServiceUI(withIdentifier identifier: String) -> UIResult<UIViewController & ServiceCreateNotifying & ServiceOnboardNotifying & CompletionNotifying, ServiceUI, Error> {
+        guard let serviceUIType = deviceManager.servicesManager.serviceUITypeByIdentifier(identifier) else {
+            return .failure(UnknownIdentifierError())
+        }
+
+        let result = serviceUIType.setupViewController(colorPalette: .default)
+        if case .success(let serviceUI) = result {
+            deviceManager.servicesManager.addActiveService(serviceUI)
+        }
+
+        return result
     }
 }
 
@@ -2073,5 +2204,22 @@ extension StatusTableViewController: PreferredGlucoseUnitObserver {
         self.preferredGlucoseUnit = preferredGlucoseUnit
         self.unitPreferencesDidChange(to: preferredGlucoseUnit)
         self.refreshContext = RefreshContext.all
+    }
+}
+
+extension StatusTableViewController: OnboardingDelegate {
+    func onboardingNotifying(_ notifying: OnboardingNotifying, hasNewTherapySettings therapySettings: TherapySettings) {
+        log.default("Onboarding has new therapy settings")
+
+        deviceManager.loopManager.settings.glucoseTargetRangeSchedule = therapySettings.glucoseTargetRangeSchedule
+        deviceManager.loopManager.settings.preMealTargetRange = therapySettings.preMealTargetRange
+        deviceManager.loopManager.settings.legacyWorkoutTargetRange = therapySettings.workoutTargetRange
+        deviceManager.loopManager.settings.suspendThreshold = therapySettings.suspendThreshold
+        deviceManager.loopManager.settings.maximumBolus = therapySettings.maximumBolus
+        deviceManager.loopManager.settings.maximumBasalRatePerHour = therapySettings.maximumBasalRatePerHour
+        deviceManager.loopManager.insulinSensitivitySchedule = therapySettings.insulinSensitivitySchedule
+        deviceManager.loopManager.carbRatioSchedule = therapySettings.carbRatioSchedule
+        deviceManager.loopManager.basalRateSchedule = therapySettings.basalRateSchedule
+        deviceManager.loopManager.insulinModelSettings = therapySettings.insulinModelSettings
     }
 }

--- a/Loop/View Models/ServicesViewModel.swift
+++ b/Loop/View Models/ServicesViewModel.swift
@@ -10,17 +10,17 @@ import LoopKit
 import SwiftUI
 
 public protocol ServicesViewModelDelegate: class {
-    func addService(identifier: String)
-    func gotoService(identifier: String)
+    func addService(withIdentifier identifier: String)
+    func gotoService(withIdentifier identifier: String)
 }
 
 public class ServicesViewModel: ObservableObject {
     
     @Published var showServices: Bool
-    @Published var availableServices: () -> [AvailableService]
+    @Published var availableServices: () -> [ServiceDescriptor]
     @Published var activeServices: () -> [Service]
     
-    var inactiveServices: () -> [AvailableService] {
+    var inactiveServices: () -> [ServiceDescriptor] {
         return {
             return self.availableServices().filter { availableService in
                 !self.activeServices().contains { $0.serviceIdentifier == availableService.identifier }
@@ -31,7 +31,7 @@ public class ServicesViewModel: ObservableObject {
     weak var delegate: ServicesViewModelDelegate?
     
     init(showServices: Bool,
-         availableServices: @escaping () -> [AvailableService],
+         availableServices: @escaping () -> [ServiceDescriptor],
          activeServices: @escaping () -> [Service],
          delegate: ServicesViewModelDelegate? = nil) {
         self.showServices = showServices
@@ -41,10 +41,10 @@ public class ServicesViewModel: ObservableObject {
     }
     
     func didTapService(_ index: Int) {
-        delegate?.gotoService(identifier: activeServices()[index].serviceIdentifier)
+        delegate?.gotoService(withIdentifier: activeServices()[index].serviceIdentifier)
     }
     
-    func didTapAddService(_ availableService: AvailableService) {
-        delegate?.addService(identifier: availableService.identifier)
+    func didTapAddService(_ availableService: ServiceDescriptor) {
+        delegate?.addService(withIdentifier: availableService.identifier)
     }
 }

--- a/Loop/View Models/ServicesViewModel.swift
+++ b/Loop/View Models/ServicesViewModel.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2020 LoopKit Authors. All rights reserved.
 //
 
-import LoopKit
 import SwiftUI
+import LoopKit
+import LoopKitUI
 
 public protocol ServicesViewModelDelegate: class {
     func addService(withIdentifier identifier: String)

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -13,7 +13,7 @@ import LoopKitUI
 import SwiftUI
 import HealthKit
 
-public class DeviceViewModel: ObservableObject {
+public class DeviceViewModel<T>: ObservableObject {
     public typealias DeleteTestingDataFunc = () -> Void
     
     let isSetUp: () -> Bool
@@ -21,20 +21,20 @@ public class DeviceViewModel: ObservableObject {
     let name: () -> String
     let deleteTestingDataFunc: () -> DeleteTestingDataFunc?
     let didTap: () -> Void
-    let didTapAdd: (_ device: AvailableDevice) -> Void
+    let didTapAdd: (_ device: T) -> Void
     var isTestingDevice: Bool {
         return deleteTestingDataFunc() != nil
     }
 
-    @Published var availableDevices: [AvailableDevice]
+    @Published var availableDevices: [T]
 
     public init(image: @escaping () -> UIImage? = { nil },
                 name: @escaping () -> String = { "" },
                 isSetUp: @escaping () -> Bool = { false },
-                availableDevices: [AvailableDevice] = [],
+                availableDevices: [T] = [],
                 deleteTestingDataFunc: @escaping  () -> DeleteTestingDataFunc? = { nil },
                 onTapped: @escaping () -> Void = { },
-                didTapAddDevice: @escaping (AvailableDevice) -> Void = { _ in  }
+                didTapAddDevice: @escaping (T) -> Void = { _ in  }
                 ) {
         self.image = image
         self.name = name
@@ -45,6 +45,9 @@ public class DeviceViewModel: ObservableObject {
         self.didTapAdd = didTapAddDevice
     }
 }
+
+public typealias CGMManagerViewModel = DeviceViewModel<CGMManagerDescriptor>
+public typealias PumpManagerViewModel = DeviceViewModel<PumpManagerDescriptor>
 
 public protocol SettingsViewModelDelegate: class {
     func dosingEnabledChanged(_: Bool)
@@ -70,9 +73,9 @@ public class SettingsViewModel: ObservableObject {
         delegate?.didTapIssueReport
     }
     
-    var activeServices: [Service]
-    let pumpManagerSettingsViewModel: DeviceViewModel
-    let cgmManagerSettingsViewModel: DeviceViewModel
+    var availableSupports: [SupportUI]
+    let pumpManagerSettingsViewModel: PumpManagerViewModel
+    let cgmManagerSettingsViewModel: CGMManagerViewModel
     let servicesViewModel: ServicesViewModel
     let criticalEventLogExportViewModel: CriticalEventLogExportViewModel
     let therapySettings: () -> TherapySettings
@@ -94,8 +97,8 @@ public class SettingsViewModel: ObservableObject {
     lazy private var cancellables = Set<AnyCancellable>()
 
     public init(notificationsCriticalAlertPermissionsViewModel: NotificationsCriticalAlertPermissionsViewModel,
-                pumpManagerSettingsViewModel: DeviceViewModel,
-                cgmManagerSettingsViewModel: DeviceViewModel,
+                pumpManagerSettingsViewModel: PumpManagerViewModel,
+                cgmManagerSettingsViewModel: CGMManagerViewModel,
                 servicesViewModel: ServicesViewModel,
                 criticalEventLogExportViewModel: CriticalEventLogExportViewModel,
                 therapySettings: @escaping () -> TherapySettings,
@@ -107,7 +110,7 @@ public class SettingsViewModel: ObservableObject {
                 isClosedLoopAllowed: Published<Bool>.Publisher,
                 preferredGlucoseUnit: HKUnit,
                 supportInfoProvider: SupportInfoProvider,
-                activeServices: [Service],
+                availableSupports: [SupportUI],
                 delegate: SettingsViewModelDelegate?
     ) {
         self.notificationsCriticalAlertPermissionsViewModel = notificationsCriticalAlertPermissionsViewModel
@@ -123,8 +126,8 @@ public class SettingsViewModel: ObservableObject {
         self.closedLoopPreference = initialDosingEnabled
         self.isClosedLoopAllowed = false
         self.preferredGlucoseUnit = preferredGlucoseUnit
-        self.activeServices = activeServices
         self.supportInfoProvider = supportInfoProvider
+        self.availableSupports = availableSupports
         self.delegate = delegate
         
         // This strangeness ensures the composed ViewModels' (ObservableObjects') changes get reported to this ViewModel (ObservableObject)

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -347,7 +347,7 @@ fileprivate class FakeService1: Service {
     required init() {}
     required init?(rawState: RawStateValue) {}
     let isOnboarded = true
-    func delete() { serviceDelegate?.serviceWasDeleted(self) }
+    func delete() { serviceDelegate?.serviceWantsDeletion(self) }
     var available: ServiceDescriptor { ServiceDescriptor(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
 }
 fileprivate class FakeService2: Service {
@@ -358,7 +358,7 @@ fileprivate class FakeService2: Service {
     required init() {}
     required init?(rawState: RawStateValue) {}
     let isOnboarded = true
-    func delete() { serviceDelegate?.serviceWasDeleted(self) }
+    func delete() { serviceDelegate?.serviceWantsDeletion(self) }
     var available: ServiceDescriptor { ServiceDescriptor(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
 }
 fileprivate let servicesViewModel = ServicesViewModel(showServices: true,

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -260,7 +260,7 @@ extension SettingsView {
         }
     }
     
-    private func makeDeleteAlert(for model: DeviceViewModel) -> SwiftUI.Alert {
+    private func makeDeleteAlert<T>(for model: DeviceViewModel<T>) -> SwiftUI.Alert {
         return SwiftUI.Alert(title: Text("Delete Testing Data"),
                              message: Text("Are you sure you want to delete all your \(model.name()) Data?\n(This action is not reversible)"),
                              primaryButton: .cancel(),
@@ -271,7 +271,7 @@ extension SettingsView {
         Section(header: SectionHeader(label: NSLocalizedString("Support", comment: "The title of the support section in settings"))) {
             NavigationLink(destination: SupportScreenView(didTapIssueReport: viewModel.didTapIssueReport,
                                                           criticalEventLogExportViewModel: viewModel.criticalEventLogExportViewModel,
-                                                          activeServices: self.viewModel.activeServices,
+                                                          availableSupports: self.viewModel.availableSupports,
                                                           supportInfoProvider: self.viewModel.supportInfoProvider))
             {
                 Text(NSLocalizedString("Support", comment: "The title of the support item in settings"))
@@ -344,18 +344,22 @@ fileprivate class FakeService1: Service {
     static var serviceIdentifier: String = "FakeService1"
     var serviceDelegate: ServiceDelegate?
     var rawState: RawStateValue = [:]
+    required init() {}
     required init?(rawState: RawStateValue) {}
-    convenience init() { self.init(rawState: [:])! }
-    var available: AvailableService { AvailableService(identifier: serviceIdentifier, localizedTitle: localizedTitle, providesOnboarding: false) }
+    let isOnboarded = true
+    func delete() { serviceDelegate?.serviceWasDeleted(self) }
+    var available: ServiceDescriptor { ServiceDescriptor(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
 }
 fileprivate class FakeService2: Service {
     static var localizedTitle: String = "Service 2"
     static var serviceIdentifier: String = "FakeService2"
     var serviceDelegate: ServiceDelegate?
     var rawState: RawStateValue = [:]
+    required init() {}
     required init?(rawState: RawStateValue) {}
-    convenience init() { self.init(rawState: [:])! }
-    var available: AvailableService { AvailableService(identifier: serviceIdentifier, localizedTitle: localizedTitle, providesOnboarding: false) }
+    let isOnboarded = true
+    func delete() { serviceDelegate?.serviceWasDeleted(self) }
+    var available: ServiceDescriptor { ServiceDescriptor(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
 }
 fileprivate let servicesViewModel = ServicesViewModel(showServices: true,
                                                       availableServices: { [FakeService1().available, FakeService2().available] },
@@ -386,10 +390,9 @@ public struct SettingsView_Previews: PreviewProvider {
     
     public static var previews: some View {
         let fakeClosedLoopAllowedPublisher = FakeClosedLoopAllowedPublisher()
-        let supportInfoProvider = MockSupportInfoProvider()
         let viewModel = SettingsViewModel(notificationsCriticalAlertPermissionsViewModel: NotificationsCriticalAlertPermissionsViewModel(),
-                                          pumpManagerSettingsViewModel: DeviceViewModel(),
-                                          cgmManagerSettingsViewModel: DeviceViewModel(),
+                                          pumpManagerSettingsViewModel: DeviceViewModel<PumpManagerDescriptor>(),
+                                          cgmManagerSettingsViewModel: DeviceViewModel<CGMManagerDescriptor>(),
                                           servicesViewModel: servicesViewModel,
                                           criticalEventLogExportViewModel: CriticalEventLogExportViewModel(exporterFactory: MockCriticalEventLogExporterFactory()),
                                           therapySettings: { TherapySettings() },
@@ -401,7 +404,7 @@ public struct SettingsView_Previews: PreviewProvider {
                                           isClosedLoopAllowed: fakeClosedLoopAllowedPublisher.$mockIsClosedLoopAllowed,
                                           preferredGlucoseUnit: .milligramsPerDeciliter,
                                           supportInfoProvider: MockSupportInfoProvider(),
-                                          activeServices: [],
+                                          availableSupports: [],
                                           delegate: nil)
         return Group {
             SettingsView(viewModel: viewModel)

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -347,7 +347,6 @@ fileprivate class FakeService1: Service {
     required init() {}
     required init?(rawState: RawStateValue) {}
     let isOnboarded = true
-    func delete() { serviceDelegate?.serviceWantsDeletion(self) }
     var available: ServiceDescriptor { ServiceDescriptor(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
 }
 fileprivate class FakeService2: Service {
@@ -358,7 +357,6 @@ fileprivate class FakeService2: Service {
     required init() {}
     required init?(rawState: RawStateValue) {}
     let isOnboarded = true
-    func delete() { serviceDelegate?.serviceWantsDeletion(self) }
     var available: ServiceDescriptor { ServiceDescriptor(identifier: serviceIdentifier, localizedTitle: localizedTitle) }
 }
 fileprivate let servicesViewModel = ServicesViewModel(showServices: true,

--- a/Loop/Views/SupportScreenView.swift
+++ b/Loop/Views/SupportScreenView.swift
@@ -21,7 +21,7 @@ struct SupportScreenView: View {
     
     var didTapIssueReport: ((_ title: String) -> Void)?
     var criticalEventLogExportViewModel: CriticalEventLogExportViewModel
-    let activeServices: [Service]
+    let availableSupports: [SupportUI]
     let supportInfoProvider: SupportInfoProvider
     
     @State private var adverseEventReportURLInvalid = false
@@ -53,19 +53,13 @@ struct SupportScreenView: View {
     }
     
     var supportMenuItems: [SupportMenuItem] {
-        return activeServices.compactMap { (service) -> SupportMenuItem? in
-            if let view = (service as? ServiceUI)?.supportMenuItem(supportInfoProvider: supportInfoProvider, urlHandler: openURL) {
-                return SupportMenuItem(id: service.serviceIdentifier, menuItemView: view)
+        return availableSupports.compactMap { (support) -> SupportMenuItem? in
+            if let view = support.supportMenuItem(supportInfoProvider: supportInfoProvider, urlHandler: openURL) {
+                return SupportMenuItem(id: support.supportIdentifier, menuItemView: view)
             } else {
                 return nil
             }
         }
-    }
-        
-    private var invalidAdverseEventReportURLAlert: SwiftUI.Alert {
-        Alert(title: Text("Invalid Adverse Event Report URL", comment: "Alert title when the adverse event report URL cannot be constructed properly."),
-              message: Text("The adverse event report URL could not be constructed properly.", comment: "Alert message when the adverse event report URL cannot be constructed properly."),
-              dismissButton: .default(Text("Dismiss", comment: "Dismiss button for the invalid adverse event report URL alert.")))
     }
 }
 
@@ -85,6 +79,6 @@ struct SupportScreenView_Previews: PreviewProvider {
 
     static var previews: some View {
         SupportScreenView(criticalEventLogExportViewModel: CriticalEventLogExportViewModel(exporterFactory: MockCriticalEventLogExporterFactory()),
-                          activeServices: [], supportInfoProvider: MockSupportInfoProvider())
+                          availableSupports: [], supportInfoProvider: MockSupportInfoProvider())
     }
 }

--- a/LoopUI/Extensions/DismissibleHostingController.swift
+++ b/LoopUI/Extensions/DismissibleHostingController.swift
@@ -20,9 +20,9 @@ extension DismissibleHostingController {
                   dismissalMode: dismissalMode,
                   isModalInPresentation: isModalInPresentation,
                   onDisappear: onDisappear,
+                  guidanceColors: GuidanceColors.default,
                   carbTintColor: .carbTintColor,
                   glucoseTintColor: .glucoseTintColor,
-                  guidanceColors: GuidanceColors.default,
                   insulinTintColor: .insulinTintColor)
     }
 }


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-2534
- https://tidepool.atlassian.net/browse/LOOP-1550
- https://tidepool.atlassian.net/browse/LOOP-2955
- Refactor onboarding and support manager functionality into separate plugin types
- Allow onboarding to provide view controller
- Move onboarding support to StatusTableViewController
- Remove providesOnboarding service functionality
- Add default LoopUIColorPalette
- Refactor setup/settingsViewController to use LoopUIColorPalette
- Update various delegates to support separate create and onboard notifications
- Rename AvailableDevice to CGMManagerDescriptor and PumpManagerDescriptor
- Rename AvailableService to ServiceDescriptor
- Refactor DeviceViewModel for explicit pump and CGM support
- Log pump manager, CGM manager, and service lifetime notifications
- Allow plugin extensions to provide additional functionality
- Minor renaming for consistency
- Fix warnings