### PR TITLE
[LOOP-3323] Allow pause onboarding

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -375,6 +375,7 @@
 		89FE21AD24AC57E30033F501 /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89FE21AC24AC57E30033F501 /* Collection.swift */; };
 		A90EF53C25DEF06200F32D61 /* PluginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16DA84122E8E112008624C2 /* PluginManager.swift */; };
 		A90EF54425DEF0A000F32D61 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4374B5EE209D84BE00D17AA8 /* OSLog.swift */; };
+		A91D2A3F26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91D2A3E26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift */; };
 		A91E4C2124F867A700BE9213 /* StoredAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91E4C2024F867A700BE9213 /* StoredAlertTests.swift */; };
 		A91E4C2324F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91E4C2224F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift */; };
 		A92E557E2464DFFD00DB93BB /* DosingDecisionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92E557D2464DFFD00DB93BB /* DosingDecisionStore.swift */; };
@@ -1288,6 +1289,7 @@
 		89F9119324358E4500ECCAF3 /* CarbAbsorptionTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbAbsorptionTime.swift; sourceTree = "<group>"; };
 		89F9119524358E6900ECCAF3 /* BolusPickerValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusPickerValues.swift; sourceTree = "<group>"; };
 		89FE21AC24AC57E30033F501 /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		A91D2A3E26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconTitleSubtitleTableViewCell.swift; sourceTree = "<group>"; };
 		A91E4C2024F867A700BE9213 /* StoredAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredAlertTests.swift; sourceTree = "<group>"; };
 		A91E4C2224F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalEventLogExportManagerTests.swift; sourceTree = "<group>"; };
 		A92E557D2464DFFD00DB93BB /* DosingDecisionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DosingDecisionStore.swift; path = ../Stores/DosingDecisionStore.swift; sourceTree = "<group>"; };
@@ -2050,6 +2052,7 @@
 				A9A056B224B93C62007CF06D /* CriticalEventLogExportView.swift */,
 				43D381611EBD9759007F8C8F /* HeaderValuesTableViewCell.swift */,
 				430D85881F44037000AF2D4F /* HUDViewTableViewCell.swift */,
+				A91D2A3E26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift */,
 				1DA46B5F2492E2E300D71A63 /* NotificationsCriticalAlertPermissionsView.swift */,
 				899433B723FE129700FA4BEA /* OverrideBadgeView.swift */,
 				89D6953D23B6DF8A002B3066 /* PotentialCarbEntryTableViewCell.swift */,
@@ -3486,6 +3489,7 @@
 				89CA2B32226C18B8004D9350 /* TestingScenariosTableViewController.swift in Sources */,
 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
 				43C05CAF21EB2C24006FB252 /* NSBundle.swift in Sources */,
+				A91D2A3F26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift in Sources */,
 				A967D94C24F99B9300CDDF8A /* OutputStream.swift in Sources */,
 				1DB1065124467E18005542BD /* AlertManager.swift in Sources */,
 				1D9650C82523FBA100A1370B /* DeviceDataManager+BolusEntryViewModelDelegate.swift in Sources */,

--- a/Loop/Base.lproj/Main.storyboard
+++ b/Loop/Base.lproj/Main.storyboard
@@ -477,7 +477,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="HUDViewTableViewCell" rowHeight="70" id="vCp-19-ZkW" customClass="HUDViewTableViewCell" customModule="Loop" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="70"/>
+                                <rect key="frame" x="0.0" y="24.5" width="375" height="70"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vCp-19-ZkW" id="b8U-Fn-hSd">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
@@ -499,7 +499,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TitleSubtitleTableViewCell" id="zTq-QB-XNu" customClass="TitleSubtitleTableViewCell" customModule="Loop" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="98" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="94.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zTq-QB-XNu" id="vD6-31-qVz">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -543,8 +543,60 @@
                                     <outlet property="titleLabel" destination="k3F-Na-7mn" id="Mrt-ZL-fKG"/>
                                 </connections>
                             </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="IconTitleSubtitleTableViewCell" id="5av-st-q28" customClass="IconTitleSubtitleTableViewCell" customModule="Loop" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="138.5" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5av-st-q28" id="lLV-fl-2Ke">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lZi-ar-9iV">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="3.5 U/hour @ 12:12 PM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fWV-jg-ICt">
