### PR TITLE
[LOOP-3578] removing device refresh out of did become active (reverting code)

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -734,7 +734,6 @@ extension DeviceDataManager {
 
     func didBecomeActive() {
         updatePumpManagerBLEHeartbeatPreference()
-        refreshDeviceData()
     }
 
     func updatePumpManagerBLEHeartbeatPreference() {


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3578

Calling `refreshDeviceData()` when the app becomes active caused regression of re-scheduling a high temp basal that was cancelled when unreliable data was received. Reverting.