### PR TITLE
LOOP-3970: Fix one of the code paths where banner row needs to be updated

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -343,7 +343,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         }
 
         guard active && visible && !refreshContext.isEmpty else {
-            updateBannerRow(animated: true)
+            updateBannerRow(animated: animated)
             redrawCharts()
             return
         }

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -322,6 +322,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
     }
 
     override func reloadData(animated: Bool = false) {
+        dispatchPrecondition(condition: .onQueue(.main))
         // This should be kept up to date immediately
         hudView?.loopCompletionHUD.lastLoopCompleted = deviceManager.loopManager.lastLoopCompleted
 
@@ -342,6 +343,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         }
 
         guard active && visible && !refreshContext.isEmpty else {
+            updateBannerRow(animated: true)
             redrawCharts()
             return
         }


### PR DESCRIPTION
Makes sure banner row is inserted in the TableView at the proper time, or else you get an `NSInternalInconsistencyException`:

```
Fatal Exception: NSInternalInconsistencyException
Invalid update: invalid number of rows in section 0. The number of rows contained in an existing section after the update (0) must be equal to the number of rows contained in that section before the update (1), plus or minus the number of rows inserted or deleted from that section (0 inserted, 0 deleted) and plus or minus the number of rows moved into or out of that section (0 moved in, 0 moved out).
```

https://tidepool.atlassian.net/browse/LOOP-3970