+                                            <rect key="frame" x="196" y="16" width="163" height="12"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Recommended Basal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xhx-PI-bBI">
+                                            <rect key="frame" x="58" y="16" width="130" height="12"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="252" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Uyb-ce-nXY">
+                                            <rect key="frame" x="16" y="5" width="33" height="33"/>
+                                        </imageView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="Uyb-ce-nXY" secondAttribute="bottom" id="3Iv-mH-pcL"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="fWV-jg-ICt" secondAttribute="bottom" constant="5" id="EjW-rd-jxl"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="xhx-PI-bBI" secondAttribute="bottom" constant="5" id="X7F-rd-kEw"/>
+                                        <constraint firstItem="xhx-PI-bBI" firstAttribute="top" secondItem="lLV-fl-2Ke" secondAttribute="topMargin" constant="5" id="YZ6-LQ-URg"/>
+                                        <constraint firstItem="Uyb-ce-nXY" firstAttribute="top" secondItem="lLV-fl-2Ke" secondAttribute="top" id="cos-il-XLC"/>
+                                        <constraint firstItem="fWV-jg-ICt" firstAttribute="leading" secondItem="xhx-PI-bBI" secondAttribute="trailing" constant="8" symbolic="YES" id="hvf-Rm-1et"/>
+                                        <constraint firstItem="fWV-jg-ICt" firstAttribute="top" secondItem="lLV-fl-2Ke" secondAttribute="topMargin" constant="5" id="jd7-tP-g9w"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="fWV-jg-ICt" secondAttribute="trailing" id="nnf-aY-RjG"/>
+                                        <constraint firstItem="xhx-PI-bBI" firstAttribute="leading" secondItem="Uyb-ce-nXY" secondAttribute="trailing" constant="8" symbolic="YES" id="o04-Iy-95H"/>
+                                        <constraint firstAttribute="leadingMargin" secondItem="Uyb-ce-nXY" secondAttribute="leading" id="qHL-Ga-aMN"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <constraints>
+                                    <constraint firstItem="lZi-ar-9iV" firstAttribute="top" secondItem="5av-st-q28" secondAttribute="top" id="9Tk-CA-OxJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="lZi-ar-9iV" secondAttribute="trailing" id="CgY-Gc-Tfq"/>
+                                    <constraint firstItem="lZi-ar-9iV" firstAttribute="leading" secondItem="5av-st-q28" secondAttribute="leading" id="FjH-CR-cTZ"/>
+                                    <constraint firstAttribute="bottom" secondItem="lZi-ar-9iV" secondAttribute="bottom" id="lyr-yc-tdb"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="backgroundView" destination="lZi-ar-9iV" id="hxP-ji-frQ"/>
+                                    <outlet property="iconImageView" destination="Uyb-ce-nXY" id="V6G-a3-3L1"/>
+                                    <outlet property="subtitleLabel" destination="fWV-jg-ICt" id="x1Z-Pa-Nro"/>
+                                    <outlet property="titleLabel" destination="xhx-PI-bBI" id="2Xd-Nu-GMe"/>
+                                </connections>
+                            </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="ChartTableViewCell" rowHeight="200" id="FEV-fX-i48" customClass="ChartTableViewCell" customModule="LoopKitUI">
-                                <rect key="frame" x="0.0" y="142" width="375" height="200"/>
+                                <rect key="frame" x="0.0" y="182.5" width="375" height="200"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="FEV-fX-i48" id="lS6-Qa-Lw7">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
@@ -635,7 +687,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Tc-kF-7yT" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="838.125" y="-458.45070422535213"/>
+            <point key="canvasLocation" x="837.60000000000002" y="-459.22038980509751"/>
         </scene>
         <!--Root Navigation Controller-->
         <scene sceneID="1UI-1d-xLb">

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -24,6 +24,7 @@ final class DeviceDataManager {
     let pluginManager: PluginManager
     weak var alertManager: AlertManager!
     let bluetoothProvider: BluetoothProvider
+    weak var onboardingManager: OnboardingManager?
 
     /// Remember the launch date of the app for diagnostic reporting
     private let launchDate = Date()
@@ -836,6 +837,10 @@ extension DeviceDataManager: CGMManagerOnboardingDelegate {
     func cgmManagerOnboarding(didOnboardCGMManager cgmManager: CGMManagerUI) {
         precondition(cgmManager.isOnboarded)
         log.default("CGM manager with identifier '%{public}@' onboarded", cgmManager.managerIdentifier)
+
+        DispatchQueue.main.async {
+            self.refreshDeviceData()
+        }
     }
 }
 
@@ -906,7 +911,10 @@ extension DeviceDataManager: PumpManagerDelegate {
     func refreshDeviceData() {
         refreshCGM() {
             self.queue.async {
-                self.pumpManager?.ensureCurrentPumpData(completion: nil)
+                guard let pumpManager = self.pumpManager, pumpManager.isOnboarded else {
+                    return
+                }
+                pumpManager.ensureCurrentPumpData(completion: nil)
             }
         }
     }
@@ -1043,12 +1051,15 @@ extension DeviceDataManager: PumpManagerOnboardingDelegate {
     func pumpManagerOnboarding(didCreatePumpManager pumpManager: PumpManagerUI) {
         log.default("Pump manager with identifier '%{public}@' created", pumpManager.managerIdentifier)
         self.pumpManager = pumpManager
-        self.deliveryUncertaintyAlertManager = DeliveryUncertaintyAlertManager(pumpManager: pumpManager, alertPresenter: alertPresenter)
     }
 
     func pumpManagerOnboarding(didOnboardPumpManager pumpManager: PumpManagerUI) {
         precondition(pumpManager.isOnboarded)
         log.default("Pump manager with identifier '%{public}@' onboarded", pumpManager.managerIdentifier)
+
+        DispatchQueue.main.async {
+            self.refreshDeviceData()
+        }
     }
 }
 

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -2150,7 +2150,8 @@ extension LoopDataManager {
 extension LoopDataManager {
     public var therapySettings: TherapySettings {
         get {
-            TherapySettings(glucoseTargetRangeSchedule: settings.glucoseTargetRangeSchedule,
+            let settings = settings
+            return TherapySettings(glucoseTargetRangeSchedule: settings.glucoseTargetRangeSchedule,
                             correctionRangeOverrides: CorrectionRangeOverrides(preMeal: settings.preMealTargetRange, workout: settings.legacyWorkoutTargetRange),
                             maximumBasalRatePerHour: settings.maximumBasalRatePerHour,
                             maximumBolus: settings.maximumBolus,
@@ -2162,7 +2163,7 @@ extension LoopDataManager {
         }
         
         set {
-            lockedSettings.mutate { settings in
+            mutateSettings { settings in
                 settings.glucoseTargetRangeSchedule = newValue.glucoseTargetRangeSchedule
                 settings.preMealTargetRange = newValue.correctionRangeOverrides?.preMeal
                 settings.legacyWorkoutTargetRange = newValue.correctionRangeOverrides?.workout

--- a/Loop/View Controllers/CarbAbsorptionViewController.swift
+++ b/Loop/View Controllers/CarbAbsorptionViewController.swift
@@ -26,6 +26,8 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
     
     private var allowEditing: Bool = true
 
+    var isOnboardingComplete: Bool = true
+
     var closedLoopStatus: ClosedLoopStatus!
 
     override func viewDidLoad() {
@@ -59,6 +61,8 @@ final class CarbAbsorptionViewController: LoopChartsTableViewController, Identif
         if let gestureRecognizer = charts.gestureRecognizer {
             tableView.addGestureRecognizer(gestureRecognizer)
         }
+
+        navigationItem.rightBarButtonItem?.isEnabled = isOnboardingComplete
 
         if !closedLoopStatus.isClosedLoop {
             allowEditing = false

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -84,6 +84,7 @@ public class SettingsViewModel: ObservableObject {
     let syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
+    let isOnboardingComplete: Bool
 
     @Published var isClosedLoopAllowed: Bool
     @Published var dosingStrategy: DosingStrategy {
@@ -114,6 +115,7 @@ public class SettingsViewModel: ObservableObject {
                 supportInfoProvider: SupportInfoProvider,
                 dosingStrategy: DosingStrategy,
                 availableSupports: [SupportUI],
+                isOnboardingComplete: Bool,
                 delegate: SettingsViewModelDelegate?
     ) {
         self.notificationsCriticalAlertPermissionsViewModel = notificationsCriticalAlertPermissionsViewModel
@@ -130,6 +132,7 @@ public class SettingsViewModel: ObservableObject {
         self.dosingStrategy = dosingStrategy
         self.supportInfoProvider = supportInfoProvider
         self.availableSupports = availableSupports
+        self.isOnboardingComplete = isOnboardingComplete
         self.delegate = delegate
 
         // This strangeness ensures the composed ViewModels' (ObservableObjects') changes get reported to this ViewModel (ObservableObject)

--- a/Loop/Views/IconTitleSubtitleTableViewCell.swift
+++ b/Loop/Views/IconTitleSubtitleTableViewCell.swift
@@ -1,0 +1,53 @@
+//
+//  IconTitleSubtitleTableViewCell.swift
+//  Loop
+//
+//  Created by Darin Krauss on 8/19/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import UIKit
+
+class IconTitleSubtitleTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var iconImageView: UIImageView!
+    
+    @IBOutlet weak var titleLabel: UILabel!
+
+    @IBOutlet weak var subtitleLabel: UILabel! {
+        didSet {
+            subtitleLabel.textColor = UIColor.secondaryLabel
+        }
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        updateColors()
+        gradient.frame = bounds
+    }
+
+    private lazy var gradient = CAGradientLayer()
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        gradient.frame = bounds
+        backgroundView?.layer.insertSublayer(gradient, at: 0)
+
+        updateColors()
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        updateColors()
+    }
+
+    private func updateColors() {
+        gradient.colors = [
+            UIColor.cellBackgroundColor.withAlphaComponent(0).cgColor,
+            UIColor.cellBackgroundColor.cgColor
+        ]
+    }
+}

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -83,12 +83,14 @@ extension SettingsView {
             Toggle(isOn: closedLoopToggleState) {
                 VStack(alignment: .leading) {
                     Text(NSLocalizedString("Closed Loop", comment: "The title text for the looping enabled switch cell"))
-                    if !viewModel.isClosedLoopAllowed {
+                    if !viewModel.isOnboardingComplete {
+                        DescriptiveText(label: NSLocalizedString("Closed Loop requires Setup to be Complete", comment: "The description text for the looping enabled switch cell when onboarding is not complete"))
+                    } else if !viewModel.isClosedLoopAllowed {
                         DescriptiveText(label: NSLocalizedString("Closed Loop requires an active CGM Sensor Session", comment: "The description text for the looping enabled switch cell when closed loop is not allowed"))
                     }
                 }
             }
-            .disabled(!viewModel.isClosedLoopAllowed)
+            .disabled(!viewModel.isOnboardingComplete || !viewModel.isClosedLoopAllowed)
         }
     }
 
@@ -162,7 +164,7 @@ extension SettingsView {
                         imageView: deviceImage(uiImage: viewModel.pumpManagerSettingsViewModel.image()),
                         label: viewModel.pumpManagerSettingsViewModel.name(),
                         descriptiveText: NSLocalizedString("Insulin Pump", comment: "Descriptive text for Insulin Pump"))
-        } else {
+        } else if viewModel.isOnboardingComplete {
             LargeButton(action: { self.pumpChooserIsPresented = true },
                         includeArrow: false,
                         imageView: AnyView(plusImage),
@@ -171,6 +173,8 @@ extension SettingsView {
                 .actionSheet(isPresented: $pumpChooserIsPresented) {
                     ActionSheet(title: Text("Add Pump", comment: "The title of the pump chooser in settings"), buttons: pumpChoices)
             }
+        } else {
+            EmptyView()
         }
     }
     
@@ -418,6 +422,7 @@ public struct SettingsView_Previews: PreviewProvider {
                                           supportInfoProvider: MockSupportInfoProvider(),
                                           dosingStrategy: .automaticBolus,
                                           availableSupports: [],
+                                          isOnboardingComplete: false,
                                           delegate: nil)
         return Group {
             SettingsView(viewModel: viewModel)

--- a/LoopUI/Extensions/UIColor.swift
+++ b/LoopUI/Extensions/UIColor.swift
@@ -21,7 +21,7 @@ extension UIColor {
     // The loopAccent color is intended to be use as the app accent color.
     @nonobjc public static let loopAccent = UIColor(named: "accent") ?? systemBlue
     
-    @nonobjc static let warning = UIColor(named: "warning") ?? systemYellow
+    @nonobjc public static let warning = UIColor(named: "warning") ?? systemYellow
 }
 
 // MARK: - Context for colors


### PR DESCRIPTION
@ps2 Just you on this PR. This is a new PR since the changes were significant from the previous PR (and the delta would have just been confusing).

- https://tidepool.atlassian.net/browse/LOOP-3323
- https://tidepool.atlassian.net/browse/LOOP-3538
- https://tidepool.atlassian.net/browse/LOOP-3539
- https://tidepool.atlassian.net/browse/LOOP-3540
- https://tidepool.atlassian.net/browse/LOOP-3541
- https://tidepool.atlassian.net/browse/LOOP-3770
- Allow suspending and resuming onboarding
- Display resumed onboarding in modal dialog presentation
- Display Complete Setup to pump pill if onboarding not complete and pump not onboarded
- Display Complete Setup banner if onboarding not complete and pump onboarded
- Only ensure current pump data if pump is onboarded
- Refresh device data immediately after CGM or pump onboarded
- Do not allow adding carbs via detail view if onboarding not complete
- Do not allow changing closed loop state if onboarding not complete
- Disable various toolbar items if onboarding not complete
- Add ResumeOnboardingProvider
- Add IconTitleSubtitleTableViewCell
- Fix bug in LoopDataManager where settings were not persisted