### PR TITLE
LOOP-3353: Avoids displaying calibration values in the CGM Pill

### DIFF
--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -292,7 +292,8 @@ class StatusViewController: UIViewController, NCWidgetProviding {
                     unit: unit,
                     staleGlucoseAge: LoopCoreConstants.inputDataRecencyInterval,
                     glucoseDisplay: context.glucoseDisplay,
-                    wasUserEntered: lastGlucose.wasUserEntered
+                    wasUserEntered: lastGlucose.wasUserEntered,
+                    isDisplayOnly: lastGlucose.isDisplayOnly
                 )
             }
 

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -536,7 +536,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                                             unit: unit,
                                                             staleGlucoseAge: LoopCoreConstants.inputDataRecencyInterval,
                                                             glucoseDisplay: self.deviceManager.glucoseDisplay(for: glucose),
-                                                            wasUserEntered: glucose.wasUserEntered)
+                                                            wasUserEntered: glucose.wasUserEntered,
+                                                            isDisplayOnly: glucose.isDisplayOnly)
                 }
                 hudView.cgmStatusHUD.presentStatusHighlight(self.deviceManager.cgmStatusHighlight)
                 hudView.cgmStatusHUD.presentStatusBadge(self.deviceManager.cgmStatusBadge)

--- a/LoopTests/ViewModels/CGMStatusHUDViewModelTests.swift
+++ b/LoopTests/ViewModels/CGMStatusHUDViewModelTests.swift
@@ -49,7 +49,8 @@ class CGMStatusHUDViewModelTests: XCTestCase {
                                      unit: .milligramsPerDeciliter,
                                      staleGlucoseAge: staleGlucoseAge,
                                      glucoseDisplay: glucoseDisplay,
-                                     isManualGlucose: false)
+                                     wasUserEntered: false,
+                                     isDisplayOnly: false)
         
         XCTAssertNil(viewModel.manualGlucoseTrendIconOverride)
         XCTAssertNil(viewModel.statusHighlight)
@@ -72,8 +73,9 @@ class CGMStatusHUDViewModelTests: XCTestCase {
                                      unit: .milligramsPerDeciliter,
                                      staleGlucoseAge: staleGlucoseAge,
                                      glucoseDisplay: glucoseDisplay,
-                                     isManualGlucose: false)
-        
+                                     wasUserEntered: false,
+                                     isDisplayOnly: false)
+
         XCTAssertNil(viewModel.manualGlucoseTrendIconOverride)
         XCTAssertNil(viewModel.statusHighlight)
         XCTAssertEqual(viewModel.glucoseValueString, "– – –")
@@ -98,7 +100,8 @@ class CGMStatusHUDViewModelTests: XCTestCase {
                                      unit: .milligramsPerDeciliter,
                                      staleGlucoseAge: staleGlucoseAge,
                                      glucoseDisplay: glucoseDisplay,
-                                     isManualGlucose: false)
+                                     wasUserEntered: false,
+                                     isDisplayOnly: false)
         wait(for: [testExpect], timeout: 1.0)
         XCTAssertTrue(staleGlucoseValueHandlerWasCalled)
         XCTAssertNil(viewModel.manualGlucoseTrendIconOverride)
@@ -124,14 +127,38 @@ class CGMStatusHUDViewModelTests: XCTestCase {
                                      unit: .milligramsPerDeciliter,
                                      staleGlucoseAge: staleGlucoseAge,
                                      glucoseDisplay: glucoseDisplay,
-                                     isManualGlucose: true)
-        
+                                     wasUserEntered: true,
+                                     isDisplayOnly: false)
+
         XCTAssertEqual(viewModel.manualGlucoseTrendIconOverride, UIImage(systemName: "questionmark.circle"))
         XCTAssertNil(viewModel.statusHighlight)
         XCTAssertEqual(viewModel.glucoseValueString, "90")
         XCTAssertNil(viewModel.trend)
         XCTAssertNotEqual(viewModel.glucoseTrendTintColor, glucoseDisplay.glucoseRangeCategory?.trendColor)
         XCTAssertEqual(viewModel.glucoseTrendTintColor, .glucoseTintColor)
