### PR TITLE
LOOP-1114: Adds VersionCheckServicesManager, a "sister" to other Service managers

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
 		1D63DEA526E950D400F46FA5 /* VersionCheckServicesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D63DEA426E950D400F46FA5 /* VersionCheckServicesManager.swift */; };
 		1D6B1B6726866D89009AC446 /* AlertPermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6B1B6626866D89009AC446 /* AlertPermissionsChecker.swift */; };
+		1D70C40126EC0F9D00C62570 /* VersionCheckServicesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D70C40026EC0F9D00C62570 /* VersionCheckServicesManagerTests.swift */; };
 		1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D80313C24746274002810DF /* AlertStoreTests.swift */; };
 		1D82E6A025377C6B009131FB /* TrustedTimeChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D82E69F25377C6B009131FB /* TrustedTimeChecker.swift */; };
 		1D8D55BC252274650044DBB6 /* BolusEntryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8D55BB252274650044DBB6 /* BolusEntryViewModelTests.swift */; };
@@ -781,6 +782,7 @@
 		1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		1D63DEA426E950D400F46FA5 /* VersionCheckServicesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCheckServicesManager.swift; sourceTree = "<group>"; };
 		1D6B1B6626866D89009AC446 /* AlertPermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPermissionsChecker.swift; sourceTree = "<group>"; };
+		1D70C40026EC0F9D00C62570 /* VersionCheckServicesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCheckServicesManagerTests.swift; sourceTree = "<group>"; };
 		1D80313C24746274002810DF /* AlertStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStoreTests.swift; sourceTree = "<group>"; };
 		1D82E69F25377C6B009131FB /* TrustedTimeChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustedTimeChecker.swift; sourceTree = "<group>"; };
 		1D8D55BB252274650044DBB6 /* BolusEntryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusEntryViewModelTests.swift; sourceTree = "<group>"; };
@@ -1634,11 +1636,12 @@
 			isa = PBXGroup;
 			children = (
 				1DA7A84024476E98008257F0 /* Alerts */,
-				A91E4C2224F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift */,
-				E9C58A7124DB489100487A17 /* LoopDataManagerTests.swift */,
-				A9F5F1F4251050EC00E7C8A4 /* ZipArchiveTests.swift */,
 				C16575722538AFF6004AE16E /* CGMStalenessMonitorTests.swift */,
+				A91E4C2224F86F1000BE9213 /* CriticalEventLogExportManagerTests.swift */,
 				C16B983F26B4898800256B05 /* DoseEnactorTests.swift */,
+				E9C58A7124DB489100487A17 /* LoopDataManagerTests.swift */,
+				1D70C40026EC0F9D00C62570 /* VersionCheckServicesManagerTests.swift */,
+				A9F5F1F4251050EC00E7C8A4 /* ZipArchiveTests.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -3802,6 +3805,7 @@
 				C16575732538AFF6004AE16E /* CGMStalenessMonitorTests.swift in Sources */,
 				A9E6DFEA246A0448005B1A1C /* PumpManagerErrorTests.swift in Sources */,
 				1DA7A84424477698008257F0 /* InAppModalAlertIssuerTests.swift in Sources */,
+				1D70C40126EC0F9D00C62570 /* VersionCheckServicesManagerTests.swift in Sources */,
 				E93E86A824DDCC4400FF40C8 /* MockDoseStore.swift in Sources */,
 				E98A55F124EDD85E0008715D /* MockDosingDecisionStore.swift in Sources */,
 				8968B114240C55F10074BB48 /* LoopSettingsTests.swift in Sources */,

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1D4990E824A25931005CC357 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E267FB2292456700A3F2AF /* FeatureFlags.swift */; };
 		1D4A3E2D2478628500FD601B /* StoredAlert+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */; };
 		1D4A3E2E2478628500FD601B /* StoredAlert+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */; };
