### PR TITLE
[LOOP-1804] Unreliable glucose data cancels high temp basal

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -397,6 +397,8 @@ final class DeviceDataManager {
                     }
                 }
             }
+        case .unreliableData:
+            loopManager.recievedUnreliableCGMReading()
         case .noData:
             log.default("CGMManager:%{public}@ did update with no data", String(describing: type(of: manager)))
 

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -501,8 +501,7 @@ extension LoopDataManager {
         }
               
         // Setting a temp basal with 0 duration effectively cancels that temp basal
-        let basalRecommendation = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: 0)
-        recommendedTempBasal = (recommendation: basalRecommendation, date: self.now())
+        recommendedTempBasal = (recommendation: TempBasalRecommendation.cancel, date: self.now())
         enactRecommendedTempBasal { (error) -> Void in
             self.storeDosingDecision(withDate: self.now(), withError: error)
             self.notify(forChange: .tempBasal)

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -500,7 +500,7 @@ extension LoopDataManager {
             return
         }
               
-        // Setting a temp basal with 0 duration effectively cancels that temp basal
+        // Cancel that temp basal
         recommendedTempBasal = (recommendation: TempBasalRecommendation.cancel, date: self.now())
         enactRecommendedTempBasal { (error) -> Void in
             self.storeDosingDecision(withDate: self.now(), withError: error)

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -494,7 +494,7 @@ extension LoopDataManager {
     /// An active high temp basal (greater than the basal schedule) is cancelled when the CGM data is unreliable.
     func recievedUnreliableCGMReading() {
         guard case .tempBasal(let tempBasal) = basalDeliveryState,
-              let scheduledBasalRate = therapySettings.basalRateSchedule?.value(at: now()),
+              let scheduledBasalRate = basalRateSchedule?.value(at: now()),
               tempBasal.unitsPerHour > scheduledBasalRate else
         {
             return

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -488,6 +488,26 @@ extension LoopDataManager {
             }
         }
     }
+    
+    /// Take actions to address how insulin is delivered when the CGM data is unreliable
+    ///
+    /// An active high temp basal (greater than the basal schedule) is cancelled when the CGM data is unreliable.
+    func recievedUnreliableCGMReading() {
+        guard case .tempBasal(let tempBasal) = basalDeliveryState,
+              let scheduledBasalRate = therapySettings.basalRateSchedule?.value(at: now()),
+              tempBasal.unitsPerHour > scheduledBasalRate else
+        {
+            return
+        }
+              
+        //TODO cancel temp basal.... is this possible here?
+        let basalRecommendation = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: .minutes(30))
+        recommendedTempBasal = (recommendation: basalRecommendation, date: self.now())
+        enactRecommendedTempBasal { (error) -> Void in
+            self.storeDosingDecision(withDate: self.now(), withError: error)
+            self.notify(forChange: .tempBasal)
+        }
+    }
 
     /// Adds and stores carb data, and recommends a bolus if needed
     ///

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -501,7 +501,7 @@ extension LoopDataManager {
         }
               
         // Setting a temp basal with 0 duration effectively cancels that temp basal
-        let basalRecommendation = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: .minutes(0))
+        let basalRecommendation = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: 0)
         recommendedTempBasal = (recommendation: basalRecommendation, date: self.now())
         enactRecommendedTempBasal { (error) -> Void in
             self.storeDosingDecision(withDate: self.now(), withError: error)

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -500,8 +500,8 @@ extension LoopDataManager {
             return
         }
               
-        //TODO cancel temp basal.... is this possible here?
-        let basalRecommendation = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: .minutes(30))
+        // Setting a temp basal with 0 duration effectively cancels that temp basal
+        let basalRecommendation = TempBasalRecommendation(unitsPerHour: scheduledBasalRate, duration: .minutes(0))
         recommendedTempBasal = (recommendation: basalRecommendation, date: self.now())
         enactRecommendedTempBasal { (error) -> Void in
             self.storeDosingDecision(withDate: self.now(), withError: error)


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1804

This is my initial thoughts for canceling high temp basal when unreliable glucose data is received. See https://github.com/tidepool-org/LoopKit/pull/321 for `LoopKit` related updates.