### PR TITLE
Fixes spelling: recieve -> receive

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -432,7 +432,7 @@ final class DeviceDataManager {
                 }
             }
         case .unreliableData:
-            loopManager.recievedUnreliableCGMReading()
+            loopManager.receivedUnreliableCGMReading()
         case .noData:
             log.default("CGMManager:%{public}@ did update with no data", String(describing: type(of: manager)))
             pumpManager?.ensureCurrentPumpData(completion: nil)

--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -42,7 +42,7 @@ public class LoopAlertsManager {
     private func onBluetoothPoweredOff() {
         log.default("Bluetooth powered off")
         let title = NSLocalizedString("Bluetooth Off Alert", comment: "Bluetooth off alert title")
-        let bgBody = NSLocalizedString("Loop will not work successfully until Bluetooth is enabled. You will not recieve glucose readings, or be able to bolus.", comment: "Bluetooth off background alert body.")
+        let bgBody = NSLocalizedString("Loop will not work successfully until Bluetooth is enabled. You will not receive glucose readings, or be able to bolus.", comment: "Bluetooth off background alert body.")
         let bgcontent = Alert.Content(title: title,
                                       body: bgBody,
                                       acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -495,7 +495,7 @@ extension LoopDataManager {
     /// Take actions to address how insulin is delivered when the CGM data is unreliable
     ///
     /// An active high temp basal (greater than the basal schedule) is cancelled when the CGM data is unreliable.
-    func recievedUnreliableCGMReading() {
+    func receivedUnreliableCGMReading() {
         guard case .tempBasal(let tempBasal) = basalDeliveryState,
               let scheduledBasalRate = basalRateSchedule?.value(at: now()),
               tempBasal.unitsPerHour > scheduledBasalRate else

--- a/LoopTests/Managers/CGMStalenessMonitorTests.swift
+++ b/LoopTests/Managers/CGMStalenessMonitorTests.swift
@@ -35,12 +35,12 @@ class CGMStalenessMonitorTests: XCTestCase {
         fetchExpectation = expectation(description: "Fetch latest cgm glucose")
         latestCGMGlucose = storedGlucoseSample
         
-        var recievedValues = [Bool]()
+        var receivedValues = [Bool]()
         let exp = expectation(description: "expected values")
         
         let cancelable = monitor.$cgmDataIsStale.sink { value in
-            recievedValues.append(value)
-            if recievedValues.count == 2 {
+            receivedValues.append(value)
+            if receivedValues.count == 2 {
                 exp.fulfill()
             }
         }
@@ -49,7 +49,7 @@ class CGMStalenessMonitorTests: XCTestCase {
         waitForExpectations(timeout: 2)
         
         XCTAssertNotNil(cancelable)
-        XCTAssertEqual(recievedValues, [true, false])
+        XCTAssertEqual(receivedValues, [true, false])
     }
     
     func testStalenessWithNoRecentCGMData() {
@@ -57,12 +57,12 @@ class CGMStalenessMonitorTests: XCTestCase {
         fetchExpectation = expectation(description: "Fetch latest cgm glucose")
         latestCGMGlucose = nil
         
-        var recievedValues = [Bool]()
+        var receivedValues = [Bool]()
         let exp = expectation(description: "expected values")
         
         let cancelable = monitor.$cgmDataIsStale.sink { value in
-            recievedValues.append(value)
-            if recievedValues.count == 2 {
+            receivedValues.append(value)
+            if receivedValues.count == 2 {
                 exp.fulfill()
             }
         }
@@ -71,7 +71,7 @@ class CGMStalenessMonitorTests: XCTestCase {
         waitForExpectations(timeout: 2)
         
         XCTAssertNotNil(cancelable)
-        XCTAssertEqual(recievedValues, [true, true])
+        XCTAssertEqual(receivedValues, [true, true])
     }
     
     func testStalenessNewReadingsArriving() {
@@ -79,12 +79,12 @@ class CGMStalenessMonitorTests: XCTestCase {
         fetchExpectation = expectation(description: "Fetch latest cgm glucose")
         latestCGMGlucose = nil
         
-        var recievedValues = [Bool]()
+        var receivedValues = [Bool]()
         let exp = expectation(description: "expected values")
         
         let cancelable = monitor.$cgmDataIsStale.sink { value in
-            recievedValues.append(value)
-            if recievedValues.count == 2 {
+            receivedValues.append(value)
+            if receivedValues.count == 2 {
                 exp.fulfill()
             }
         }
@@ -96,7 +96,7 @@ class CGMStalenessMonitorTests: XCTestCase {
         waitForExpectations(timeout: 2)
         
         XCTAssertNotNil(cancelable)
-        XCTAssertEqual(recievedValues, [true, false])
+        XCTAssertEqual(receivedValues, [true, false])
     }
 }
 


### PR DESCRIPTION
In displayed content, but also everywhere else...(this was just bugging me...)