+        XCTAssertEqual(viewModel.glucoseValueTintColor, glucoseDisplay.glucoseRangeCategory?.glucoseColor)
+        XCTAssertEqual(viewModel.unitsString, HKUnit.milligramsPerDeciliter.localizedShortUnitString)
+    }
+    
+    func testSetGlucoseQuantityCalibrationDoesNotShow() {
+        let glucoseDisplay = TestGlucoseDisplay(isStateValid: true,
+                                                trendType: .down,
+                                                isLocal: true,
+                                                glucoseRangeCategory: .urgentLow)
+        let glucoseStartDate = Date()
+        let staleGlucoseAge: TimeInterval = .minutes(15)
+        viewModel.setGlucoseQuantity(90,
+                                     at: glucoseStartDate,
+                                     unit: .milligramsPerDeciliter,
+                                     staleGlucoseAge: staleGlucoseAge,
+                                     glucoseDisplay: glucoseDisplay,
+                                     wasUserEntered: true,
+                                     isDisplayOnly: true)
+
+        XCTAssertNil(viewModel.manualGlucoseTrendIconOverride)
+        XCTAssertEqual(viewModel.glucoseValueString, "90")
+        XCTAssertEqual(viewModel.trend, .down)
+        XCTAssertEqual(viewModel.glucoseTrendTintColor, glucoseDisplay.glucoseRangeCategory?.trendColor)
         XCTAssertEqual(viewModel.glucoseValueTintColor, glucoseDisplay.glucoseRangeCategory?.glucoseColor)
         XCTAssertEqual(viewModel.unitsString, HKUnit.milligramsPerDeciliter.localizedShortUnitString)
     }

--- a/LoopUI/ViewModel/CGMStatusHUDViewModel.swift
+++ b/LoopUI/ViewModel/CGMStatusHUDViewModel.swift
@@ -107,7 +107,8 @@ public class CGMStatusHUDViewModel {
                             unit: HKUnit,
                             staleGlucoseAge: TimeInterval,
                             glucoseDisplay: GlucoseDisplayable?,
-                            isManualGlucose: Bool)
+                            wasUserEntered: Bool,
+                            isDisplayOnly: Bool)
     {
         var accessibilityStrings = [String]()
         
@@ -140,7 +141,8 @@ public class CGMStatusHUDViewModel {
             }
             accessibilityStrings.append(String(format: LocalizedString("%1$@ at %2$@", comment: "Accessbility format value describing glucose: (1: glucose number)(2: glucose time)"), valueString, time))
         }
-        
+        // Only a user-entered glucose value that is *not* display-only (i.e. a calibration) is considered a manual glucose entry.
+        let isManualGlucose = wasUserEntered && !isDisplayOnly
         if isManualGlucose, glucoseValueCurrent {
             // a manual glucose value presents any status highlight icon instead of a trend icon
             setManualGlucoseTrendIconOverride()

--- a/LoopUI/Views/CGMStatusHUDView.swift
+++ b/LoopUI/Views/CGMStatusHUDView.swift
@@ -108,14 +108,16 @@ public final class CGMStatusHUDView: DeviceStatusHUDView, NibLoadable {
                                    unit: HKUnit,
                                    staleGlucoseAge: TimeInterval,
                                    glucoseDisplay: GlucoseDisplayable?,
-                                   wasUserEntered: Bool)
+                                   wasUserEntered: Bool,
+                                   isDisplayOnly: Bool)
     {
         viewModel.setGlucoseQuantity(glucoseQuantity,
                                      at: glucoseStartDate,
                                      unit: unit,
                                      staleGlucoseAge: staleGlucoseAge,
                                      glucoseDisplay: glucoseDisplay,
-                                     isManualGlucose: wasUserEntered)
+                                     wasUserEntered: wasUserEntered,
+                                     isDisplayOnly: isDisplayOnly)
         
         updateDisplay()
     }


### PR DESCRIPTION
This makes the logic for displaying "manual glucose" values in the CGM pill require that `wasUserEntered == true` and `isDisplayOnly == false` (on the understanding that `isDisplayOnly` means "this is a calibration value").