### PR TITLE
[LOOP-3323] Allow pause onboarding

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		89FE21AD24AC57E30033F501 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FE21AC24AC57E30033F501 /* Collection.swift */; };
 		A90EF53C25DEF06200F32D61 /* PluginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16DA84122E8E112008624C2 /* PluginManager.swift */; };
 		A90EF54425DEF0A000F32D61 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4374B5EE209D84BE00D17AA8 /* OSLog.swift */; };
+		A91D2A3F26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91D2A3E26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift */; };
 		A91E4C2124F867A700BE9213 /* StoredAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91E4C2024F867A700BE9213 /* StoredAlertTests.swift */; };
 		A91E4C2324F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91E4C2224F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift */; };
 		A92E557E2464DFFD00DB93BB /* DosingDecisionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92E557D2464DFFD00DB93BB /* DosingDecisionStore.swift */; };
@@ -1288,6 +1289,7 @@
 		89F9119324358E4500ECCAF3 /* CarbAbsorptionTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbAbsorptionTime.swift; sourceTree = "<group>"; };
 		89F9119524358E6900ECCAF3 /* BolusPickerValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusPickerValues.swift; sourceTree = "<group>"; };
 		89FE21AC24AC57E30033F501 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		A91D2A3E26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconTitleSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		A91E4C2024F867A700BE9213 /* StoredAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredAlertTests.swift; sourceTree = "<group>"; };
 		A91E4C2224F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalEventLogExportManagerTests.swift; sourceTree = "<group>"; };
 		A92E557D2464DFFD00DB93BB /* DosingDecisionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DosingDecisionStore.swift; path = ../Stores/DosingDecisionStore.swift; sourceTree = "<group>"; };
@@ -2050,6 +2052,7 @@
 				A9A056B224B93C62007CF06D /* CriticalEventLogExportView.swift */,
 				43D381611EBD9759007F8C8F /* HeaderValuesTableViewCell.swift */,
 				430D85881F44037000AF2D4F /* HUDViewTableViewCell.swift */,
+				A91D2A3E26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift */,
 				1DA46B5F2492E2E300D71A63 /* NotificationsCriticalAlertPermissionsView.swift */,
 				899433B723FE129700FA4BEA /* OverrideBadgeView.swift */,
 				89D6953D23B6DF8A002B3066 /* PotentialCarbEntryTableViewCell.swift */,
@@ -3486,6 +3489,7 @@
 				89CA2B32226C18B8004D9350 /* TestingScenariosTableViewController.swift in Sources */,
 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
 				43C05CAF21EB2C24006FB252 /* NSBundle.swift in Sources */,
+				A91D2A3F26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift in Sources */,
 				A967D94C24F99B9300CDDF8A /* OutputStream.swift in Sources */,
 				1DB1065124467E18005542BD /* AlertManager.swift in Sources */,
 				1D9650C82523FBA100A1370B /* DeviceDataManager+BolusEntryViewModelDelegate.swift in Sources */,

--- a/Loop/Base.lproj/Main.storyboard
+++ b/Loop/Base.lproj/Main.storyboard
@@ -477,7 +477,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="HUDViewTableViewCell" rowHeight="70" id="vCp-19-ZkW" customClass="HUDViewTableViewCell" customModule="Loop" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="70"/>
+                                <rect key="frame" x="0.0" y="24.5" width="375" height="70"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vCp-19-ZkW" id="b8U-Fn-hSd">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -499,7 +499,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TitleSubtitleTableViewCell" id="zTq-QB-XNu" customClass="TitleSubtitleTableViewCell" customModule="Loop" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="98" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="94.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zTq-QB-XNu" id="vD6-31-qVz">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -543,8 +543,60 @@
                                     <outlet property="titleLabel" destination="k3F-Na-7mn" id="Mrt-ZL-fKG"/>
                                 </connections>
                             </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="IconTitleSubtitleTableViewCell" id="5av-st-q28" customClass="IconTitleSubtitleTableViewCell" customModule="Loop" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="138.5" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5av-st-q28" id="lLV-fl-2Ke">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lZi-ar-9iV">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="3.5 U/hour @ 12:12 PM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fWV-jg-ICt">
