### PR TITLE
[FIX-Upload] missing usage description

### DIFF
--- a/WatchApp Extension/Info.plist
+++ b/WatchApp Extension/Info.plist
@@ -48,6 +48,10 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.watchkit</string>
 	</dict>
+	<key>NSHealthShareUsageDescription</key>
+	<string>Meal data from the Health database is used to determine glucose effects. Glucose data from the Health database is used for graphing and momentum calculation. Sleep data from the Health database is used to optimize delivery of Apple Watch complication updates during the time you are awake.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Carbohydrate meal data entered in the app and on the watch is stored in the Health database. Glucose data retrieved from the CGM is stored securely in HealthKit.</string>
 	<key>RemoteInterfacePrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).StatusInterfaceController</string>
 	<key>WKExtensionDelegateClassName</key>


### PR DESCRIPTION
CCI upload [task failing](https://app.circleci.com/pipelines/github/tidepool-org/LoopWorkspace/4048/workflows/8f25cbba-cf4e-42e2-9f8c-1ef6f13acf95/jobs/29528) with `missing purpose string in info.plist`. Developer forum suggested adding the missing purpose descriptions to the watch app extension. Do this allowed me to validate a build locally. Now would like to try on CCI.

