### PR TITLE
LOOP-1421: Avoids loading plugins designated as simulators unless "allowSimulators" is true

### DIFF
--- a/Common/FeatureFlags.swift
+++ b/Common/FeatureFlags.swift
@@ -177,4 +177,18 @@ extension FeatureFlagConfiguration {
         return false
         #endif
     }
+    
+    var allowSimulators: Bool {
+        if debugEnabled {
+            return true
+        }
+        if UserDefaults.appGroup?.allowSimulators ?? false {
+            return true
+        }
+        #if ALLOW_SIMULATORS_ENABLED
+        return true
+        #else
+        return false
+        #endif
+    }
 }

--- a/Common/Models/PumpManager.swift
+++ b/Common/Models/PumpManager.swift
@@ -11,17 +11,19 @@ import LoopKitUI
 import MockKit
 import MockKitUI
 
-let staticPumpManagers: [PumpManagerUI.Type] = [
-    MockPumpManager.self,
-]
-
 let staticPumpManagersByIdentifier: [String: PumpManagerUI.Type] = [
     MockPumpManager.managerIdentifier : MockPumpManager.self
 ]
 
-let availableStaticPumpManagers = [
-    PumpManagerDescriptor(identifier: MockPumpManager.managerIdentifier, localizedTitle: MockPumpManager.localizedTitle)
-]
+var availableStaticPumpManagers: [PumpManagerDescriptor] {
+    if FeatureFlags.allowSimulators {
+        return [
+            PumpManagerDescriptor(identifier: MockPumpManager.managerIdentifier, localizedTitle: MockPumpManager.localizedTitle)
+        ]
+    } else {
+        return []
+    }
+}
 
 extension PumpManager {
     var rawValue: [String: Any] {

--- a/Loop/Managers/CGMManager.swift
+++ b/Loop/Managers/CGMManager.swift
@@ -9,16 +9,19 @@ import LoopKit
 import LoopKitUI
 import MockKit
 
-// TODO: Need a flag other than Debug for including MockCGMManager
-let staticCGMManagers: [CGMManager.Type] = [MockCGMManager.self]
-
 let staticCGMManagersByIdentifier: [String: CGMManager.Type] = [
     MockCGMManager.managerIdentifier: MockCGMManager.self
 ]
 
-let availableStaticCGMManagers = [
-    CGMManagerDescriptor(identifier: MockCGMManager.managerIdentifier, localizedTitle: MockCGMManager.localizedTitle)
-]
+var availableStaticCGMManagers: [CGMManagerDescriptor] {
+    if FeatureFlags.allowSimulators {
+        return [
+            CGMManagerDescriptor(identifier: MockCGMManager.managerIdentifier, localizedTitle: MockCGMManager.localizedTitle)
+        ]
+    } else {
+        return []
+    }
+}
 
 func CGMManagerFromRawValue(_ rawValue: [String: Any]) -> CGMManager? {
     guard let managerIdentifier = rawValue["managerIdentifier"] as? String,

--- a/Loop/Plugins/PluginManager.swift
+++ b/Loop/Plugins/PluginManager.swift
@@ -26,7 +26,7 @@ class PluginManager {
             do {
                 for pluginURL in try FileManager.default.contentsOfDirectory(at: pluginsURL, includingPropertiesForKeys: nil).filter({$0.path.hasSuffix(".framework")}) {
                     if let bundle = Bundle(url: pluginURL) {
-                        if bundle.isLoopPlugin {
+                        if bundle.isLoopPlugin && (!bundle.isSimulator || FeatureFlags.allowSimulators) {
                             log.debug("Found loop plugin: %{public}@", pluginURL.absoluteString)
                             bundles.append(bundle)
                             if bundle.isSupportPlugin {
@@ -203,6 +203,8 @@ extension Bundle {
 
     var isLoopExtension: Bool { object(forInfoDictionaryKey: LoopPluginBundleKey.extensionIdentifier.rawValue) as? String != nil }
 
+    var isSimulator: Bool { object(forInfoDictionaryKey: LoopPluginBundleKey.pluginIsSimulator.rawValue) as? Bool == true }
+    
     fileprivate func loadAndInstantiateSupport() throws -> SupportUI? {
         try loadAndReturnError()
 

--- a/LoopCore/NSUserDefaults.swift
+++ b/LoopCore/NSUserDefaults.swift
@@ -24,6 +24,7 @@ extension UserDefaults {
         case lastBedtimeQuery = "com.loopkit.Loop.lastBedtimeQuery"
         case bedtime = "com.loopkit.Loop.bedtime"
         case allowDebugFeatures = "com.loopkit.Loop.allowDebugFeatures"
+        case allowSimulators = "com.loopkit.Loop.allowSimulators"
     }
 
     public static let appGroup = UserDefaults(suiteName: Bundle.main.appGroupSuiteName)
@@ -181,5 +182,9 @@ extension UserDefaults {
     
     public var allowDebugFeatures: Bool {
         return bool(forKey: Key.allowDebugFeatures.rawValue)
+    }
+
+    public var allowSimulators: Bool {
+        return bool(forKey: Key.allowSimulators.rawValue)
     }
 }


### PR DESCRIPTION
Also makes the MockPumpManager and MockCGMManager unavailable unless "allowSimulators" is true
This will be configurable via LoopConfigurator.  See https://github.com/tidepool-org/LoopConfigurator/pull/3

https://tidepool.atlassian.net/browse/LOOP-1421