+                                            <rect key="frame" x="196" y="16" width="163" height="12"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Recommended Basal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xhx-PI-bBI">
+                                            <rect key="frame" x="58" y="16" width="130" height="12"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Uyb-ce-nXY">
+                                            <rect key="frame" x="16" y="5" width="33" height="33"/>
+                                        </imageView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="Uyb-ce-nXY" secondAttribute="bottom" id="3Iv-mH-pcL"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="fWV-jg-ICt" secondAttribute="bottom" constant="5" id="EjW-rd-jxl"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="xhx-PI-bBI" secondAttribute="bottom" constant="5" id="X7F-rd-kEw"/>
+                                        <constraint firstItem="xhx-PI-bBI" firstAttribute="top" secondItem="lLV-fl-2Ke" secondAttribute="topMargin" constant="5" id="YZ6-LQ-URg"/>
+                                        <constraint firstItem="Uyb-ce-nXY" firstAttribute="top" secondItem="lLV-fl-2Ke" secondAttribute="top" id="cos-il-XLC"/>
+                                        <constraint firstItem="fWV-jg-ICt" firstAttribute="leading" secondItem="xhx-PI-bBI" secondAttribute="trailing" constant="8" symbolic="YES" id="hvf-Rm-1et"/>
+                                        <constraint firstItem="fWV-jg-ICt" firstAttribute="top" secondItem="lLV-fl-2Ke" secondAttribute="topMargin" constant="5" id="jd7-tP-g9w"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="fWV-jg-ICt" secondAttribute="trailing" id="nnf-aY-RjG"/>
+                                        <constraint firstItem="xhx-PI-bBI" firstAttribute="leading" secondItem="Uyb-ce-nXY" secondAttribute="trailing" constant="8" symbolic="YES" id="o04-Iy-95H"/>
+                                        <constraint firstAttribute="leadingMargin" secondItem="Uyb-ce-nXY" secondAttribute="leading" id="qHL-Ga-aMN"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <constraints>
+                                    <constraint firstItem="lZi-ar-9iV" firstAttribute="top" secondItem="5av-st-q28" secondAttribute="top" id="9Tk-CA-OxJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="lZi-ar-9iV" secondAttribute="trailing" id="CgY-Gc-Tfq"/>
+                                    <constraint firstItem="lZi-ar-9iV" firstAttribute="leading" secondItem="5av-st-q28" secondAttribute="leading" id="FjH-CR-cTZ"/>
+                                    <constraint firstAttribute="bottom" secondItem="lZi-ar-9iV" secondAttribute="bottom" id="lyr-yc-tdb"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="backgroundView" destination="lZi-ar-9iV" id="hxP-ji-frQ"/>
+                                    <outlet property="iconImageView" destination="Uyb-ce-nXY" id="V6G-a3-3L1"/>
+                                    <outlet property="subtitleLabel" destination="fWV-jg-ICt" id="x1Z-Pa-Nro"/>
+                                    <outlet property="titleLabel" destination="xhx-PI-bBI" id="2Xd-Nu-GMe"/>
+                                </connections>
+                            </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="ChartTableViewCell" rowHeight="200" id="FEV-fX-i48" customClass="ChartTableViewCell" customModule="LoopKitUI">
-                                <rect key="frame" x="0.0" y="142" width="375" height="200"/>
+                                <rect key="frame" x="0.0" y="182.5" width="375" height="200"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FEV-fX-i48" id="lS6-Qa-Lw7">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
@@ -635,7 +687,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Tc-kF-7yT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="838.125" y="-458.45070422535213"/>
+            <point key="canvasLocation" x="837.60000000000002" y="-459.22038980509751"/>
         </scene>
         <!--Root Navigation Controller-->
         <scene sceneID="1UI-1d-xLb">

