### PR TITLE
[LOOP-1003] Avoid displaying stale glucose values

### DIFF
--- a/WatchApp Extension/Controllers/HUDInterfaceController.swift
+++ b/WatchApp Extension/Controllers/HUDInterfaceController.swift
@@ -29,9 +29,10 @@ class HUDInterfaceController: WKInterfaceController {
                 }
             }
         }
-        
-        loopManager.requestGlucoseBackfillIfNecessary()
-        loopManager.requestContextUpdate()
+
+        loopManager.requestContextUpdate(completion: {
+            self.loopManager.requestGlucoseBackfillIfNecessary()
+        })
     }
 
     override func didDeactivate() {

--- a/WatchApp Extension/Managers/LoopDataManager.swift
+++ b/WatchApp Extension/Managers/LoopDataManager.swift
@@ -166,7 +166,7 @@ extension LoopDataManager {
         return true
     }
 
-    func requestContextUpdate() {
+    func requestContextUpdate(completion: @escaping () -> Void = { }) {
         try? WCSession.default.sendContextRequestMessage(WatchContextRequestUserInfo(), completionHandler: { (result) in
             DispatchQueue.main.async {
                 switch result {
@@ -175,6 +175,7 @@ extension LoopDataManager {
                 case .failure:
                     break
                 }
+                completion()
             }
         })
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1003

get context update first, then glucose backfill. This presents the current glucose value instead of any stale glucose values from the backfill. 

@ps2 what I see in the sysdiagnose attached to the ticket looks right to me. Each time the chart or HUD become active, there is a potential request for glucose backfill. This is blocked when there has been a recent request. I'm guessing Becky was swiping between the chart and HUD multiple times while waiting for data to be received. The issue as I see it was that the backfill request took ~2 mins to receive 12 samples. Note that I do not see this long delay; as the response is typically received within seconds (longest I've seen is 1 instance of ~10s). 