### PR TITLE
LOOP-1302: Remove early `dismiss()` that was hiding certain errors from send bolus

### DIFF
--- a/WatchApp Extension/Extensions/WCSession.swift
+++ b/WatchApp Extension/Extensions/WCSession.swift
@@ -67,6 +67,7 @@ extension WCSession {
                 completionHandler(nil)
             },
             errorHandler: { error in
+                log.info("sendBolusMessage failure: %{public}@", error.localizedDescription)
                 completionHandler(error)
             }
         )

--- a/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
+++ b/WatchApp Extension/View Models/CarbAndBolusFlowViewModel.swift
@@ -196,7 +196,6 @@ final class CarbAndBolusFlowViewModel: ObservableObject {
         }
 
         sendSetBolusUserInfo(carbEntry: carbEntry, bolus: 0)
-        dismiss()
     }
 
     func addCarbsAndDeliverBolus(_ bolusAmount: Double) {


### PR DESCRIPTION
Turns out this `dismiss` was closing the view before any bolus error (that is SwiftUI-based) gets shown to the user.  Thanks to Pete for helping me out with this!
Note: this will bring up an error and return you to the previous screen.

https://tidepool.atlassian.net/browse/LOOP-1302