### PR TITLE
LOOP-3856: Adds canceling of temp basal if user lowers max basal below temp basal

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -185,9 +185,14 @@ final class LoopDataManager: LoopSettingsAlerterDelegate {
                 overrideHistory.recordOverride(settings.scheduleOverride)
 
                 // Invalidate cached effects affected by the override
-                self.carbEffect = nil
-                self.carbsOnBoard = nil
-                self.insulinEffect = nil
+                carbEffect = nil
+                carbsOnBoard = nil
+                insulinEffect = nil
+            }
+            
+            if settings.maximumBasalRatePerHour != oldValue.maximumBasalRatePerHour {
+                predictedGlucose = nil
+                loop()
             }
 
             UserDefaults.appGroup?.loopSettings = settings

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1534,7 +1534,8 @@ extension LoopDataManager {
         }
     }
     
-    /// Ensures that the current basal delivery is at or below the proposed max temp basal either proceed with saving max temp, or display an error.
+    /// Ensures that the current temp basal is at or below the proposed max temp basal, and if not, cancel it before proceeding.
+    /// Calls the completion with `nil` if successful, or an `error` if canceling the active temp basal fails.
     public func validateMaxTempBasal(unitsPerHour: Double, completion: @escaping (_ error: Error?) -> Void) {
         dataAccessQueue.async {
             switch self.basalDeliveryState {

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1534,7 +1534,8 @@ extension LoopDataManager {
         }
     }
     
-    public func validateTempBasal(unitsPerHour: Double, completion: @escaping (_ error: Error?) -> Void) {
+    /// Ensures that the current basal delivery is at or below the proposed max temp basal either proceed with saving max temp, or display an error.
+    public func validateMaxTempBasal(unitsPerHour: Double, completion: @escaping (_ error: Error?) -> Void) {
         dataAccessQueue.async {
             switch self.basalDeliveryState {
             case .some(.tempBasal(let dose)):

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1536,7 +1536,7 @@ extension LoopDataManager {
     
     /// Ensures that the current temp basal is at or below the proposed max temp basal, and if not, cancel it before proceeding.
     /// Calls the completion with `nil` if successful, or an `error` if canceling the active temp basal fails.
-    public func validateMaxTempBasal(unitsPerHour: Double, completion: @escaping (_ error: Error?) -> Void) {
+    public func maxTempBasalSavePreflight(unitsPerHour: Double, completion: @escaping (_ error: Error?) -> Void) {
         dataAccessQueue.async {
             switch self.basalDeliveryState {
             case .some(.tempBasal(let dose)):

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1401,12 +1401,6 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                         maximumBasalScheduleEntryCount: $0.maximumBasalScheduleEntryCount)
             }
         }
-        let syncBasalRateSchedule = { [weak self] in
-            self?.deviceManager.pumpManager?.syncBasalRateSchedule
-        }
-        let maxTempBasalSavePreflight = { [weak self] in
-            self?.deviceManager.loopManager.maxTempBasalSavePreflight
-        }
         let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: { [weak self] in self?.deviceManager.servicesManager.availableServices ?? [] },
                                                   activeServices: { [weak self] in self?.deviceManager.servicesManager.activeServices ?? [] },
@@ -1419,8 +1413,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           therapySettings: { [weak self] in self?.deviceManager.loopManager.therapySettings ?? TherapySettings() },
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
-                                          syncBasalRateSchedule: syncBasalRateSchedule,
-                                          maxTempBasalSavePreflight: maxTempBasalSavePreflight,
+                                          syncBasalRateSchedule: deviceManager.pumpManager?.syncBasalRateSchedule,
+                                          maxTempBasalSavePreflight: deviceManager.loopManager.maxTempBasalSavePreflight,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
                                           isClosedLoopAllowed: closedLoopStatus.$isClosedLoopAllowed,

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1404,8 +1404,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let syncBasalRateSchedule = { [weak self] in
             self?.deviceManager.pumpManager?.syncBasalRateSchedule
         }
-        let enactTempBasal = { [weak self] in
-            self?.deviceManager.pumpManager?.enactTempBasal
+        let validateTempBasal = { [weak self] in
+            self?.deviceManager.loopManager.validateTempBasal
         }
         let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: { [weak self] in self?.deviceManager.servicesManager.availableServices ?? [] },
@@ -1420,7 +1420,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
                                           syncBasalRateSchedule: syncBasalRateSchedule,
-                                          enactTempBasal: enactTempBasal,
+                                          validateTempBasal: validateTempBasal,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
                                           isClosedLoopAllowed: closedLoopStatus.$isClosedLoopAllowed,

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1404,6 +1404,9 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let syncBasalRateSchedule = { [weak self] in
             self?.deviceManager.pumpManager?.syncBasalRateSchedule
         }
+        let enactTempBasal = { [weak self] in
+            self?.deviceManager.pumpManager?.enactTempBasal
+        }
         let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: { [weak self] in self?.deviceManager.servicesManager.availableServices ?? [] },
                                                   activeServices: { [weak self] in self?.deviceManager.servicesManager.activeServices ?? [] },
@@ -1416,7 +1419,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           therapySettings: { [weak self] in self?.deviceManager.loopManager.therapySettings ?? TherapySettings() },
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
-                                          syncPumpSchedule: syncBasalRateSchedule,
+                                          syncBasalRateSchedule: syncBasalRateSchedule,
+                                          enactTempBasal: enactTempBasal,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
                                           isClosedLoopAllowed: closedLoopStatus.$isClosedLoopAllowed,

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1404,8 +1404,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let syncBasalRateSchedule = { [weak self] in
             self?.deviceManager.pumpManager?.syncBasalRateSchedule
         }
-        let validateMaxTempBasal = { [weak self] in
-            self?.deviceManager.loopManager.validateMaxTempBasal
+        let maxTempBasalSavePreflight = { [weak self] in
+            self?.deviceManager.loopManager.maxTempBasalSavePreflight
         }
         let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: { [weak self] in self?.deviceManager.servicesManager.availableServices ?? [] },
@@ -1420,7 +1420,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
                                           syncBasalRateSchedule: syncBasalRateSchedule,
-                                          validateMaxTempBasal: validateMaxTempBasal,
+                                          maxTempBasalSavePreflight: maxTempBasalSavePreflight,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
                                           isClosedLoopAllowed: closedLoopStatus.$isClosedLoopAllowed,

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1404,8 +1404,8 @@ final class StatusTableViewController: LoopChartsTableViewController {
         let syncBasalRateSchedule = { [weak self] in
             self?.deviceManager.pumpManager?.syncBasalRateSchedule
         }
-        let validateTempBasal = { [weak self] in
-            self?.deviceManager.loopManager.validateTempBasal
+        let validateMaxTempBasal = { [weak self] in
+            self?.deviceManager.loopManager.validateMaxTempBasal
         }
         let servicesViewModel = ServicesViewModel(showServices: FeatureFlags.includeServicesInSettingsEnabled,
                                                   availableServices: { [weak self] in self?.deviceManager.servicesManager.availableServices ?? [] },
@@ -1420,7 +1420,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: FeatureFlags.fiaspInsulinModelEnabled, walshModelEnabled: FeatureFlags.walshInsulinModelEnabled),
                                           pumpSupportedIncrements: pumpSupportedIncrements,
                                           syncBasalRateSchedule: syncBasalRateSchedule,
-                                          validateTempBasal: validateTempBasal,
+                                          validateMaxTempBasal: validateMaxTempBasal,
                                           sensitivityOverridesEnabled: FeatureFlags.sensitivityOverridesEnabled,
                                           initialDosingEnabled: deviceManager.loopManager.settings.dosingEnabled,
                                           isClosedLoopAllowed: closedLoopStatus.$isClosedLoopAllowed,

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -82,7 +82,7 @@ public class SettingsViewModel: ObservableObject {
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
     let syncBasalRateSchedule: (() -> PumpManager.SyncBasalRateSchedule?)?
-    let enactTempBasal: (() -> PumpManager.EnactTempBasal?)?
+    let validateTempBasal: (() -> PumpManager.ValidateTempBasal?)?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
@@ -105,7 +105,7 @@ public class SettingsViewModel: ObservableObject {
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
                 syncBasalRateSchedule: (() -> PumpManager.SyncBasalRateSchedule?)?,
-                enactTempBasal: (() -> PumpManager.EnactTempBasal?)?,
+                validateTempBasal: (() -> PumpManager.ValidateTempBasal?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 isClosedLoopAllowed: Published<Bool>.Publisher,
@@ -122,7 +122,7 @@ public class SettingsViewModel: ObservableObject {
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
         self.syncBasalRateSchedule = syncBasalRateSchedule
-        self.enactTempBasal = enactTempBasal
+        self.validateTempBasal = validateTempBasal
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.closedLoopPreference = initialDosingEnabled
         self.isClosedLoopAllowed = false

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -81,8 +81,8 @@ public class SettingsViewModel: ObservableObject {
     let therapySettings: () -> TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
-    let syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?
-    let maxTempBasalSavePreflight: (() -> TherapySettingsViewModel.MaxTempBasalSavePreflight?)?
+    let syncBasalRateSchedule: TherapySettingsViewModel.SyncBasalRateSchedule?
+    let maxTempBasalSavePreflight: TherapySettingsViewModel.MaxTempBasalSavePreflight?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
@@ -104,8 +104,8 @@ public class SettingsViewModel: ObservableObject {
                 therapySettings: @escaping () -> TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
-                syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?,
-                maxTempBasalSavePreflight: (() -> TherapySettingsViewModel.MaxTempBasalSavePreflight?)?,
+                syncBasalRateSchedule: TherapySettingsViewModel.SyncBasalRateSchedule?,
+                maxTempBasalSavePreflight: TherapySettingsViewModel.MaxTempBasalSavePreflight?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 isClosedLoopAllowed: Published<Bool>.Publisher,

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -82,7 +82,7 @@ public class SettingsViewModel: ObservableObject {
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
     let syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?
-    let validateMaxTempBasal: (() -> TherapySettingsViewModel.ValidateMaxTempBasal?)?
+    let maxTempBasalSavePreflight: (() -> TherapySettingsViewModel.MaxTempBasalSavePreflight?)?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
@@ -105,7 +105,7 @@ public class SettingsViewModel: ObservableObject {
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
                 syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?,
-                validateMaxTempBasal: (() -> TherapySettingsViewModel.ValidateMaxTempBasal?)?,
+                maxTempBasalSavePreflight: (() -> TherapySettingsViewModel.MaxTempBasalSavePreflight?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 isClosedLoopAllowed: Published<Bool>.Publisher,
@@ -122,7 +122,7 @@ public class SettingsViewModel: ObservableObject {
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
         self.syncBasalRateSchedule = syncBasalRateSchedule
-        self.validateMaxTempBasal = validateMaxTempBasal
+        self.maxTempBasalSavePreflight = maxTempBasalSavePreflight
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.closedLoopPreference = initialDosingEnabled
         self.isClosedLoopAllowed = false

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -82,7 +82,7 @@ public class SettingsViewModel: ObservableObject {
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
     let syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?
-    let validateTempBasal: (() -> TherapySettingsViewModel.ValidateTempBasal?)?
+    let validateMaxTempBasal: (() -> TherapySettingsViewModel.ValidateMaxTempBasal?)?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
@@ -105,7 +105,7 @@ public class SettingsViewModel: ObservableObject {
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
                 syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?,
-                validateTempBasal: (() -> TherapySettingsViewModel.ValidateTempBasal?)?,
+                validateMaxTempBasal: (() -> TherapySettingsViewModel.ValidateMaxTempBasal?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 isClosedLoopAllowed: Published<Bool>.Publisher,
@@ -122,7 +122,7 @@ public class SettingsViewModel: ObservableObject {
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
         self.syncBasalRateSchedule = syncBasalRateSchedule
-        self.validateTempBasal = validateTempBasal
+        self.validateMaxTempBasal = validateMaxTempBasal
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.closedLoopPreference = initialDosingEnabled
         self.isClosedLoopAllowed = false

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -81,7 +81,8 @@ public class SettingsViewModel: ObservableObject {
     let therapySettings: () -> TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
-    let syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?
+    let syncBasalRateSchedule: (() -> PumpManager.SyncBasalRateSchedule?)?
+    let enactTempBasal: (() -> PumpManager.EnactTempBasal?)?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
@@ -103,7 +104,8 @@ public class SettingsViewModel: ObservableObject {
                 therapySettings: @escaping () -> TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
-                syncPumpSchedule: (() -> PumpManager.SyncSchedule?)?,
+                syncBasalRateSchedule: (() -> PumpManager.SyncBasalRateSchedule?)?,
+                enactTempBasal: (() -> PumpManager.EnactTempBasal?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 isClosedLoopAllowed: Published<Bool>.Publisher,
@@ -119,7 +121,8 @@ public class SettingsViewModel: ObservableObject {
         self.therapySettings = therapySettings
         self.supportedInsulinModelSettings = supportedInsulinModelSettings
         self.pumpSupportedIncrements = pumpSupportedIncrements
-        self.syncPumpSchedule = syncPumpSchedule
+        self.syncBasalRateSchedule = syncBasalRateSchedule
+        self.enactTempBasal = enactTempBasal
         self.sensitivityOverridesEnabled = sensitivityOverridesEnabled
         self.closedLoopPreference = initialDosingEnabled
         self.isClosedLoopAllowed = false

--- a/Loop/View Models/SettingsViewModel.swift
+++ b/Loop/View Models/SettingsViewModel.swift
@@ -81,8 +81,8 @@ public class SettingsViewModel: ObservableObject {
     let therapySettings: () -> TherapySettings
     let supportedInsulinModelSettings: SupportedInsulinModelSettings
     let pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?
-    let syncBasalRateSchedule: (() -> PumpManager.SyncBasalRateSchedule?)?
-    let validateTempBasal: (() -> PumpManager.ValidateTempBasal?)?
+    let syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?
+    let validateTempBasal: (() -> TherapySettingsViewModel.ValidateTempBasal?)?
     let sensitivityOverridesEnabled: Bool
     let supportInfoProvider: SupportInfoProvider
 
@@ -104,8 +104,8 @@ public class SettingsViewModel: ObservableObject {
                 therapySettings: @escaping () -> TherapySettings,
                 supportedInsulinModelSettings: SupportedInsulinModelSettings,
                 pumpSupportedIncrements: (() -> PumpSupportedIncrements?)?,
-                syncBasalRateSchedule: (() -> PumpManager.SyncBasalRateSchedule?)?,
-                validateTempBasal: (() -> PumpManager.ValidateTempBasal?)?,
+                syncBasalRateSchedule: (() -> TherapySettingsViewModel.SyncBasalRateSchedule?)?,
+                validateTempBasal: (() -> TherapySettingsViewModel.ValidateTempBasal?)?,
                 sensitivityOverridesEnabled: Bool,
                 initialDosingEnabled: Bool,
                 isClosedLoopAllowed: Published<Bool>.Publisher,

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -119,7 +119,7 @@ extension SettingsView {
                                                                             supportedInsulinModelSettings: self.viewModel.supportedInsulinModelSettings,
                                                                             pumpSupportedIncrements: self.viewModel.pumpSupportedIncrements,
                                                                             syncBasalRateSchedule: self.viewModel.syncBasalRateSchedule,
-                                                                            validateMaxTempBasal: self.viewModel.validateMaxTempBasal,
+                                                                            maxTempBasalSavePreflight: self.viewModel.maxTempBasalSavePreflight,
                                                                             didSave: self.viewModel.didSave))
                         .environmentObject(displayGlucoseUnitObservable)
                         .environment(\.dismissAction, self.dismiss)
@@ -399,7 +399,7 @@ public struct SettingsView_Previews: PreviewProvider {
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,
                                           syncBasalRateSchedule: nil,
-                                          validateMaxTempBasal: nil,
+                                          maxTempBasalSavePreflight: nil,
                                           sensitivityOverridesEnabled: false,
                                           initialDosingEnabled: true,
                                           isClosedLoopAllowed: fakeClosedLoopAllowedPublisher.$mockIsClosedLoopAllowed,

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -119,7 +119,7 @@ extension SettingsView {
                                                                             supportedInsulinModelSettings: self.viewModel.supportedInsulinModelSettings,
                                                                             pumpSupportedIncrements: self.viewModel.pumpSupportedIncrements,
                                                                             syncBasalRateSchedule: self.viewModel.syncBasalRateSchedule,
-                                                                            enactTempBasal: self.viewModel.enactTempBasal,
+                                                                            validateTempBasal: self.viewModel.validateTempBasal,
                                                                             didSave: self.viewModel.didSave))
                         .environmentObject(displayGlucoseUnitObservable)
                         .environment(\.dismissAction, self.dismiss)
@@ -399,7 +399,7 @@ public struct SettingsView_Previews: PreviewProvider {
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,
                                           syncBasalRateSchedule: nil,
-                                          enactTempBasal: nil,
+                                          validateTempBasal: nil,
                                           sensitivityOverridesEnabled: false,
                                           initialDosingEnabled: true,
                                           isClosedLoopAllowed: fakeClosedLoopAllowedPublisher.$mockIsClosedLoopAllowed,

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -119,7 +119,7 @@ extension SettingsView {
                                                                             supportedInsulinModelSettings: self.viewModel.supportedInsulinModelSettings,
                                                                             pumpSupportedIncrements: self.viewModel.pumpSupportedIncrements,
                                                                             syncBasalRateSchedule: self.viewModel.syncBasalRateSchedule,
-                                                                            validateTempBasal: self.viewModel.validateTempBasal,
+                                                                            validateMaxTempBasal: self.viewModel.validateMaxTempBasal,
                                                                             didSave: self.viewModel.didSave))
                         .environmentObject(displayGlucoseUnitObservable)
                         .environment(\.dismissAction, self.dismiss)
@@ -399,7 +399,7 @@ public struct SettingsView_Previews: PreviewProvider {
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,
                                           syncBasalRateSchedule: nil,
-                                          validateTempBasal: nil,
+                                          validateMaxTempBasal: nil,
                                           sensitivityOverridesEnabled: false,
                                           initialDosingEnabled: true,
                                           isClosedLoopAllowed: fakeClosedLoopAllowedPublisher.$mockIsClosedLoopAllowed,

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -118,7 +118,8 @@ extension SettingsView {
                                         viewModel: TherapySettingsViewModel(therapySettings: self.viewModel.therapySettings(),
                                                                             supportedInsulinModelSettings: self.viewModel.supportedInsulinModelSettings,
                                                                             pumpSupportedIncrements: self.viewModel.pumpSupportedIncrements,
-                                                                            syncPumpSchedule: self.viewModel.syncPumpSchedule,
+                                                                            syncBasalRateSchedule: self.viewModel.syncBasalRateSchedule,
+                                                                            enactTempBasal: self.viewModel.enactTempBasal,
                                                                             didSave: self.viewModel.didSave))
                         .environmentObject(displayGlucoseUnitObservable)
                         .environment(\.dismissAction, self.dismiss)
@@ -397,7 +398,8 @@ public struct SettingsView_Previews: PreviewProvider {
                                           therapySettings: { TherapySettings() },
                                           supportedInsulinModelSettings: SupportedInsulinModelSettings(fiaspModelEnabled: true, walshModelEnabled: true),
                                           pumpSupportedIncrements: nil,
-                                          syncPumpSchedule: nil,
+                                          syncBasalRateSchedule: nil,
+                                          enactTempBasal: nil,
                                           sensitivityOverridesEnabled: false,
                                           initialDosingEnabled: true,
                                           isClosedLoopAllowed: fakeClosedLoopAllowedPublisher.$mockIsClosedLoopAllowed,

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -52,6 +52,7 @@ class LoopDataManagerDosingTests: XCTestCase {
     let retrospectiveCorrectionGroupingIntervalMultiplier = 1.01
     let inputDataRecencyInterval = TimeInterval(minutes: 15)
     let dateFormatter = ISO8601DateFormatter.localTimeDate()
+    let defaultAccuracy = 1.0 / 40.0
     
     // MARK: Settings
     let maxBasalRate = 5.0
@@ -74,7 +75,7 @@ class LoopDataManagerDosingTests: XCTestCase {
     // MARK: Mock stores
     var loopDataManager: LoopDataManager!
     
-    func setUp(for test: DataManagerTestType) {
+    func setUp(for test: DataManagerTestType, basalDeliveryState: PumpManagerStatus.BasalDeliveryState? = nil) {
         let settings = LoopSettings(
             dosingEnabled: false,
             glucoseTargetRangeSchedule: glucoseTargetRangeSchedule,
@@ -92,7 +93,7 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         loopDataManager = LoopDataManager(
             lastLoopCompleted: currentDate,
-            basalDeliveryState: .active(currentDate),
+            basalDeliveryState: basalDeliveryState ?? .active(currentDate),
             settings: settings,
             overrideHistory: TemporaryScheduleOverrideHistory(),
             lastPumpEventsReconciliation: nil, // this date is only used to init the doseStore if a DoseStoreProtocol isn't passed in, so this date can be nil
@@ -140,10 +141,10 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         for (expected, calculated) in zip(predictedGlucoseOutput, predictedGlucose!) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: 1.0 / 40.0)
+            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: defaultAccuracy)
         }
 
-        XCTAssertEqual(1.40, recommendedTempBasal!.unitsPerHour, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(1.40, recommendedTempBasal!.unitsPerHour, accuracy: defaultAccuracy)
     }
     
     func testHighAndStable() {
@@ -167,10 +168,10 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         for (expected, calculated) in zip(predictedGlucoseOutput, predictedGlucose!) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: 1.0 / 40.0)
+            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: defaultAccuracy)
         }
 
-        XCTAssertEqual(4.63, recommendedBasal!.unitsPerHour, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(4.63, recommendedBasal!.unitsPerHour, accuracy: defaultAccuracy)
     }
     
     func testHighAndFalling() {
@@ -194,10 +195,10 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         for (expected, calculated) in zip(predictedGlucoseOutput, predictedGlucose!) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: 1.0 / 40.0)
+            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: defaultAccuracy)
         }
 
-        XCTAssertEqual(0, recommendedTempBasal!.unitsPerHour, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(0, recommendedTempBasal!.unitsPerHour, accuracy: defaultAccuracy)
     }
     
     func testHighAndRisingWithCOB() {
@@ -221,10 +222,10 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         for (expected, calculated) in zip(predictedGlucoseOutput, predictedGlucose!) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: 1.0 / 40.0)
+            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: defaultAccuracy)
         }
 
-        XCTAssertEqual(1.6, recommendedBolus!.amount, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(1.6, recommendedBolus!.amount, accuracy: defaultAccuracy)
     }
     
     func testLowAndFallingWithCOB() {
@@ -248,10 +249,10 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         for (expected, calculated) in zip(predictedGlucoseOutput, predictedGlucose!) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: 1.0 / 40.0)
+            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: defaultAccuracy)
         }
 
-        XCTAssertEqual(0, recommendedTempBasal!.unitsPerHour, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(0, recommendedTempBasal!.unitsPerHour, accuracy: defaultAccuracy)
     }
     
     func testLowWithLowTreatment() {
@@ -275,10 +276,66 @@ class LoopDataManagerDosingTests: XCTestCase {
         
         for (expected, calculated) in zip(predictedGlucoseOutput, predictedGlucose!) {
             XCTAssertEqual(expected.startDate, calculated.startDate)
-            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: 1.0 / 40.0)
+            XCTAssertEqual(expected.quantity.doubleValue(for: .milligramsPerDeciliter), calculated.quantity.doubleValue(for: .milligramsPerDeciliter), accuracy: defaultAccuracy)
         }
 
-        XCTAssertEqual(0, recommendedTempBasal!.unitsPerHour, accuracy: 1.0 / 40.0)
+        XCTAssertEqual(0, recommendedTempBasal!.unitsPerHour, accuracy: defaultAccuracy)
+    }
+    
+    func testValidateTempBasalDoesntCancelTempBasalIfHigher() {
+        let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 3.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
+        setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
+
+        class MockDelegate: LoopDataManagerDelegate {
+            var recommendation: TempBasalRecommendation?
+            var error: Error?
+            func loopDataManager(_ manager: LoopDataManager, didRecommendBasalChange basal: (recommendation: TempBasalRecommendation, date: Date), completion: @escaping (Error?) -> Void) {
+                self.recommendation = basal.recommendation
+                completion(error)
+            }
+            func loopDataManager(_ manager: LoopDataManager, roundBasalRate unitsPerHour: Double) -> Double { unitsPerHour }
+            func loopDataManager(_ manager: LoopDataManager, roundBolusVolume units: Double) -> Double { units }
+            var pumpManagerStatus: PumpManagerStatus?
+        }
+        let delegate = MockDelegate()
+        loopDataManager.delegate = delegate
+        let exp = expectation(description: #function)
+        var error: Error?
+        loopDataManager.validateTempBasal(unitsPerHour: 5.0) {
+            error = $0
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNil(error)
+        XCTAssertNil(delegate.recommendation)
+    }
+    
+    func testValidateTempBasalCancelsTempBasalIfLower() {
+        let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
+        setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
+
+        class MockDelegate: LoopDataManagerDelegate {
+            var recommendation: TempBasalRecommendation?
+            var error: Error?
+            func loopDataManager(_ manager: LoopDataManager, didRecommendBasalChange basal: (recommendation: TempBasalRecommendation, date: Date), completion: @escaping (Error?) -> Void) {
+                self.recommendation = basal.recommendation
+                completion(error)
+            }
+            func loopDataManager(_ manager: LoopDataManager, roundBasalRate unitsPerHour: Double) -> Double { unitsPerHour }
+            func loopDataManager(_ manager: LoopDataManager, roundBolusVolume units: Double) -> Double { units }
+            var pumpManagerStatus: PumpManagerStatus?
+        }
+        let delegate = MockDelegate()
+        loopDataManager.delegate = delegate
+        let exp = expectation(description: #function)
+        var error: Error?
+        loopDataManager.validateTempBasal(unitsPerHour: 3.0) {
+            error = $0
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertNil(error)
+        XCTAssertEqual(TempBasalRecommendation.cancel, delegate.recommendation)
     }
 }
 

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -311,14 +311,14 @@ class LoopDataManagerDosingTests: XCTestCase {
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
         // This wait is working around the issue presented by LoopDataManager.init().  It cancels the temp basal if
         // `isClosedLoop` is false (which it is from `setUp` above). When that happens, it races with
-        // `validateMaxTempBasal` below.  This ensures only one happens at a time.
+        // `maxTempBasalSavePreflight` below.  This ensures only one happens at a time.
         waitOnDataQueue()
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         var error: Error?
         let exp = expectation(description: #function)
         XCTAssertNil(delegate.recommendation)
-        loopDataManager.validateMaxTempBasal(unitsPerHour: 5.0) {
+        loopDataManager.maxTempBasalSavePreflight(unitsPerHour: 5.0) {
             error = $0
             exp.fulfill()
         }
@@ -332,14 +332,14 @@ class LoopDataManagerDosingTests: XCTestCase {
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
         // This wait is working around the issue presented by LoopDataManager.init().  It cancels the temp basal if
         // `isClosedLoop` is false (which it is from `setUp` above). When that happens, it races with
-        // `validateMaxTempBasal` below.  This ensures only one happens at a time.
+        // `maxTempBasalSavePreflight` below.  This ensures only one happens at a time.
         waitOnDataQueue()
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         var error: Error?
         let exp = expectation(description: #function)
         XCTAssertNil(delegate.recommendation)
-        loopDataManager.validateMaxTempBasal(unitsPerHour: 3.0) {
+        loopDataManager.maxTempBasalSavePreflight(unitsPerHour: 3.0) {
             error = $0
             exp.fulfill()
         }

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -306,19 +306,19 @@ class LoopDataManagerDosingTests: XCTestCase {
         wait(for: [e], timeout: timeout)
     }
     
-    func testValidateTempBasalDoesntCancelTempBasalIfHigher() {
+    func testValidateMaxTempBasalDoesntCancelTempBasalIfHigher() {
         let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 3.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
         // This wait is working around the issue presented by LoopDataManager.init().  It cancels the temp basal if
         // `isClosedLoop` is false (which it is from `setUp` above). When that happens, it races with
-        // `validateTempBasal` below.  This ensures only one happens at a time.
+        // `validateMaxTempBasal` below.  This ensures only one happens at a time.
         waitOnDataQueue()
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         var error: Error?
         let exp = expectation(description: #function)
         XCTAssertNil(delegate.recommendation)
-        loopDataManager.validateTempBasal(unitsPerHour: 5.0) {
+        loopDataManager.validateMaxTempBasal(unitsPerHour: 5.0) {
             error = $0
             exp.fulfill()
         }
@@ -327,19 +327,19 @@ class LoopDataManagerDosingTests: XCTestCase {
         XCTAssertNil(delegate.recommendation)
     }
     
-    func testValidateTempBasalCancelsTempBasalIfLower() {
+    func testValidateMaxTempBasalCancelsTempBasalIfLower() {
         let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
         // This wait is working around the issue presented by LoopDataManager.init().  It cancels the temp basal if
         // `isClosedLoop` is false (which it is from `setUp` above). When that happens, it races with
-        // `validateTempBasal` below.  This ensures only one happens at a time.
+        // `validateMaxTempBasal` below.  This ensures only one happens at a time.
         waitOnDataQueue()
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         var error: Error?
         let exp = expectation(description: #function)
         XCTAssertNil(delegate.recommendation)
-        loopDataManager.validateTempBasal(unitsPerHour: 3.0) {
+        loopDataManager.validateMaxTempBasal(unitsPerHour: 3.0) {
             error = $0
             exp.fulfill()
         }

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -350,6 +350,7 @@ class LoopDataManagerDosingTests: XCTestCase {
     
     func testChangingMaxBasalCausesLoop() {
         setUp(for: .highAndStable)
+        waitOnDataQueue()
         var looped = false
         let exp = expectation(description: #function)
         let observer = NotificationCenter.default.addObserver(forName: .LoopDataUpdated, object: nil, queue: nil) { _ in

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -298,13 +298,21 @@ class LoopDataManagerDosingTests: XCTestCase {
         var pumpManagerStatus: PumpManagerStatus?
     }
 
+    func waitOnDataQueue(timeout: TimeInterval = 1.0) {
+        let e = expectation(description: "dataQueue")
+        loopDataManager.getLoopState { _, _ in
+            e.fulfill()
+        }
+        wait(for: [e], timeout: timeout)
+    }
+    
     func testValidateTempBasalDoesntCancelTempBasalIfHigher() {
         let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 3.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
-        // This wait on main is working around the issue presented by LoopDataManager.init().  It cancels the temp basal
-        // if `isClosedLoop` is false (which it is from `setUp` above), but on the main thread. When that happens, it
-        // races with `validateTempBasal` below.  This ensures only one happens at a time.
-        waitOnMain()
+        // This wait is working around the issue presented by LoopDataManager.init().  It cancels the temp basal if
+        // `isClosedLoop` is false (which it is from `setUp` above). When that happens, it races with
+        // `validateTempBasal` below.  This ensures only one happens at a time.
+        waitOnDataQueue()
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         var error: Error?
@@ -322,10 +330,10 @@ class LoopDataManagerDosingTests: XCTestCase {
     func testValidateTempBasalCancelsTempBasalIfLower() {
         let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
-        // This wait on main is working around the issue presented by LoopDataManager.init().  It cancels the temp basal
-        // if `isClosedLoop` is false (which it is from `setUp` above), but on the main thread. When that happens, it
-        // races with `validateTempBasal` below.  This ensures only one happens at a time.
-        waitOnMain()
+        // This wait is working around the issue presented by LoopDataManager.init().  It cancels the temp basal if
+        // `isClosedLoop` is false (which it is from `setUp` above). When that happens, it races with
+        // `validateTempBasal` below.  This ensures only one happens at a time.
+        waitOnDataQueue()
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         var error: Error?

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -109,6 +109,10 @@ class LoopDataManagerDosingTests: XCTestCase {
         )
     }
     
+    override func tearDownWithError() throws {
+        loopDataManager = nil
+    }
+    
     // MARK: Functions to load fixtures
     func loadGlucoseEffect(_ name: String) -> [GlucoseEffect] {
         let fixture: [JSONDictionary] = loadFixture(name)
@@ -308,12 +312,12 @@ class LoopDataManagerDosingTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
         XCTAssertNil(error)
         XCTAssertNil(delegate.recommendation)
+        loopDataManager.delegate = nil
     }
     
     func testValidateTempBasalCancelsTempBasalIfLower() {
         let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
         setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
-
         let delegate = MockDelegate()
         loopDataManager.delegate = delegate
         let exp = expectation(description: #function)
@@ -325,6 +329,7 @@ class LoopDataManagerDosingTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
         XCTAssertNil(error)
         XCTAssertEqual(TempBasalRecommendation.cancel, delegate.recommendation)
+        loopDataManager.delegate = nil
     }
     
     func testChangingMaxBasalCausesLoop() {


### PR DESCRIPTION
Wires up an `ValidateTempBasal` hook so TherapySettings can use it if changing the max basal rate.
This implements cancellation of temp basal if the max basal rate is lowered below the current temp basal.

Also, if it does change, this triggers a `loop()`

https://tidepool.atlassian.net/browse/LOOP-3856

LWPR: https://github.com/tidepool-org/LoopWorkspace/pull/658