### PR TITLE
[HOTFIX] Closed loop status nil for carb absorption view

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1156,8 +1156,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
         switch targetViewController {
         case let vc as CarbAbsorptionViewController:
-            vc.deviceManager = deviceManager
             vc.closedLoopStatus = closedLoopStatus
+            vc.deviceManager = deviceManager
             vc.hidesBottomBarWhenPushed = true
         case let vc as InsulinDeliveryTableViewController:
             vc.doseStore = deviceManager.doseStore


### PR DESCRIPTION
assigning the `deviceManager` triggers actions in the carb absorption view and causes a crash. So assign `closedLoopStatus` first.