### PR TITLE
LOOP-3932: Fix memory leak when deleting CGM Manager

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -787,7 +787,11 @@ extension DeviceDataManager: CGMManagerDelegate {
         log.default("CGM manager with identifier '%{public}@' wants deletion", manager.managerIdentifier)
 
         DispatchQueue.main.async {
+            if let cgmManagerUI = self.cgmManager as? CGMManagerUI {
+                self.removeDisplayGlucoseUnitObserver(cgmManagerUI)
+            }
             self.cgmManager = nil
+            self.displayGlucoseUnitObservers.cleanupDeallocatedElements()
         }
     }
 


### PR DESCRIPTION
This ensures that _all_ memory associated with a CGM manager is freed when it is removed.