### PR TITLE
LOOP-3647: Fixes typo: 'Alert Permissions Disabled' instead of 'Alerts Permissions Disabled'

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -824,7 +824,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
   
         override func updateConfiguration(using state: UICellConfigurationState) {
             super.updateConfiguration(using: state)
-            let content = NSLocalizedString("Alerts Permissions Disabled", comment: "Warning text for when Notifications or Critical Alerts Permissions is disabled")
+            let content = NSLocalizedString("Alert Permissions Disabled", comment: "Warning text for when Notifications or Critical Alerts Permissions is disabled")
             var contentConfig = defaultContentConfiguration().updated(for: state)
             contentConfig.text = content
             contentConfig.textProperties.color = .red


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3647