### PR TITLE
Tweaks version string in settings (and gets rid of the "57" build number)

### DIFF
--- a/Common/Extensions/NSBundle.swift
+++ b/Common/Extensions/NSBundle.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Bundle {
     var fullVersionString: String {
-        return "\(shortVersionString).\(version)"
+        return "\(shortVersionString) (\(version))"
     }
 
     var shortVersionString: String {

--- a/Version.xcconfig
+++ b/Version.xcconfig
@@ -7,8 +7,8 @@
 //
 
 // Version [DEFAULT]
-LOOP_MARKETING_VERSION = 1.10.1
-CURRENT_PROJECT_VERSION = 57
+LOOP_MARKETING_VERSION = 0.0.1
+CURRENT_PROJECT_VERSION = 0
 
 // Optional override
 #include? "VersionOverride.xcconfig"


### PR DESCRIPTION
This changes the version string that is shown in Settings (and, anywhere else) from `x.y.z.nnnn` to `x.y.z (nnnn)`.

I also took the liberty of changing the "magical mysterious 57" build number for local dev builds.  I think this is ok, but I'm open to discuss.