+		1D63DEA526E950D400F46FA5 /* VersionCheckServicesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D63DEA426E950D400F46FA5 /* VersionCheckServicesManager.swift */; };
 		1D6B1B6726866D89009AC446 /* AlertPermissionsChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6B1B6626866D89009AC446 /* AlertPermissionsChecker.swift */; };
 		1D80313D24746274002810DF /* AlertStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D80313C24746274002810DF /* AlertStoreTests.swift */; };
 		1D82E6A025377C6B009131FB /* TrustedTimeChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D82E69F25377C6B009131FB /* TrustedTimeChecker.swift */; };
@@ -778,6 +779,7 @@
 		1D49795724E7289700948F05 /* ServicesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServicesViewModel.swift; sourceTree = "<group>"; };
 		1D4A3E2B2478628500FD601B /* StoredAlert+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataClass.swift"; sourceTree = "<group>"; };
 		1D4A3E2C2478628500FD601B /* StoredAlert+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoredAlert+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		1D63DEA426E950D400F46FA5 /* VersionCheckServicesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCheckServicesManager.swift; sourceTree = "<group>"; };
 		1D6B1B6626866D89009AC446 /* AlertPermissionsChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPermissionsChecker.swift; sourceTree = "<group>"; };
 		1D80313C24746274002810DF /* AlertStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertStoreTests.swift; sourceTree = "<group>"; };
 		1D82E69F25377C6B009131FB /* TrustedTimeChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustedTimeChecker.swift; sourceTree = "<group>"; };
@@ -2100,6 +2102,7 @@
 				4F70C20F1DE8FAC5006380B7 /* ExtensionDataManager.swift */,
 				89ADE13A226BFA0F0067222B /* TestingScenariosManager.swift */,
 				1D82E69F25377C6B009131FB /* TrustedTimeChecker.swift */,
+				1D63DEA426E950D400F46FA5 /* VersionCheckServicesManager.swift */,
 				4328E0341CFC0AE100E199AA /* WatchDataManager.swift */,
 				1DA6499D2441266400F61E75 /* Alerts */,
 				E95D37FF24EADE68005E2F50 /* Store Protocols */,
@@ -3532,6 +3535,7 @@
 				899433B823FE129800FA4BEA /* OverrideBadgeView.swift in Sources */,
 				89D1503E24B506EB00EDE253 /* Dictionary.swift in Sources */,
 				4302F4E31D4EA54200F0FCAF /* InsulinDeliveryTableViewController.swift in Sources */,
+				1D63DEA526E950D400F46FA5 /* VersionCheckServicesManager.swift in Sources */,
 				4FC8C8011DEB93E400A1452E /* NSUserDefaults+StatusExtension.swift in Sources */,
 				43E93FB61E469A4000EAB8DB /* NumberFormatter.swift in Sources */,
 				C1FB428C217806A400FAB378 /* StateColorPalette.swift in Sources */,

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -312,12 +312,15 @@ final class DeviceDataManager {
             glucoseStore: glucoseStore,
             settingsStore: settingsStore
         )
+        
+        let versionCheckServicesManager = VersionCheckServicesManager()
 
         servicesManager = ServicesManager(
             pluginManager: pluginManager,
             analyticsServicesManager: analyticsServicesManager,
             loggingServicesManager: loggingServicesManager,
-            remoteDataServicesManager: remoteDataServicesManager
+            remoteDataServicesManager: remoteDataServicesManager,
+            versionCheckServicesManager: versionCheckServicesManager
         )
 
         let criticalEventLogs: [CriticalEventLog] = [settingsStore, glucoseStore, carbStore, dosingDecisionStore, doseStore, deviceLog, alertManager.alertStore]

