### PR TITLE
LOOP-1769: Support for controlling debug features through AppGroup via a separate app

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -157,7 +157,20 @@ extension FeatureFlagConfiguration : CustomDebugStringConvertible {
             "* simulatedCoreDataEnabled: \(simulatedCoreDataEnabled)",
             "* siriEnabled: \(siriEnabled)",
             "* automaticBolusEnabled: \(automaticBolusEnabled)",
-            "* manualDoseEntryEnabled: \(manualDoseEntryEnabled)"
+            "* manualDoseEntryEnabled: \(manualDoseEntryEnabled)",
+            "* allowDebugFeatures: \(allowDebugFeatures)",
         ].joined(separator: "\n")
+    }
+}
+
+extension FeatureFlagConfiguration {
+    var allowDebugFeatures: Bool {
+        if debugEnabled {
+            return true
+        }
+        if UserDefaults.appGroup?.allowDebugFeatures ?? false {
+            return true
+        }
+        return false
     }
 }

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		1D080CBD2473214A00356610 /* AlertStore.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1D080CBB2473214A00356610 /* AlertStore.xcdatamodeld */; };
 		1D12D3B92548EFDD00B53E8B /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D12D3B82548EFDD00B53E8B /* main.swift */; };
 		1D2609AD248EEB9900A6F258 /* LoopAlertsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D2609AC248EEB9900A6F258 /* LoopAlertsManager.swift */; };
+		1D3F0F7526D59B6C004A5960 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892A5D58222F0A27008961AB /* Debug.swift */; };
+		1D3F0F7626D59DCD004A5960 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892A5D58222F0A27008961AB /* Debug.swift */; };
+		1D3F0F7726D59DCE004A5960 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892A5D58222F0A27008961AB /* Debug.swift */; };
 		1D49795824E7289700948F05 /* ServicesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D49795724E7289700948F05 /* ServicesViewModel.swift */; };
 		1D4990E824A25931005CC357 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E267FB2292456700A3F2AF /* FeatureFlags.swift */; };
 		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
@@ -3611,6 +3614,7 @@
 				439A7945211FE23A0041B75F /* NSUserActivity.swift in Sources */,
 				43A943881B926B7B0051FA24 /* ExtensionDelegate.swift in Sources */,
 				43511CEE220FC61700566C63 /* HUDRowController.swift in Sources */,
+				1D3F0F7526D59B6C004A5960 /* Debug.swift in Sources */,
 				892FB4CD22040104005293EC /* OverridePresetRow.swift in Sources */,
 				4F75F00220FCFE8C00B5570E /* GlucoseChartScene.swift in Sources */,
 				89E26800229267DF00A3F2AF /* Optional.swift in Sources */,
@@ -3832,6 +3836,7 @@
 				43BFF0CD1E466C8400FF19A9 /* StateColorPalette.swift in Sources */,
 				4FC8C8021DEB943800A1452E /* NSUserDefaults+StatusExtension.swift in Sources */,
 				4F70C2121DE900EA006380B7 /* StatusExtensionContext.swift in Sources */,
+				1D3F0F7626D59DCD004A5960 /* Debug.swift in Sources */,
 				4F70C1E11DE8DCA7006380B7 /* StatusViewController.swift in Sources */,
 				A90EF54425DEF0A000F32D61 /* OSLog.swift in Sources */,
 			);
@@ -3904,6 +3909,7 @@
 				E9B07FEE253BBC7100BAD8F8 /* OverrideIntentHandler.swift in Sources */,
 				E942DE9F253BE6A900AC532D /* NSTimeInterval.swift in Sources */,
 				E9B08016253BBD7300BAD8F8 /* UserDefaults+LoopIntents.swift in Sources */,
+				1D3F0F7726D59DCE004A5960 /* Debug.swift in Sources */,
 				E942DF34253BF87F00AC532D /* Intents.intentdefinition in Sources */,
 				E9B07F7F253BBA6500BAD8F8 /* IntentHandler.swift in Sources */,
 			);

