### PR TITLE
[LOOP-3840] alert presenter can dismiss an alert not at the top of the alert stack

### DIFF
--- a/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
+++ b/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
@@ -54,12 +54,15 @@ public class InAppModalAlertIssuer: AlertIssuer {
     public func retractAlert(identifier: Alert.Identifier) {
         DispatchQueue.main.async {
             self.removePendingAlert(identifier: identifier)
-            self.removePresentedAlert(identifier: identifier, completion: nil)
+            self.removePresentedAlert(identifier: identifier)
         }
     }
 
-    func removePresentedAlert(identifier: Alert.Identifier, completion: (() -> Void)?) {
-        guard let alertPresented = alertsPresented[identifier] else { return }
+    func removePresentedAlert(identifier: Alert.Identifier, completion: (() -> Void)? = nil) {
+        guard let alertPresented = alertsPresented[identifier] else {
+            completion?()
+            return
+        }
         alertPresenter?.dismissAlert(alertPresented.0, animated: true, completion: completion)
         clearPresentedAlert(identifier: identifier)
     }

--- a/Loop/Managers/DeliveryUncertaintyAlertManager.swift
+++ b/Loop/Managers/DeliveryUncertaintyAlertManager.swift
@@ -39,7 +39,7 @@ class DeliveryUncertaintyAlertManager {
                 self.showUncertainDeliveryRecoveryView()
             }
             alert.addAction(action)
-            self.alertPresenter.dismiss(animated: false) {
+            self.alertPresenter.dismissTopMost(animated: false) {
                 self.alertPresenter.present(alert, animated: animated)
             }
             self.uncertainDeliveryAlert = alert

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -329,18 +329,27 @@ extension LoopAppManager: AlertPresenter {
                 alertToDismiss.dismiss(animated: animated, completion: completion)
             } else {
                 // Do not animate any of these view transitions, since the alert to dismiss is not at the top of the stack
-                // dismiss all the child presented alerts
+
+                // dismiss all the child presented alerts.
+                // Calling dismiss() on a VC that is presenting an other VC will dismiss the presented VC and all of its child presented VCs
                 alertToDismiss.dismiss(animated: false) {
                     // dismiss the desired alert
+                    // Calling dismiss() on a VC that is NOT presenting any other VCs will dismiss said VC
                     alertToDismiss.dismiss(animated: false) {
                         // present the child alerts that were undesirably dismissed
-                        for alert in presentedAlerts {
+                        var orderedPresentationBlock: (() -> Void)? = nil
+                        for alert in presentedAlerts.reversed() {
                             if alert == presentedAlerts.last {
-                                self.present(alert, animated: false, completion: completion)
+                                orderedPresentationBlock = {
+                                    self.present(alert, animated: false, completion: completion)
+                                }
                             } else {
-                                self.present(alert, animated: false, completion: nil)
+                                orderedPresentationBlock = {
+                                    self.present(alert, animated: false, completion: orderedPresentationBlock)
+                                }
                             }
                         }
+                        orderedPresentationBlock?()
                     }
                 }
             }

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -25,12 +25,20 @@ public protocol AlertPresenter: AnyObject {
     /// - Parameters:
     ///   - animated: Animate the alert view controller dismissal or not.
     ///   - completion: Completion to call once view controller is dismissed.
-    func dismiss(animated: Bool, completion: (() -> Void)?)
+    func dismissTopMost(animated: Bool, completion: (() -> Void)?)
+
+    /// Dismiss an alert, even if it is not the top most alert.
+    /// - Parameters:
+    ///   - alertToDismiss: The alert to dismiss
+    ///   - animated: Animate the alert view controller dismissal or not.
+    ///   - completion: Completion to call once view controller is dismissed.
+    func dismissAlert(_ alertToDismiss: UIAlertController, animated: Bool, completion: (() -> Void)?)
 }
 
 public extension AlertPresenter {
     func present(_ viewController: UIViewController, animated: Bool) { present(viewController, animated: animated, completion: nil) }
-    func dismiss(animated: Bool) { dismiss(animated: animated, completion: nil) }
+    func dismissTopMost(animated: Bool) { dismissTopMost(animated: animated, completion: nil) }
+    func dismissAlert(_ alertToDismiss: UIAlertController, animated: Bool) { dismissAlert(alertToDismiss, animated: animated, completion: nil) }
 }
 
 protocol WindowProvider: AnyObject {
@@ -297,8 +305,46 @@ extension LoopAppManager: AlertPresenter {
         rootViewController?.topmostViewController.present(viewControllerToPresent, animated: animated, completion: completion)
     }
 
-    func dismiss(animated: Bool, completion: (() -> Void)?) {
+    func dismissTopMost(animated: Bool, completion: (() -> Void)?) {
         rootViewController?.topmostViewController.dismiss(animated: animated, completion: completion)
+    }
+
+    func dismissAlert(_ alertToDismiss: UIAlertController, animated: Bool, completion: (() -> Void)?) {
+        if rootViewController?.topmostViewController == alertToDismiss {
+            dismissTopMost(animated: animated, completion: completion)
+        } else {
+            // check if the alert to dismiss is presenting another alert (and so on)
+            // calling dismiss() on an alert presenting another alert will only dismiss the presented alert
+            // (and any other alerts presented by the presented alert)
+
+            // get the stack of presented alerts that would be undesirably dismissed
+            var presentedAlerts: [UIAlertController] = []
+            var currentAlert = alertToDismiss
+            while let presentedAlert = currentAlert.presentedViewController as? UIAlertController {
+                presentedAlerts.append(presentedAlert)
+                currentAlert = presentedAlert
+            }
+
+            if presentedAlerts.isEmpty {
+                alertToDismiss.dismiss(animated: animated, completion: completion)
+            } else {
+                // Do not animate any of these view transitions, since the alert to dismiss is not at the top of the stack
+                // dismiss all the child presented alerts
+                alertToDismiss.dismiss(animated: false) {
+                    // dismiss the desired alert
+                    alertToDismiss.dismiss(animated: false) {
+                        // present the child alerts that were undesirably dismissed
+                        for alert in presentedAlerts {
+                            if alert == presentedAlerts.last {
+                                self.present(alert, animated: false, completion: completion)
+                            } else {
+                                self.present(alert, animated: false, completion: nil)
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -66,7 +66,8 @@ class AlertManagerTests: XCTestCase {
     
     class MockPresenter: AlertPresenter {
         func present(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?) { completion?() }
-        func dismiss(animated: Bool, completion: (() -> Void)?) { completion?() }
+        func dismissTopMost(animated: Bool, completion: (() -> Void)?) { completion?() }
+        func dismissAlert(_ alertToDismiss: UIAlertController, animated: Bool, completion: (() -> Void)?) { completion?() }
     }
 
     class MockSoundVendor: AlertSoundVendor {

--- a/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
@@ -190,7 +190,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
         XCTAssertNotNil(alertControllerPresented)
 
         var dismissed = false
-        inAppModalAlertIssuer.removeDeliveredAlert(identifier: alert.identifier) {
+        inAppModalAlertIssuer.removePresentedAlert(identifier: alert.identifier) {
             dismissed = true
         }
 

--- a/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
@@ -42,10 +42,26 @@ class InAppModalAlertIssuerTests: XCTestCase {
     
     class MockViewController: UIViewController, AlertPresenter {
         var viewControllerPresented: UIViewController?
+        var alertDismissed: UIAlertController?
         var autoComplete = true
         var completion: (() -> Void)?
         override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
             viewControllerPresented = viewControllerToPresent
+            if autoComplete {
+                completion?()
+            } else {
+                self.completion = completion
+            }
+        }
+        func dismissTopMost(animated: Bool, completion: (() -> Void)?) {
+            if autoComplete {
+                completion?()
+            } else {
+                self.completion = completion
+            }
+        }
+        func dismissAlert(_ alertToDismiss: UIAlertController, animated: Bool, completion: (() -> Void)?) {
+            alertDismissed = alertToDismiss
             if autoComplete {
                 completion?()
             } else {
@@ -170,14 +186,17 @@ class InAppModalAlertIssuerTests: XCTestCase {
         inAppModalAlertIssuer.issueAlert(alert)
         
         waitOnMain()
+        let alertControllerPresented = mockViewController.viewControllerPresented as? UIAlertController
+        XCTAssertNotNil(alertControllerPresented)
+
         var dismissed = false
         inAppModalAlertIssuer.removeDeliveredAlert(identifier: alert.identifier) {
             dismissed = true
         }
-        
+
         waitOnMain()
-        let alertController = mockViewController.viewControllerPresented as? UIAlertController
-        XCTAssertNotNil(alertController)
+        let alertDimissed = mockViewController.alertDismissed
+        XCTAssertNotNil(alertDimissed)
         XCTAssertTrue(dismissed)
     }
     


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3840

Following @rickpasetto suggestion, the `AlertPresenter` is responsible for presenting and dismissing alerts. If the alert to dismiss is not at the top of the alert stack, we need to manipulate the presented alerts, such that all the presented alerts down to the desired alert are dismissed and then re-present the alerts that should not have been dismissed.