### PR TITLE
LOOP-3915: Ensure `loop()` is called if max basal is set below temp basal

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1646,8 +1646,13 @@ extension LoopDataManager {
             switch self.basalDeliveryState {
             case .some(.tempBasal(let dose)):
                 if dose.unitsPerHour > unitsPerHour {
-                    // Temp basal is higher than proposed rate, so should cancel
-                    self.cancelActiveTempBasal(completion: completion)
+                    // Temp basal is higher than proposed rate, so should cancel and trigger loop
+                    self.cancelActiveTempBasal { error in
+                        completion(error)
+                        if error == nil {
+                            self.loop()
+                        }
+                    }
                 } else {
                     completion(nil)
                 }

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -1646,13 +1646,8 @@ extension LoopDataManager {
             switch self.basalDeliveryState {
             case .some(.tempBasal(let dose)):
                 if dose.unitsPerHour > unitsPerHour {
-                    // Temp basal is higher than proposed rate, so should cancel and trigger loop
-                    self.cancelActiveTempBasal { error in
-                        completion(error)
-                        if error == nil {
-                            self.loop()
-                        }
-                    }
+                    // Temp basal is higher than proposed rate, so should cancel
+                    self.cancelActiveTempBasal(completion: completion)
                 } else {
                     completion(nil)
                 }

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -226,7 +226,12 @@ final class LoopDataManager: LoopSettingsAlerterDelegate {
             self.carbsOnBoard = nil
             self.insulinEffect = nil
         }
-
+        
+        if newValue.maximumBasalRatePerHour != oldValue.maximumBasalRatePerHour {
+            predictedGlucose = nil
+            loop()
+        }
+        
         UserDefaults.appGroup?.loopSettings = newValue
         notify(forChange: .preferences)
         analyticsServicesManager.didChangeLoopSettings(from: oldValue, to: newValue)

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -290,6 +290,7 @@ class LoopDataManagerDosingTests: XCTestCase {
     }
     
     class MockDelegate: LoopDataManagerDelegate {
+        enum MockError: Error { case arbitrary }
         var recommendation: AutomaticDoseRecommendation?
         var error: Error?
         func loopDataManager(_ manager: LoopDataManager, didRecommend automaticDose: (recommendation: AutomaticDoseRecommendation, date: Date), completion: @escaping (Error?) -> Void) {
@@ -351,19 +352,84 @@ class LoopDataManagerDosingTests: XCTestCase {
         XCTAssertEqual(TempBasalRecommendation.cancel, delegate.recommendation?.basalAdjustment)
     }
     
-    func testChangingMaxBasalCausesLoop() {
-        setUp(for: .highAndStable)
+    func testChangingMaxBasalDoesNotLoopIfNotLower() {
+        let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
+        setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
         waitOnDataQueue()
+        let delegate = MockDelegate()
+        loopDataManager.delegate = delegate
         var looped = false
-        let exp = expectation(description: #function)
+        let exp = expectation(description: #function + "NotificationCenter.default.addObserver")
+        exp.isInverted = true
         let observer = NotificationCenter.default.addObserver(forName: .LoopCompleted, object: nil, queue: nil) { _ in
             looped = true
             exp.fulfill()
         }
         XCTAssertFalse(looped)
-        loopDataManager.mutateSettings { $0.maximumBasalRatePerHour = 2.0 }
-        wait(for: [exp], timeout: 1.0)
+        var error: Error?
+        let exp2 = expectation(description: #function + "maxTempBasalSavePreflight")
+        loopDataManager.maxTempBasalSavePreflight(unitsPerHour: 6.0) {
+            error = $0
+            exp2.fulfill()
+        }
+        wait(for: [exp, exp2], timeout: 1.0)
+        XCTAssertNil(error)
+        XCTAssertFalse(looped)
+        XCTAssertNil(delegate.recommendation)
+        NotificationCenter.default.removeObserver(observer)
+    }
+    
+    func testChangingMaxBasalDoesNotLoopIfError() {
+        let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
+        setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
+        waitOnDataQueue()
+        let delegate = MockDelegate()
+        delegate.error = MockDelegate.MockError.arbitrary
+        loopDataManager.delegate = delegate
+        var looped = false
+        let exp = expectation(description: #function + "NotificationCenter.default.addObserver")
+        exp.isInverted = true
+        let observer = NotificationCenter.default.addObserver(forName: .LoopCompleted, object: nil, queue: nil) { _ in
+            looped = true
+            exp.fulfill()
+        }
+        XCTAssertFalse(looped)
+        var error: Error?
+        let exp2 = expectation(description: #function + "maxTempBasalSavePreflight")
+        loopDataManager.maxTempBasalSavePreflight(unitsPerHour: 3.0) {
+            error = $0
+            exp2.fulfill()
+        }
+        wait(for: [exp, exp2], timeout: 1.0)
+        XCTAssertNotNil(error)
+        XCTAssertFalse(looped)
+        XCTAssertNotNil(delegate.recommendation)
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    func testChangingMaxBasalCausesLoopIfLower() {
+        let dose = DoseEntry(type: .tempBasal, startDate: Date(), endDate: nil, value: 5.0, unit: .unitsPerHour, deliveredUnits: nil, description: nil, syncIdentifier: nil, scheduledBasalRate: nil)
+        setUp(for: .highAndStable, basalDeliveryState: .tempBasal(dose))
+        waitOnDataQueue()
+        let delegate = MockDelegate()
+        loopDataManager.delegate = delegate
+        var looped = false
+        let exp = expectation(description: #function + "NotificationCenter.default.addObserver")
+        let observer = NotificationCenter.default.addObserver(forName: .LoopCompleted, object: nil, queue: nil) { _ in
+            looped = true
+            exp.fulfill()
+        }
+        XCTAssertFalse(looped)
+        var error: Error?
+        let exp2 = expectation(description: #function + "maxTempBasalSavePreflight")
+        loopDataManager.maxTempBasalSavePreflight(unitsPerHour: 3.0) {
+            error = $0
+            exp2.fulfill()
+        }
+        wait(for: [exp, exp2], timeout: 1.0)
+        XCTAssertNil(error)
         XCTAssertTrue(looped)
+        XCTAssertNotNil(delegate.recommendation)
         NotificationCenter.default.removeObserver(observer)
     }
 }

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -356,7 +356,7 @@ class LoopDataManagerDosingTests: XCTestCase {
         waitOnDataQueue()
         var looped = false
         let exp = expectation(description: #function)
-        let observer = NotificationCenter.default.addObserver(forName: .LoopDataUpdated, object: nil, queue: nil) { _ in
+        let observer = NotificationCenter.default.addObserver(forName: .LoopCompleted, object: nil, queue: nil) { _ in
             looped = true
             exp.fulfill()
         }


### PR DESCRIPTION
Follow up from [LOOP-3856](https://tidepool.atlassian.net/browse/LOOP-3856): Turns out this was a merge conflict mistake...some code did not come in from `release/v1.1.0` that should have, and a unit tests specifically written to catch this had a bug in it.  A double fault!

[LOOP-3915](https://tidepool.atlassian.net/browse/LOOP-3915)