--- a/Loop/Extensions/Debug.swift
+++ b/Loop/Extensions/Debug.swift
@@ -7,7 +7,7 @@
 //
 
 var debugEnabled: Bool {
-    #if DEBUG || IOS_SIMULATOR
+    #if DEBUG || IOS_SIMULATOR || targetEnvironment(simulator)
     return true
     #else
     return false

--- a/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
+++ b/Loop/Extensions/DeviceDataManager+DeviceStatus.swift
@@ -75,7 +75,7 @@ extension DeviceDataManager {
         {
             return .openAppURL(url)
         } else if let cgmManagerUI = (cgmManager as? CGMManagerUI) {
-            return .presentViewController(cgmManagerUI.settingsViewController(bluetoothProvider: bluetoothProvider, displayGlucoseUnitObservable: displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled))
+            return .presentViewController(cgmManagerUI.settingsViewController(bluetoothProvider: bluetoothProvider, displayGlucoseUnitObservable: displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures))
         } else {
             return .setupNewCGM
         }
@@ -86,11 +86,11 @@ extension DeviceDataManager {
             return action
         } else if let pumpManagerHUDProvider = pumpManagerHUDProvider,
             let view = view,
-            let action = pumpManagerHUDProvider.didTapOnHUDView(view, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled)
+            let action = pumpManagerHUDProvider.didTapOnHUDView(view, allowDebugFeatures: FeatureFlags.allowDebugFeatures)
         {
             return action
         } else if let pumpManager = pumpManager {
-            return .presentViewController(pumpManager.settingsViewController(bluetoothProvider: bluetoothProvider, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled, allowedInsulinTypes: allowedInsulinTypes))
+            return .presentViewController(pumpManager.settingsViewController(bluetoothProvider: bluetoothProvider, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures, allowedInsulinTypes: allowedInsulinTypes))
         } else {
             return .setupNewPump
         }

--- a/Loop/Managers/DeliveryUncertaintyAlertManager.swift
+++ b/Loop/Managers/DeliveryUncertaintyAlertManager.swift
@@ -21,7 +21,7 @@ class DeliveryUncertaintyAlertManager {
     }
 
     private func showUncertainDeliveryRecoveryView() {
-        var controller = pumpManager.deliveryUncertaintyRecoveryViewController(colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled)
+        var controller = pumpManager.deliveryUncertaintyRecoveryViewController(colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures)
         controller.completionDelegate = self
         self.alertPresenter.present(controller, animated: true)
     }

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -390,7 +390,7 @@ final class DeviceDataManager {
             return .failure(UnknownPumpManagerIdentifierError())
         }
 
-        let result = pumpManagerUIType.setupViewController(initialSettings: settings, bluetoothProvider: bluetoothProvider, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled, allowedInsulinTypes: allowedInsulinTypes)
+        let result = pumpManagerUIType.setupViewController(initialSettings: settings, bluetoothProvider: bluetoothProvider, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures, allowedInsulinTypes: allowedInsulinTypes)
         if case .createdAndOnboarded(let pumpManagerUI) = result {
             pumpManagerOnboarding(didCreatePumpManager: pumpManagerUI)
             pumpManagerOnboarding(didOnboardPumpManager: pumpManagerUI)
@@ -483,7 +483,7 @@ final class DeviceDataManager {
             return .failure(UnknownCGMManagerIdentifierError())
         }
 
-        let result = cgmManagerUIType.setupViewController(bluetoothProvider: bluetoothProvider, displayGlucoseUnitObservable: displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled)
+        let result = cgmManagerUIType.setupViewController(bluetoothProvider: bluetoothProvider, displayGlucoseUnitObservable: displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures)
         if case .createdAndOnboarded(let cgmManagerUI) = result {
             cgmManagerOnboarding(didCreateCGMManager: cgmManagerUI)
             cgmManagerOnboarding(didOnboardCGMManager: cgmManagerUI)
@@ -750,7 +750,7 @@ extension DeviceDataManager: DeviceManagerDelegate {
     }
     
     var allowDebugFeatures: Bool {
-        FeatureFlags.mockTherapySettingsEnabled // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
+        FeatureFlags.allowDebugFeatures // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
     }
 }
 

--- a/Loop/Managers/OnboardingManager.swift
+++ b/Loop/Managers/OnboardingManager.swift
@@ -291,7 +291,7 @@ extension OnboardingManager: CGMManagerProvider {
             return .failure(OnboardingError.invalidState)
         }
 
-        return .success(.userInteractionRequired(cgmManagerUI.settingsViewController(bluetoothProvider: self, displayGlucoseUnitObservable: deviceDataManager.displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled)))
+        return .success(.userInteractionRequired(cgmManagerUI.settingsViewController(bluetoothProvider: self, displayGlucoseUnitObservable: deviceDataManager.displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures)))
     }
 }
 
@@ -330,7 +330,7 @@ extension OnboardingManager: PumpManagerProvider {
             return .success(.createdAndOnboarded(pumpManager))
         }
 
-        return .success(.userInteractionRequired(pumpManager.settingsViewController(bluetoothProvider: self, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled, allowedInsulinTypes: deviceDataManager.allowedInsulinTypes)))
+        return .success(.userInteractionRequired(pumpManager.settingsViewController(bluetoothProvider: self, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures, allowedInsulinTypes: deviceDataManager.allowedInsulinTypes)))
     }
 }
 