--- a/Loop/Managers/ServicesManager.swift
+++ b/Loop/Managers/ServicesManager.swift
@@ -19,6 +19,8 @@ class ServicesManager {
     let loggingServicesManager: LoggingServicesManager
 
     let remoteDataServicesManager: RemoteDataServicesManager
+    
+    let versionCheckServicesManager: VersionCheckServicesManager
 
     private var services = [Service]()
 
@@ -30,13 +32,14 @@ class ServicesManager {
         pluginManager: PluginManager,
         analyticsServicesManager: AnalyticsServicesManager,
         loggingServicesManager: LoggingServicesManager,
-        remoteDataServicesManager: RemoteDataServicesManager
+        remoteDataServicesManager: RemoteDataServicesManager,
+        versionCheckServicesManager: VersionCheckServicesManager
     ) {
         self.pluginManager = pluginManager
         self.analyticsServicesManager = analyticsServicesManager
         self.loggingServicesManager = loggingServicesManager
         self.remoteDataServicesManager = remoteDataServicesManager
-        
+        self.versionCheckServicesManager = versionCheckServicesManager
         restoreState()
     }
 
@@ -115,6 +118,9 @@ class ServicesManager {
             if let remoteDataService = service as? RemoteDataService {
                 remoteDataServicesManager.addService(remoteDataService)
             }
+            if let versionCheckService = service as? VersionCheckService {
+                versionCheckServicesManager.addService(versionCheckService)
+            }
 
             saveState()
         }
@@ -130,6 +136,9 @@ class ServicesManager {
             }
             if let analyticsService = service as? AnalyticsService {
                 analyticsServicesManager.removeService(analyticsService)
+            }
+            if let versionCheckService = service as? VersionCheckService {
+                versionCheckServicesManager.removeService(versionCheckService)
             }
 
             services.removeAll { $0.serviceIdentifier == service.serviceIdentifier }
@@ -159,6 +168,9 @@ class ServicesManager {
                 }
                 if let remoteDataService = service as? RemoteDataService {
                     remoteDataServicesManager.restoreService(remoteDataService)
+                }
+                if let versionCheckService = service as? VersionCheckService {
+                    versionCheckServicesManager.restoreService(versionCheckService)
                 }
             }
         }

