### PR TITLE
allow debug features from flag

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -14,7 +14,6 @@ struct FeatureFlagConfiguration: Decodable {
     let automaticBolusEnabled: Bool
     let cgmManagerCategorizeManualGlucoseRangeEnabled: Bool
     let criticalAlertsEnabled: Bool
-    let debugFeaturesEnabled: Bool
     let entryDeletionEnabled: Bool
     let fiaspInsulinModelEnabled: Bool
     let includeServicesInSettingsEnabled: Bool
@@ -47,12 +46,6 @@ struct FeatureFlagConfiguration: Decodable {
         self.criticalAlertsEnabled = true
         #else
         self.criticalAlertsEnabled = false
-        #endif
-
-        #if DEBUG_FEATURES_ENABLED
-        self.debugFeaturesEnabled = true
-        #else
-        self.debugFeaturesEnabled = false
         #endif
 
         // Swift compiler config is inverse, since the default state is enabled.
@@ -178,9 +171,10 @@ extension FeatureFlagConfiguration {
         if UserDefaults.appGroup?.allowDebugFeatures ?? false {
             return true
         }
-        if debugFeaturesEnabled {
-            return debugFeaturesEnabled
-        }
+        #if ALLOW_DEBUG_FEATURES_ENABLED
+        return true
+        #else
         return false
+        #endif
     }
 }

--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -11,11 +11,14 @@ import Foundation
 let FeatureFlags = FeatureFlagConfiguration()
 
 struct FeatureFlagConfiguration: Decodable {
+    let automaticBolusEnabled: Bool
     let cgmManagerCategorizeManualGlucoseRangeEnabled: Bool
     let criticalAlertsEnabled: Bool
+    let debugFeaturesEnabled: Bool
     let entryDeletionEnabled: Bool
     let fiaspInsulinModelEnabled: Bool
     let includeServicesInSettingsEnabled: Bool
+    let manualDoseEntryEnabled: Bool
     let mockTherapySettingsEnabled: Bool
     let nonlinearCarbModelEnabled: Bool
     let observeHealthKitSamplesFromOtherApps: Bool
@@ -25,10 +28,15 @@ struct FeatureFlagConfiguration: Decodable {
     let sensitivityOverridesEnabled: Bool
     let simulatedCoreDataEnabled: Bool
     let siriEnabled: Bool
-    let automaticBolusEnabled: Bool
-    let manualDoseEntryEnabled: Bool
 
     fileprivate init() {
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if AUTOMATIC_BOLUS_DISABLED
+        self.automaticBolusEnabled = false
+        #else
+        self.automaticBolusEnabled = true
+        #endif
+
         #if CGM_MANAGER_CATEGORIZE_GLUCOSE_RANGE_ENABLED
         self.cgmManagerCategorizeManualGlucoseRangeEnabled = true
         #else
@@ -40,7 +48,13 @@ struct FeatureFlagConfiguration: Decodable {
         #else
         self.criticalAlertsEnabled = false
         #endif
-        
+
+        #if DEBUG_FEATURES_ENABLED
+        self.debugFeaturesEnabled = true
+        #else
+        self.debugFeaturesEnabled = false
+        #endif
+
         // Swift compiler config is inverse, since the default state is enabled.
         #if ENTRY_DELETION_DISABLED
         self.entryDeletionEnabled = false
@@ -69,6 +83,13 @@ struct FeatureFlagConfiguration: Decodable {
         self.includeServicesInSettingsEnabled = true
         #endif
         
+        // Swift compiler config is inverse, since the default state is enabled.
+        #if MANUAL_DOSE_ENTRY_DISABLED
+        self.manualDoseEntryEnabled = false
+        #else
+        self.manualDoseEntryEnabled = true
+        #endif
+
         // Swift compiler config is inverse, since the default state is enabled.
         #if MOCK_THERAPY_SETTINGS_ENABLED
         self.mockTherapySettingsEnabled = true
@@ -121,20 +142,6 @@ struct FeatureFlagConfiguration: Decodable {
         #else
         self.siriEnabled = true
         #endif
-        
-        // Swift compiler config is inverse, since the default state is enabled.
-        #if AUTOMATIC_BOLUS_DISABLED
-        self.automaticBolusEnabled = false
-        #else
-        self.automaticBolusEnabled = true
-        #endif
-        
-        // Swift compiler config is inverse, since the default state is enabled.
-        #if MANUAL_DOSE_ENTRY_DISABLED
-        self.manualDoseEntryEnabled = false
-        #else
-        self.manualDoseEntryEnabled = true
-        #endif
     }
 }
 
@@ -170,6 +177,9 @@ extension FeatureFlagConfiguration {
         }
         if UserDefaults.appGroup?.allowDebugFeatures ?? false {
             return true
+        }
+        if debugFeaturesEnabled {
+            return debugFeaturesEnabled
         }
         return false
     }


### PR DESCRIPTION
Certain versions of Tidepool Loop need to be able to enable debug features using a flag instead of Loop Configurator. 