### PR TITLE
Critical alerts should not show destructive button

### DIFF
--- a/Loop/Managers/Alerts/InAppModalAlertPresenter.swift
+++ b/Loop/Managers/Alerts/InAppModalAlertPresenter.swift
@@ -139,7 +139,7 @@ extension InAppModalAlertPresenter {
         dispatchPrecondition(condition: .onQueue(.main))
         // For now, this is a simple alert with an "OK" button
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alertController.addAction(newActionFunc(action, isCritical ? .destructive : .default, { _ in completion() }))
+        alertController.addAction(newActionFunc(action, .default, { _ in completion() }))
         rootViewController?.topmostViewController.present(alertController, animated: true)
         return alertController
     }


### PR DESCRIPTION
During a design review with Matt, he noted that critical alert buttons should not show red (destructive).