--- a/Loop/Managers/VersionCheckServicesManager.swift
+++ b/Loop/Managers/VersionCheckServicesManager.swift
@@ -33,7 +33,7 @@ final class VersionCheckServicesManager {
     
     func checkVersion(currentVersion: String) -> VersionUpdate {
         let semaphore = DispatchSemaphore(value: 0)
-        var results = [String: Result<VersionUpdate, Error>]()
+        var results = [String: Result<VersionUpdate?, Error>]()
         let services = versionCheckServices.value
         services.forEach { versionCheckService in
             dispatchQueue.async {
@@ -53,7 +53,7 @@ final class VersionCheckServicesManager {
             case .failure(let error):
                 self.log.error("Error from version check service %{public}@: %{public}@", key, error.localizedDescription)
             case .success(let versionUpdate):
-                if versionUpdate > aggregatedVersionUpdate {
+                if let versionUpdate = versionUpdate, versionUpdate > aggregatedVersionUpdate {
                     aggregatedVersionUpdate = versionUpdate
                 }
             }

--- a/Loop/Managers/VersionCheckServicesManager.swift
+++ b/Loop/Managers/VersionCheckServicesManager.swift
@@ -1,0 +1,63 @@
+//
+//  VersionCheckServicesManager.swift
+//  Loop
+//
+//  Created by Rick Pasetto on 9/8/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import LoopKit
+
+final class VersionCheckServicesManager {
+
+    private lazy var log = DiagnosticLog(category: "VersionCheckServicesManager")
+
+    private lazy var dispatchQueue = DispatchQueue(label: "com.loopkit.Loop.VersionCheckServicesManager")
+    
+    private var versionCheckServices = [VersionCheckService]()
+
+    init() {}
+
+    func addService(_ versionCheckService: VersionCheckService) {
+        versionCheckServices.append(versionCheckService)
+    }
+
+    func restoreService(_ versionCheckService: VersionCheckService) {
+        versionCheckServices.append(versionCheckService)
+    }
+
+    func removeService(_ versionCheckService: VersionCheckService) {
+        versionCheckServices.removeAll { $0.serviceIdentifier == versionCheckService.serviceIdentifier }
+    }
+
+    func checkVersion(currentVersion: String) -> VersionUpdate {
+        let semaphore = DispatchSemaphore(value: 0)
+        var results = [String: Result<VersionUpdate, Error>]()
+        versionCheckServices.forEach { versionCheckService in
+            dispatchQueue.async {
+                versionCheckService.checkVersion(currentVersion: currentVersion) { result in
+                    self.dispatchQueue.async {
+                        results[versionCheckService.serviceIdentifier] = result
+                        semaphore.signal()
+                    }
+                }
+            }
+            semaphore.wait()
+        }
+        
+        var aggregatedVersionUpdate = VersionUpdate.noneNeeded
+        results.forEach { key, value in
+            switch value {
+            case .failure(let error):
+                self.log.error("Error from version check service %{public}@: %{public}@", key, error.localizedDescription)
+            case .success(let versionUpdate):
+                if versionUpdate > aggregatedVersionUpdate {
+                    aggregatedVersionUpdate = versionUpdate
+                }
+            }
+        }
+        return aggregatedVersionUpdate
+    }
+    
+}

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1516,8 +1516,11 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
     @objc private func showLoopCompletionMessage(_: Any) {
         guard let loopCompletionMessage = hudView?.loopCompletionHUD.loopCompletionMessage else { return }
-        let versionCheckMessage = "Version \(Bundle.main.shortVersionString): \(deviceManager.servicesManager.versionCheckServicesManager.checkVersion(currentVersion: Bundle.main.shortVersionString))"
-        presentLoopCompletionMesage(title: loopCompletionMessage.title, message: loopCompletionMessage.message + "\n\n" + versionCheckMessage)
+        var message = loopCompletionMessage.message
+        if FeatureFlags.allowDebugFeatures {
+            message.append("\n\nVersion \(Bundle.main.shortVersionString): \(deviceManager.servicesManager.versionCheckServicesManager.checkVersion(currentVersion: Bundle.main.shortVersionString).localizedDescription)")
+        }
+        presentLoopCompletionMesage(title: loopCompletionMessage.title, message: message)
     }
 
     private func presentLoopCompletionMesage(title: String, message: String) {

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1520,10 +1520,10 @@ final class StatusTableViewController: LoopChartsTableViewController {
         if FeatureFlags.allowDebugFeatures {
             message.append("\n\nVersion \(Bundle.main.shortVersionString): \(deviceManager.servicesManager.versionCheckServicesManager.checkVersion(currentVersion: Bundle.main.shortVersionString).localizedDescription)")
         }
-        presentLoopCompletionMesage(title: loopCompletionMessage.title, message: message)
+        presentLoopCompletionMessage(title: loopCompletionMessage.title, message: message)
     }
 
-    private func presentLoopCompletionMesage(title: String, message: String) {
+    private func presentLoopCompletionMessage(title: String, message: String) {
         let action = UIAlertAction(title: NSLocalizedString("Dismiss", comment: "The button label of the action used to dismiss an error alert"),
                                    style: .default)
         let alertController = UIAlertController(title: title,

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1516,7 +1516,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
 
     @objc private func showLoopCompletionMessage(_: Any) {
         guard let loopCompletionMessage = hudView?.loopCompletionHUD.loopCompletionMessage else { return }
-        presentLoopCompletionMesage(title: loopCompletionMessage.title, message: loopCompletionMessage.message)
+        let versionCheckMessage = "Version \(Bundle.main.shortVersionString): \(deviceManager.servicesManager.versionCheckServicesManager.checkVersion(currentVersion: Bundle.main.shortVersionString))"
+        presentLoopCompletionMesage(title: loopCompletionMessage.title, message: loopCompletionMessage.message + "\n\n" + versionCheckMessage)
     }
 
     private func presentLoopCompletionMesage(title: String, message: String) {

--- a/LoopTests/Managers/VersionCheckServicesManagerTests.swift
+++ b/LoopTests/Managers/VersionCheckServicesManagerTests.swift
@@ -1,0 +1,60 @@
+//
+//  VersionCheckServicesManagerTests.swift
+//  LoopTests
+//
+//  Created by Rick Pasetto on 9/10/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+import LoopKit
+@testable import Loop
+
+class VersionCheckServicesManagerTests: XCTestCase {
+
+    class MockVersionCheckService: VersionCheckService {
+        var mockResult: Result<VersionUpdate, Error> = .success(.noneNeeded)
+        func checkVersion(currentVersion: String, completion: @escaping (Result<VersionUpdate, Error>) -> Void) {
+            completion(mockResult)
+        }
+        convenience init() { self.init(rawState: [:])! }
+        static var localizedTitle = "MockVersionCheckService"
+        static var serviceIdentifier = "MockVersionCheckService"
+        var serviceDelegate: ServiceDelegate?
+        required init?(rawState: RawStateValue) { }
+        var rawState: RawStateValue = [:]
+        var isOnboarded: Bool = false
+    }
+    
+    var versionCheckServicesManager: VersionCheckServicesManager!
+    var mockVersionCheckService: MockVersionCheckService!
+    
+    override func setUp() {
+        versionCheckServicesManager = VersionCheckServicesManager()
+        mockVersionCheckService = MockVersionCheckService()
+        versionCheckServicesManager.addService(mockVersionCheckService)
+    }
+    
+    func testVersionCheckOneService() throws {
+        XCTAssertEqual(.noneNeeded, versionCheckServicesManager.checkVersion(currentVersion: ""))
+        mockVersionCheckService.mockResult = .success(.criticalNeeded)
+        XCTAssertEqual(.criticalNeeded, versionCheckServicesManager.checkVersion(currentVersion: ""))
+    }
+    
+    enum MockError: Error { case nothing }
+    func testVersionCheckOneServiceError() throws {
+        // Error doesn't really do anything but log
+        mockVersionCheckService.mockResult = .failure(MockError.nothing)
+        XCTAssertEqual(.noneNeeded, versionCheckServicesManager.checkVersion(currentVersion: ""))
+    }
+
+    func testVersionCheckMultipleServices() throws {
+        let anotherService = MockVersionCheckService()
+        versionCheckServicesManager.addService(anotherService)
+        XCTAssertEqual(.noneNeeded, versionCheckServicesManager.checkVersion(currentVersion: ""))
+        anotherService.mockResult = .success(.criticalNeeded)
+        XCTAssertEqual(.criticalNeeded, versionCheckServicesManager.checkVersion(currentVersion: ""))
+        mockVersionCheckService.mockResult = .success(.supportedNeeded)
+        XCTAssertEqual(.criticalNeeded, versionCheckServicesManager.checkVersion(currentVersion: ""))
+    }
+}

--- a/LoopTests/Managers/VersionCheckServicesManagerTests.swift
+++ b/LoopTests/Managers/VersionCheckServicesManagerTests.swift
@@ -14,7 +14,7 @@ class VersionCheckServicesManagerTests: XCTestCase {
 
     class MockVersionCheckService: VersionCheckService {
         var mockResult: Result<VersionUpdate, Error> = .success(.noneNeeded)
-        func checkVersion(currentVersion: String, completion: @escaping (Result<VersionUpdate, Error>) -> Void) {
+        func checkVersion(bundleIdentifier: String, currentVersion: String, completion: @escaping (Result<VersionUpdate, Error>) -> Void) {
             completion(mockResult)
         }
         convenience init() { self.init(rawState: [:])! }

--- a/LoopTests/Managers/VersionCheckServicesManagerTests.swift
+++ b/LoopTests/Managers/VersionCheckServicesManagerTests.swift
@@ -13,8 +13,8 @@ import LoopKit
 class VersionCheckServicesManagerTests: XCTestCase {
 
     class MockVersionCheckService: VersionCheckService {
-        var mockResult: Result<VersionUpdate, Error> = .success(.noneNeeded)
-        func checkVersion(bundleIdentifier: String, currentVersion: String, completion: @escaping (Result<VersionUpdate, Error>) -> Void) {
+        var mockResult: Result<VersionUpdate?, Error> = .success(.noneNeeded)
+        func checkVersion(bundleIdentifier: String, currentVersion: String, completion: @escaping (Result<VersionUpdate?, Error>) -> Void) {
             completion(mockResult)
         }
         convenience init() { self.init(rawState: [:])! }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1114

- Adds a new `VersionCheckServicesManager` to manage services that support `VersionCheckService`
- Also adds logic for aggregating multiple `VersionCheckService`s if necessary
- Adds code to display version check info (for now, by tapping the Loop icon) if `allowDebugFeatures` is `true`

See also https://github.com/tidepool-org/LoopKit/pull/396