@@ -368,7 +368,7 @@ extension OnboardingManager: TherapySettingsProvider {
 // MARK: - OnboardingProvider
 
 extension OnboardingManager: OnboardingProvider {
-    var allowDebugFeatures: Bool { FeatureFlags.mockTherapySettingsEnabled }   // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
+    var allowDebugFeatures: Bool { FeatureFlags.allowDebugFeatures }   // NOTE: DEBUG FEATURES - DEBUG AND TEST ONLY
 }
 
 // MARK: - OnboardingUI

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1383,7 +1383,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     private func onPumpTapped() {
-        guard var settingsViewController = deviceManager.pumpManager?.settingsViewController(bluetoothProvider: deviceManager.bluetoothProvider, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled, allowedInsulinTypes: deviceManager.allowedInsulinTypes) else {
+        guard var settingsViewController = deviceManager.pumpManager?.settingsViewController(bluetoothProvider: deviceManager.bluetoothProvider, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures, allowedInsulinTypes: deviceManager.allowedInsulinTypes) else {
             // assert?
             return
         }
@@ -1398,7 +1398,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             return
         }
 
-        var settings = cgmManager.settingsViewController(bluetoothProvider: deviceManager.bluetoothProvider, displayGlucoseUnitObservable: deviceManager.displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.mockTherapySettingsEnabled)
+        var settings = cgmManager.settingsViewController(bluetoothProvider: deviceManager.bluetoothProvider, displayGlucoseUnitObservable: deviceManager.displayGlucoseUnitObservable, colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures)
         settings.cgmManagerOnboardingDelegate = deviceManager
         settings.completionDelegate = self
         show(settings, sender: self)
@@ -1585,7 +1585,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     var rotateTimer: Timer?
     let rotateTimerTimeout = TimeInterval.seconds(2)
     private func maybeOpenDebugMenu() {
-        guard FeatureFlags.scenariosEnabled || FeatureFlags.simulatedCoreDataEnabled || FeatureFlags.mockTherapySettingsEnabled else {
+        guard FeatureFlags.allowDebugFeatures else {
             return
         }
         // Opens the debug menu if you rotate the phone 6 times (or back & forth 3 times), each rotation within 2 secs.
@@ -1609,14 +1609,18 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        if FeatureFlags.scenariosEnabled || FeatureFlags.simulatedCoreDataEnabled || FeatureFlags.mockTherapySettingsEnabled {
-            if motion == .motionShake {
-                presentDebugMenu()
-            }
+        guard FeatureFlags.allowDebugFeatures else {
+            return
+        }
+        if motion == .motionShake {
+            presentDebugMenu()
         }
     }
 
     private func presentDebugMenu() {
+        guard FeatureFlags.allowDebugFeatures else {
+            return
+        }
         guard FeatureFlags.scenariosEnabled || FeatureFlags.simulatedCoreDataEnabled || FeatureFlags.mockTherapySettingsEnabled else {
             fatalError("\(#function) should be invoked only when scenarios, simulated core data, or mock therapy settings are enabled")
         }

--- a/LoopCore/NSUserDefaults.swift
+++ b/LoopCore/NSUserDefaults.swift
@@ -23,6 +23,7 @@ extension UserDefaults {
         case overrideHistory = "com.loopkit.overrideHistory"
         case lastBedtimeQuery = "com.loopkit.Loop.lastBedtimeQuery"
         case bedtime = "com.loopkit.Loop.bedtime"
+        case allowDebugFeatures = "com.loopkit.Loop.allowDebugFeatures"
     }
 
     public static let appGroup = UserDefaults(suiteName: Bundle.main.appGroupSuiteName)
@@ -176,5 +177,9 @@ extension UserDefaults {
         set {
             set(newValue, forKey: Key.bedtime.rawValue)
         }
+    }
+    
+    public var allowDebugFeatures: Bool {
+        return bool(forKey: Key.allowDebugFeatures.rawValue)
     }
 }


### PR DESCRIPTION
This now makes a new `UserDefault`, `allowDebugFeatures`, control all of the places where we used to have `allowDebugFeatures`, controlled via the `AppGroup`, so a separate app can do it.  Shout out to @darinkrauss for the idea!

https://tidepool.atlassian.net/browse/LOOP-1769