--- a/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
+++ b/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
@@ -36,6 +36,8 @@ extension DeviceDataManager {
         let bluetoothState = bluetoothProvider.bluetoothState
         if bluetoothState == .unsupported || bluetoothState == .unauthorized || bluetoothState == .poweredOff {
             return BluetoothState.enableHighlight
+        } else if !resumeOnboardingProvider.onboardingStatus.isComplete, pumpManager?.isOnboarded != true {
+            return DeviceDataManager.resumeOnboardingStatusHighlight
         } else if pumpManager == nil {
             return DeviceDataManager.addPumpStatusHighlight
         } else {
@@ -51,6 +53,16 @@ extension DeviceDataManager {
         return pumpManager?.pumpLifecycleProgress
     }
     
+    static var resumeOnboardingStatusHighlight: ResumeOnboardingStatusHighlight {
+        return ResumeOnboardingStatusHighlight()
+    }
+
+    struct ResumeOnboardingStatusHighlight: DeviceStatusHighlight {
+        var localizedMessage: String = NSLocalizedString("Complete Setup", comment: "Title text for button to complete setup")
+        var imageName: String = "exclamationmark.circle.fill"
+        var state: DeviceStatusHighlightState = .warning
+    }
+
     static var addCGMStatusHighlight: AddDeviceStatusHighlight {
         return AddDeviceStatusHighlight(localizedMessage: NSLocalizedString("Add CGM", comment: "Title text for button to set up a CGM"),
                                         state: .critical)
@@ -84,6 +96,9 @@ extension DeviceDataManager {
     func didTapOnPumpStatus(_ view: BaseHUDView? = nil) -> HUDTapAction? {
         if let action = bluetoothProvider.bluetoothState.action {
             return action
+        } else if !resumeOnboardingProvider.onboardingStatus.isComplete, pumpManager?.isOnboarded != true {
+            resumeOnboardingProvider.resumeOnboarding()
+            return .takeNoAction
         } else if let pumpManagerHUDProvider = pumpManagerHUDProvider,
             let view = view,
             let action = pumpManagerHUDProvider.didTapOnHUDView(view, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled)

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -2150,7 +2150,8 @@ extension LoopDataManager {
 extension LoopDataManager {
     public var therapySettings: TherapySettings {
         get {
-            TherapySettings(glucoseTargetRangeSchedule: settings.glucoseTargetRangeSchedule,
+            let settings = settings
+            return TherapySettings(glucoseTargetRangeSchedule: settings.glucoseTargetRangeSchedule,
                             correctionRangeOverrides: CorrectionRangeOverrides(preMeal: settings.preMealTargetRange, workout: settings.legacyWorkoutTargetRange),
                             maximumBasalRatePerHour: settings.maximumBasalRatePerHour,
                             maximumBolus: settings.maximumBolus,
@@ -2162,7 +2163,7 @@ extension LoopDataManager {
         }
         
         set {
-            lockedSettings.mutate { settings in
+            mutateSettings { settings in
                 settings.glucoseTargetRangeSchedule = newValue.glucoseTargetRangeSchedule
                 settings.preMealTargetRange = newValue.correctionRangeOverrides?.preMeal
                 settings.legacyWorkoutTargetRange = newValue.correctionRangeOverrides?.workout

--- a/Loop/Managers/OnboardingManager.swift
+++ b/Loop/Managers/OnboardingManager.swift
@@ -10,6 +10,14 @@ import HealthKit
 import LoopKit
 import LoopKitUI
 
+class OnboardingStatus {
+    @Published var isComplete: Bool
+
+    init(isComplete: Bool) {
+        self.isComplete = isComplete
+    }
+}
+
 class OnboardingManager {
     private let pluginManager: PluginManager
     private let bluetoothProvider: BluetoothProvider
@@ -19,8 +27,13 @@ class OnboardingManager {
     private weak var windowProvider: WindowProvider?
     private let userDefaults: UserDefaults
 
-    private var isOnboarded: Bool {
-        didSet { userDefaults.onboardingManagerIsOnboarded = isOnboarded }
+    public let status: OnboardingStatus
+
+    private var isComplete: Bool {
+        didSet {
+            userDefaults.onboardingManagerIsComplete = isComplete
+            status.isComplete = isComplete
+        }
     }
     private var completedOnboardingIdentifiers: [String] = [] {
         didSet { userDefaults.onboardingManagerCompletedOnboardingIdentifiers = completedOnboardingIdentifiers }
@@ -40,8 +53,12 @@ class OnboardingManager {
         self.windowProvider = windowProvider
         self.userDefaults = userDefaults
 
-        self.isOnboarded = userDefaults.onboardingManagerIsOnboarded && loopDataManager.therapySettings.isComplete
-        if !isOnboarded {
+        let isComplete = userDefaults.onboardingManagerIsComplete && loopDataManager.therapySettings.isComplete
+
+        self.status = OnboardingStatus(isComplete: isComplete)
+
+        self.isComplete = isComplete
+        if !isComplete {
             if loopDataManager.therapySettings.isComplete {
                 self.completedOnboardingIdentifiers = userDefaults.onboardingManagerCompletedOnboardingIdentifiers
             }
@@ -52,30 +69,41 @@ class OnboardingManager {
         }
     }
 
-    func onboard(_ completion: @escaping () -> Void) {
+    func launch(_ completion: @escaping () -> Void) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        precondition(self.completion == nil)
+
         self.completion = completion
-        resumeOnboarding()
+        continueOnboarding()
     }
 
-    private func resumeOnboarding() {
+    func resume() {
+        dispatchPrecondition(condition: .onQueue(.main))
+        precondition(self.completion == nil)
+
+        self.completion = {
+            self.windowProvider?.window?.rootViewController?.dismiss(animated: true, completion: nil)
+        }
+        continueOnboarding(resumeSuspended: true)
+    }
+
+    private func continueOnboarding(resumeSuspended: Bool = false) {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        guard !isOnboarded else {
+        guard !isComplete else {
+            complete()
+            return
+        }
+        guard let onboarding = nextActiveOnboarding else {
+            authorizeAndComplete()
+            return
+        }
+        guard !onboarding.isSuspended || resumeSuspended else {
             complete()
             return
         }
 
-        if let onboarding = nextActiveOnboarding {
-            displayOnboarding(onboarding)
-            return
-        }
-
-        ensureAuthorization {
-            DispatchQueue.main.async {
-                self.isOnboarded = true
-                self.complete()
-            }
-        }
+        displayOnboarding(onboarding)
     }
 
     private var nextActiveOnboarding: OnboardingUI? {
@@ -111,17 +139,22 @@ class OnboardingManager {
         onboardingViewController.serviceOnboardingDelegate = servicesManager
         onboardingViewController.completionDelegate = self
 
-        windowProvider?.window?.rootViewController = onboardingViewController
+        if onboarding.isSuspended {
+            onboardingViewController.isModalInPresentation = true
+            windowProvider?.window?.rootViewController?.present(onboardingViewController, animated: true, completion: nil)
+        } else {
+            windowProvider?.window?.rootViewController = onboardingViewController
+        }
     }
 
     private func completeActiveOnboarding() {
         dispatchPrecondition(condition: .onQueue(.main))
 
-        if let activeOnboarding = self.activeOnboarding {
+        if let activeOnboarding = self.activeOnboarding, !activeOnboarding.isSuspended {
             completedOnboardingIdentifiers.append(activeOnboarding.onboardingIdentifier)
             self.activeOnboarding = nil
         }
-        resumeOnboarding()
+        continueOnboarding()
     }
 
     private func ensureAuthorization(_ completion: @escaping () -> Void) {
@@ -158,6 +191,15 @@ class OnboardingManager {
             return
         }
         authorizeBluetooth { _ in completion() }
+    }
+
+    private func authorizeAndComplete() {
+        ensureAuthorization {
+            DispatchQueue.main.async {
+                self.isComplete = true
+                self.complete()
+            }
+        }
     }
 
     private func complete() {
@@ -401,14 +443,14 @@ enum OnboardingError: LocalizedError {
 
 fileprivate extension UserDefaults {
     private enum Key: String {
-        case onboardingManagerIsOnboarded = "com.loopkit.Loop.OnboardingManager.IsOnboarded"
+        case onboardingManagerIsComplete = "com.loopkit.Loop.OnboardingManager.IsComplete"
         case onboardingManagerCompletedOnboardingIdentifiers = "com.loopkit.Loop.OnboardingManager.CompletedOnboardingIdentifiers"
         case onboardingManagerActiveOnboardingRawValue = "com.loopkit.Loop.OnboardingManager.ActiveOnboardingRawValue"
     }
 
-    var onboardingManagerIsOnboarded: Bool {
-        get { bool(forKey: Key.onboardingManagerIsOnboarded.rawValue) }
-        set { set(newValue, forKey: Key.onboardingManagerIsOnboarded.rawValue) }
+    var onboardingManagerIsComplete: Bool {
+        get { bool(forKey: Key.onboardingManagerIsComplete.rawValue) }
+        set { set(newValue, forKey: Key.onboardingManagerIsComplete.rawValue) }
     }
 
     var onboardingManagerCompletedOnboardingIdentifiers: [String] {

--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -26,6 +26,8 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
     
     private var allowEditing: Bool = true
 
+    var onboardingStatus: OnboardingStatus!
+
     var closedLoopStatus: ClosedLoopStatus!
 
     override func viewDidLoad() {
@@ -59,6 +61,8 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
         if let gestureRecognizer = charts.gestureRecognizer {
             tableView.addGestureRecognizer(gestureRecognizer)
         }
+
+        navigationItem.rightBarButtonItem?.isEnabled = onboardingStatus.isComplete
 
         if !closedLoopStatus.isClosedLoop {
             allowEditing = false

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -30,6 +30,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
     lazy var quantityFormatter: QuantityFormatter = QuantityFormatter()
 
+    var resumeOnboardingProvider: ResumeOnboardingProvider!
+
     var closedLoopStatus: ClosedLoopStatus!
     
     let notificationsCriticalAlertPermissionsViewModel = NotificationsCriticalAlertPermissionsViewModel()
@@ -160,6 +162,11 @@ final class StatusTableViewController: LoopChartsTableViewController {
         notificationsCriticalAlertPermissionsViewModel.updateState()
         
         updateBolusProgress()
+
+        resumeOnboardingProvider.onboardingStatus.$isComplete
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.updateToolbarItems() }
+            .store(in: &cancellables)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -238,6 +245,17 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
     private func updateHUDActive() {
         deviceManager.pumpManagerHUDProvider?.visible = active && onscreen
+    }
+
+    private func updateToolbarItems() {
+        let isOnboardingComplete = resumeOnboardingProvider.onboardingStatus.isComplete
+        let isClosedLoop = closedLoopStatus.isClosedLoop
+
+        toolbarItems![0].isEnabled = isOnboardingComplete
+        toolbarItems![2].isEnabled = isOnboardingComplete && isClosedLoop
+        toolbarItems![4].isEnabled = isOnboardingComplete
+        toolbarItems![6].isEnabled = isOnboardingComplete
+        toolbarItems![8].isEnabled = true
     }
 
     public var basalDeliveryState: PumpManagerStatus.BasalDeliveryState? = nil {
@@ -457,7 +475,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             }
         }
 
-        updatePreMealModeAvailability(allowed: isClosedLoop)
+        updatePreMealModeAvailability(isClosedLoop: isClosedLoop)
 
         if deviceManager.loopManager.settings.preMealTargetRange == nil {
             preMealMode = nil
@@ -625,6 +643,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         case bolusing(dose: DoseEntry)
         case cancelingBolus
         case pumpSuspended(resuming: Bool)
+        case onboardingSuspended
         case recommendManualGlucoseEntry
 
         var hasRow: Bool {
@@ -652,7 +671,9 @@ final class StatusTableViewController: LoopChartsTableViewController {
             statusRowMode = .pumpSuspended(resuming: true)
         } else if case .inProgress(let dose) = bolusState, dose.endDate.timeIntervalSinceNow > 0 {
             statusRowMode = .bolusing(dose: dose)
-        } else if deviceManager.isGlucoseValueStale {
+        } else if !resumeOnboardingProvider.onboardingStatus.isComplete, deviceManager.pumpManager?.isOnboarded == true {
+            statusRowMode = .onboardingSuspended
+        } else if resumeOnboardingProvider.onboardingStatus.isComplete, deviceManager.isGlucoseValueStale {
             statusRowMode = .recommendManualGlucoseEntry
         } else if let scheduleOverride = deviceManager.loopManager.settings.scheduleOverride,
             !scheduleOverride.hasFinished()
@@ -746,11 +767,12 @@ final class StatusTableViewController: LoopChartsTableViewController {
             guard oldValue != preMealMode else {
                 return
             }
-            updatePreMealModeAvailability(allowed: closedLoopStatus.isClosedLoop)
+            updatePreMealModeAvailability(isClosedLoop: closedLoopStatus.isClosedLoop)
         }
     }
 
-    private func updatePreMealModeAvailability(allowed: Bool) {
+    private func updatePreMealModeAvailability(isClosedLoop: Bool) {
+        let allowed = resumeOnboardingProvider.onboardingStatus.isComplete && isClosedLoop
         toolbarItems![2] = createPreMealButtonItem(selected: preMealMode ?? false && allowed, isEnabled: allowed)
     }
 
@@ -761,7 +783,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
             }
 
             if let workoutMode = workoutMode {
-                toolbarItems![6] = createWorkoutButtonItem(selected: workoutMode)
+                let allowed = resumeOnboardingProvider.onboardingStatus.isComplete
+                toolbarItems![6] = createWorkoutButtonItem(selected: workoutMode, isEnabled: allowed)
             } else {
                 toolbarItems![6].isEnabled = false
             }
@@ -944,6 +967,18 @@ final class StatusTableViewController: LoopChartsTableViewController {
                     }
                     cell.selectionStyle = .default
                     return cell
+                case .onboardingSuspended:
+                    let cell = tableView.dequeueReusableCell(withIdentifier: IconTitleSubtitleTableViewCell.className, for: indexPath) as! IconTitleSubtitleTableViewCell
+                    cell.selectionStyle = .default
+                    cell.backgroundColor = .secondarySystemBackground
+                    cell.iconImageView.image = UIImage(systemName: "exclamationmark.circle.fill")
+                    cell.iconImageView.tintColor = .warning
+                    cell.iconImageView.contentMode = .scaleAspectFit
+                    cell.iconImageView.preferredSymbolConfiguration = UIImage.SymbolConfiguration(pointSize: 28)
+                    cell.titleLabel.text = NSLocalizedString("Setup Incomplete", comment: "The title of the cell indicating that onboarding is suspended")
+                    cell.subtitleLabel.text = NSLocalizedString("Tap to Resume", comment: "The subtitle of the cell displaying an action to resume onboarding")
+                    cell.accessoryView = nil
+                    return cell
                 case .recommendManualGlucoseEntry:
                     let cell = getTitleSubtitleCell()
                     cell.titleLabel.text = NSLocalizedString("No Recent Glucose", comment: "The title of the cell indicating that there is no recent glucose")
@@ -1077,6 +1112,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
                             }
                         }
                     }
+                case .onboardingSuspended:
+                    resumeOnboardingProvider.resumeOnboarding()
                 case .recommendManualGlucoseEntry:
                     presentBolusEntryView(enableManualGlucoseEntry: true)
                 default:
@@ -1130,6 +1167,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
         switch targetViewController {
         case let vc as CarbAbsorptionViewController:
+            vc.onboardingStatus = resumeOnboardingProvider.onboardingStatus
             vc.closedLoopStatus = closedLoopStatus
             vc.deviceManager = deviceManager
             vc.hidesBottomBarWhenPushed = true
@@ -1223,7 +1261,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         return item
     }
 
-    private func createWorkoutButtonItem(selected: Bool) -> UIBarButtonItem {
+    private func createWorkoutButtonItem(selected: Bool, isEnabled: Bool) -> UIBarButtonItem {
         let item = UIBarButtonItem(image: UIImage.workoutImage(selected: selected), style: .plain, target: self, action: #selector(toggleWorkoutMode(_:)))
         item.accessibilityLabel = NSLocalizedString("Workout Targets", comment: "The label of the workout mode toggle button")
 
@@ -1235,6 +1273,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         }
 
         item.tintColor = UIColor.glucoseTintColor
+        item.isEnabled = isEnabled
 
         return item
     }
@@ -1323,7 +1362,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let pumpViewModel = PumpManagerViewModel(
             image: { [weak self] in self?.deviceManager.pumpManager?.smallImage },
             name: { [weak self] in self?.deviceManager.pumpManager?.localizedTitle ?? "" },
-            isSetUp: { [weak self] in self?.deviceManager.pumpManager != nil },
+            isSetUp: { [weak self] in self?.deviceManager.pumpManager?.isOnboarded == true },
             availableDevices: deviceManager.availablePumpManagers,
             deleteTestingDataFunc: deletePumpDataFunc,
             onTapped: { [weak self] in
@@ -1336,7 +1375,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let cgmViewModel = CGMManagerViewModel(
             image: {[weak self] in (self?.deviceManager.cgmManager as? DeviceManagerUI)?.smallImage },
             name: {[weak self] in self?.deviceManager.cgmManager?.localizedTitle ?? "" },
-            isSetUp: {[weak self] in self?.deviceManager.cgmManager != nil },
+            isSetUp: {[weak self] in self?.deviceManager.cgmManager?.isOnboarded == true },
             availableDevices: deviceManager.availableCGMManagers,
             deleteTestingDataFunc: deleteCGMDataFunc,
             onTapped: { [weak self] in
@@ -1369,6 +1408,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           syncPumpSchedule: syncBasalRateSchedule,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
+                                          isOnboardingComplete: resumeOnboardingProvider.onboardingStatus.$isComplete,
                                           isClosedLoopAllowed: closedLoopStatus.$isClosedLoopAllowed,
                                           supportInfoProvider: deviceManager,
                                           dosingStrategy: deviceManager.loopManager.settings.dosingStrategy,
@@ -1405,7 +1445,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private func closedLoopStatusChanged(_ isClosedLoop: Bool) {
-        updatePreMealModeAvailability(allowed: isClosedLoop)
+        updatePreMealModeAvailability(isClosedLoop: isClosedLoop)
         hudView?.loopCompletionHUD.loopIconClosed = isClosedLoop
     }
 

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -85,6 +85,7 @@ public class SettingsViewModel: ObservableObject {
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
+    @Published var isOnboardingComplete: Bool
     @Published var isClosedLoopAllowed: Bool
     @Published var dosingStrategy: DosingStrategy {
         didSet {
@@ -110,6 +111,7 @@ public class SettingsViewModel: ObservableObject {
                 syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
+                isOnboardingComplete: Published<Bool>.Publisher,
                 isClosedLoopAllowed: Published<Bool>.Publisher,
                 supportInfoProvider: SupportInfoProvider,
                 dosingStrategy: DosingStrategy,
@@ -126,6 +128,7 @@ public class SettingsViewModel: ObservableObject {
         self.syncPumpSchedule = syncPumpSchedule
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.closedLoopPreference = initialDosingEnabled
+        self.isOnboardingComplete = false
         self.isClosedLoopAllowed = false
         self.dosingStrategy = dosingStrategy
         self.supportInfoProvider = supportInfoProvider
@@ -146,6 +149,9 @@ public class SettingsViewModel: ObservableObject {
         }
         .store(in: &cancellables)
         
+        isOnboardingComplete
+            .assign(to: \.isOnboardingComplete, on: self)
+            .store(in: &cancellables)
         isClosedLoopAllowed
             .assign(to: \.isClosedLoopAllowed, on: self)
             .store(in: &cancellables)

--- a/Loop/Views/IconTitleSubtitleTableViewCell.swift
+++ b/Loop/Views/IconTitleSubtitleTableViewCell.swift
@@ -1,0 +1,53 @@
+//
+//  IconTitleSubtitleTableViewCell.swift
+//  Loop
+//
+//  Created by Darin Krauss on 8/19/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+
+class IconTitleSubtitleTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var iconImageView: UIImageView!
+    
+    @IBOutlet weak var titleLabel: UILabel!
+
+    @IBOutlet weak var subtitleLabel: UILabel! {
+        didSet {
+            subtitleLabel.textColor = UIColor.secondaryLabel
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        updateColors()
+        gradient.frame = bounds
+    }
+
+    private lazy var gradient = CAGradientLayer()
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        gradient.frame = bounds
+        backgroundView?.layer.insertSublayer(gradient, at: 0)
+
+        updateColors()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        updateColors()
+    }
+
+    private func updateColors() {
+        gradient.colors = [
+            UIColor.cellBackgroundColor.withAlphaComponent(0).cgColor,
+            UIColor.cellBackgroundColor.cgColor
+        ]
+    }
+}

--- a/LoopUI/Extensions/UIColor.swift
+++ b/LoopUI/Extensions/UIColor.swift
@@ -21,7 +21,7 @@ extension UIColor {
     // The loopAccent color is intended to be use as the app accent color.
     @nonobjc public static let loopAccent = UIColor(named: "accent") ?? systemBlue
     
-    @nonobjc static let warning = UIColor(named: "warning") ?? systemYellow
+    @nonobjc public static let warning = UIColor(named: "warning") ?? systemYellow
 }
 
 // MARK: - Context for colors


### PR DESCRIPTION
- https://tidepool.atlassian.net/browse/LOOP-3323
- https://tidepool.atlassian.net/browse/LOOP-3538
- https://tidepool.atlassian.net/browse/LOOP-3539
- https://tidepool.atlassian.net/browse/LOOP-3540
- https://tidepool.atlassian.net/browse/LOOP-3541
- https://tidepool.atlassian.net/browse/LOOP-3770
- Allow suspending and resuming onboarding
- Display resumed onboarding in modal dialog presentation
- Display Complete Setup to pump pill if onboarding not complete and pump not onboarded
- Display Complete Setup banner if onboarding not complete and pump onboarded
- Only ensure current pump data if pump is onboarded
- Refresh device data immediately after CGM or pump onboarded
- Do not allow adding carbs via detail view if onboarding not complete
- Do not allow changing closed loop state if onboarding not complete
- Disable various toolbar items if onboarding not complete
- Add ResumeOnboardingProvider
- Add IconTitleSubtitleTableViewCell
- Fix bug in LoopDataManager where settings were not persisted