### PR TITLE
LOOP-3973: Introducing `interruptionLevel` as a replacement for `Alert.isCritical`

### DIFF
--- a/Loop/Extensions/AlertStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/AlertStore+SimulatedCoreData.swift
@@ -53,11 +53,11 @@ fileprivate extension AlertStore.DatedAlert {
                           foregroundContent: Alert.Content(title: "Simulated Alert Foreground Title",
                                                            body: "The body of a foreground simulated alert approximates an actual alert body.",
                                                            acknowledgeActionButtonLabel: "Acknowledged",
-                                                           isCritical: false),
+                                                           interruptionLevel: .timeSensitive),
                           backgroundContent: Alert.Content(title: "Simulated Alert Background Title",
                                                            body: "The body of a background simulated alert approximates an actual alert body.",
                                                            acknowledgeActionButtonLabel: "Acknowledged",
-                                                           isCritical: false),
+                                                           interruptionLevel: .active),
                           trigger: .delayed(interval: 60),
                           sound: .sound(name: "simulated"))
         return AlertStore.DatedAlert(date: date, alert: alert)

--- a/Loop/Extensions/AlertStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/AlertStore+SimulatedCoreData.swift
@@ -52,12 +52,10 @@ fileprivate extension AlertStore.DatedAlert {
                                                        alertIdentifier: "simulatedAlertIdentifier"),
                           foregroundContent: Alert.Content(title: "Simulated Alert Foreground Title",
                                                            body: "The body of a foreground simulated alert approximates an actual alert body.",
-                                                           acknowledgeActionButtonLabel: "Acknowledged",
-                                                           interruptionLevel: .timeSensitive),
+                                                           acknowledgeActionButtonLabel: "Acknowledged"),
                           backgroundContent: Alert.Content(title: "Simulated Alert Background Title",
                                                            body: "The body of a background simulated alert approximates an actual alert body.",
-                                                           acknowledgeActionButtonLabel: "Acknowledged",
-                                                           interruptionLevel: .active),
+                                                           acknowledgeActionButtonLabel: "Acknowledged"),
                           trigger: .delayed(interval: 60),
                           sound: .sound(name: "simulated"))
         return AlertStore.DatedAlert(date: date, alert: alert)

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -236,7 +236,7 @@ extension AlertManager {
                     * issued: \(storedAlert.issuedDate)
                     * acknowledged: \(storedAlert.acknowledgedDate?.description ?? "n/a")
                     * retracted: \(storedAlert.retractedDate?.description ?? "n/a")
-                    * isCritical: \(storedAlert.isCritical)
+                    * interruptionLevel: \(storedAlert.interruptionLevel)
                     * trigger: \(storedAlert.trigger)
                     * foregroundContent: \(storedAlert.foregroundContent ?? "n/a")
                     * backgroundContent: \(storedAlert.backgroundContent ?? "n/a")

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -237,6 +237,7 @@ extension AlertManager {
                     * acknowledged: \(storedAlert.acknowledgedDate?.description ?? "n/a")
                     * retracted: \(storedAlert.retractedDate?.description ?? "n/a")
                     * trigger: \(storedAlert.trigger)
+                    * interruptionLevel: \(storedAlert.interruptionLevel)
                     * foregroundContent: \(storedAlert.foregroundContent ?? "n/a")
                     * backgroundContent: \(storedAlert.backgroundContent ?? "n/a")
                     * sound: \(storedAlert.sound ?? "n/a")

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -236,7 +236,6 @@ extension AlertManager {
                     * issued: \(storedAlert.issuedDate)
                     * acknowledged: \(storedAlert.acknowledgedDate?.description ?? "n/a")
                     * retracted: \(storedAlert.retractedDate?.description ?? "n/a")
-                    * interruptionLevel: \(storedAlert.interruptionLevel)
                     * trigger: \(storedAlert.trigger)
                     * foregroundContent: \(storedAlert.foregroundContent ?? "n/a")
                     * backgroundContent: \(storedAlert.backgroundContent ?? "n/a")

--- a/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
+++ b/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17511" systemVersion="20C69" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21A559" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="StoredAlert" representedClassName=".StoredAlert" syncable="YES">
         <attribute name="acknowledgedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="alertIdentifier" attributeType="String"/>
         <attribute name="backgroundContent" optional="YES" attributeType="String"/>
         <attribute name="foregroundContent" optional="YES" attributeType="String"/>
-        <attribute name="isCritical" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="interruptionLevel" attributeType="Integer 16" usesScalarValueType="YES"/>
         <attribute name="issuedDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="managerIdentifier" attributeType="String"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
+++ b/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
@@ -5,6 +5,7 @@
         <attribute name="alertIdentifier" attributeType="String"/>
         <attribute name="backgroundContent" optional="YES" attributeType="String"/>
         <attribute name="foregroundContent" optional="YES" attributeType="String"/>
+        <attribute name="interruptionLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="issuedDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="managerIdentifier" attributeType="String"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -17,6 +18,6 @@
         </fetchIndex>
     </entity>
     <elements>
-        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="194"/>
+        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="209"/>
     </elements>
 </model>

--- a/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
+++ b/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
@@ -5,7 +5,6 @@
         <attribute name="alertIdentifier" attributeType="String"/>
         <attribute name="backgroundContent" optional="YES" attributeType="String"/>
         <attribute name="foregroundContent" optional="YES" attributeType="String"/>
-        <attribute name="interruptionLevel" attributeType="Integer 16" usesScalarValueType="YES"/>
         <attribute name="issuedDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="managerIdentifier" attributeType="String"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -18,6 +17,6 @@
         </fetchIndex>
     </entity>
     <elements>
-        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="209"/>
+        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="194"/>
     </elements>
 </model>

--- a/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
+++ b/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
@@ -5,7 +5,7 @@
         <attribute name="alertIdentifier" attributeType="String"/>
         <attribute name="backgroundContent" optional="YES" attributeType="String"/>
         <attribute name="foregroundContent" optional="YES" attributeType="String"/>
-        <attribute name="interruptionLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interruptionLevel" attributeType="Integer 16" defaultValueString="2" usesScalarValueType="YES"/>
         <attribute name="issuedDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="managerIdentifier" attributeType="String"/>
         <attribute name="modificationCounter" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
+++ b/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
@@ -106,7 +106,7 @@ extension InAppModalAlertIssuer {
             let alertController = self.constructAlert(title: content.title,
                                                       message: content.body,
                                                       action: content.acknowledgeActionButtonLabel,
-                                                      isCritical: content.interruptionLevel == .critical) { [weak self] in
+                                                      isCritical: alert.interruptionLevel == .critical) { [weak self] in
                 // the completion is called after the alert is acknowledged
                 self?.clearPresentedAlert(identifier: alert.identifier)
                 self?.alertManagerResponder?.acknowledgeAlert(identifier: alert.identifier)

--- a/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
+++ b/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
@@ -106,7 +106,7 @@ extension InAppModalAlertIssuer {
             let alertController = self.constructAlert(title: content.title,
                                                       message: content.body,
                                                       action: content.acknowledgeActionButtonLabel,
-                                                      isCritical: content.isCritical) { [weak self] in
+                                                      isCritical: content.interruptionLevel == .critical) { [weak self] in
                 // the completion is called after the alert is acknowledged
                 self?.clearPresentedAlert(identifier: alert.identifier)
                 self?.alertManagerResponder?.acknowledgeAlert(identifier: alert.identifier)

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
@@ -17,12 +17,12 @@ public class StoredAlert: NSManagedObject {
         get {
             willAccessValue(forKey: "interruptionLevel")
             defer { didAccessValue(forKey: "interruptionLevel") }
-            return (try? Alert.InterruptionLevel(storedValue: primitiveInterruptionLevel)) ?? .timeSensitive
+            return try! Alert.InterruptionLevel(storedValue: primitiveValue(forKey: "interruptionLevel") as! Int16)
         }
         set {
             willChangeValue(forKey: "interruptionLevel")
             defer { didChangeValue(forKey: "interruptionLevel") }
-            primitiveInterruptionLevel = newValue.storedValue
+            setPrimitiveValue(newValue.storedValue, forKey: "interruptionLevel") 
         }
     }
     

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
@@ -17,12 +17,12 @@ public class StoredAlert: NSManagedObject {
         get {
             willAccessValue(forKey: "interruptionLevel")
             defer { didAccessValue(forKey: "interruptionLevel") }
-            return try! Alert.InterruptionLevel(storedValue: primitiveValue(forKey: "interruptionLevel") as! Int16)
+            return Alert.InterruptionLevel(storedValue: primitiveInterruptionLevel)!
         }
         set {
             willChangeValue(forKey: "interruptionLevel")
             defer { didChangeValue(forKey: "interruptionLevel") }
-            setPrimitiveValue(newValue.storedValue, forKey: "interruptionLevel") 
+            primitiveInterruptionLevel = newValue.storedValue
         }
     }
     

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
@@ -9,9 +9,23 @@
 
 import Foundation
 import CoreData
-
+import LoopKit
 
 public class StoredAlert: NSManagedObject {
+    
+    var interruptionLevel: Alert.InterruptionLevel {
+        get {
+            willAccessValue(forKey: "interruptionLevel")
+            defer { didAccessValue(forKey: "interruptionLevel") }
+            return (try? Alert.InterruptionLevel(storedValue: primitiveInterruptionLevel)) ?? .timeSensitive
+        }
+        set {
+            willChangeValue(forKey: "interruptionLevel")
+            defer { didChangeValue(forKey: "interruptionLevel") }
+            primitiveInterruptionLevel = newValue.storedValue
+        }
+    }
+    
     var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
 
     func updateModificationCounter() { setPrimitiveValue(managedObjectContext!.modificationCounter!, forKey: "modificationCounter") }

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -21,6 +21,7 @@ extension StoredAlert {
     @NSManaged public var alertIdentifier: String
     @NSManaged public var backgroundContent: String?
     @NSManaged public var foregroundContent: String?
+    @NSManaged public var primitiveInterruptionLevel: Int16
     @NSManaged public var issuedDate: Date
     @NSManaged public var managerIdentifier: String
     @NSManaged public var modificationCounter: Int64
@@ -45,6 +46,7 @@ extension StoredAlert: Encodable {
         try container.encodeIfPresent(sound, forKey: .sound)
         try container.encodeIfPresent(triggerInterval?.doubleValue, forKey: .triggerInterval)
         try container.encode(triggerType, forKey: .triggerType)
+        try container.encode(interruptionLevel, forKey: .interruptionLevel)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -52,6 +54,7 @@ extension StoredAlert: Encodable {
         case alertIdentifier
         case backgroundContent
         case foregroundContent
+        case interruptionLevel
         case issuedDate
         case managerIdentifier
         case modificationCounter

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -21,7 +21,6 @@ extension StoredAlert {
     @NSManaged public var alertIdentifier: String
     @NSManaged public var backgroundContent: String?
     @NSManaged public var foregroundContent: String?
-    @NSManaged public var primitiveInterruptionLevel: Int16
     @NSManaged public var issuedDate: Date
     @NSManaged public var managerIdentifier: String
     @NSManaged public var modificationCounter: Int64

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -28,7 +28,8 @@ extension StoredAlert {
     @NSManaged public var sound: String?
     @NSManaged public var triggerInterval: NSNumber?
     @NSManaged public var triggerType: Int16
-
+    @NSManaged public var primitiveInterruptionLevel: NSNumber
+    
 }
 
 extension StoredAlert: Encodable {

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -21,7 +21,6 @@ extension StoredAlert {
     @NSManaged public var alertIdentifier: String
     @NSManaged public var backgroundContent: String?
     @NSManaged public var foregroundContent: String?
-    @NSManaged public var interruptionLevel: Int16
     @NSManaged public var issuedDate: Date
     @NSManaged public var managerIdentifier: String
     @NSManaged public var modificationCounter: Int64
@@ -39,7 +38,6 @@ extension StoredAlert: Encodable {
         try container.encode(alertIdentifier, forKey: .alertIdentifier)
         try container.encodeIfPresent(backgroundContent, forKey: .backgroundContent)
         try container.encodeIfPresent(foregroundContent, forKey: .foregroundContent)
-        try container.encode(interruptionLevel, forKey: .interruptionLevel)
         try container.encode(issuedDate, forKey: .issuedDate)
         try container.encode(managerIdentifier, forKey: .managerIdentifier)
         try container.encode(modificationCounter, forKey: .modificationCounter)
@@ -54,7 +52,6 @@ extension StoredAlert: Encodable {
         case alertIdentifier
         case backgroundContent
         case foregroundContent
-        case interruptionLevel
         case issuedDate
         case managerIdentifier
         case modificationCounter

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -21,7 +21,7 @@ extension StoredAlert {
     @NSManaged public var alertIdentifier: String
     @NSManaged public var backgroundContent: String?
     @NSManaged public var foregroundContent: String?
-    @NSManaged public var isCritical: Bool
+    @NSManaged public var interruptionLevel: Int16
     @NSManaged public var issuedDate: Date
     @NSManaged public var managerIdentifier: String
     @NSManaged public var modificationCounter: Int64
@@ -39,7 +39,7 @@ extension StoredAlert: Encodable {
         try container.encode(alertIdentifier, forKey: .alertIdentifier)
         try container.encodeIfPresent(backgroundContent, forKey: .backgroundContent)
         try container.encodeIfPresent(foregroundContent, forKey: .foregroundContent)
-        try container.encode(isCritical, forKey: .isCritical)
+        try container.encode(interruptionLevel, forKey: .interruptionLevel)
         try container.encode(issuedDate, forKey: .issuedDate)
         try container.encode(managerIdentifier, forKey: .managerIdentifier)
         try container.encode(modificationCounter, forKey: .modificationCounter)
@@ -54,7 +54,7 @@ extension StoredAlert: Encodable {
         case alertIdentifier
         case backgroundContent
         case foregroundContent
-        case isCritical
+        case interruptionLevel
         case issuedDate
         case managerIdentifier
         case modificationCounter

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -17,7 +17,9 @@ extension StoredAlert {
           
     convenience init(from alert: Alert, context: NSManagedObjectContext, issuedDate: Date = Date()) {
         do {
-            self.init(context: context)
+            let name = String(describing: type(of: self))
+            let entity = NSEntityDescription.entity(forEntityName: name, in: context)!
+            self.init(entity: entity, insertInto: context)
             self.issuedDate = issuedDate
             alertIdentifier = alert.identifier.alertIdentifier
             managerIdentifier = alert.identifier.managerIdentifier

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -22,7 +22,9 @@ extension StoredAlert {
             managerIdentifier = alert.identifier.managerIdentifier
             triggerType = alert.trigger.storedType
             triggerInterval = alert.trigger.storedInterval
-            isCritical = alert.foregroundContent?.isCritical ?? false || alert.backgroundContent?.isCritical ?? false
+            interruptionLevel = alert.backgroundContent?.interruptionLevel.storedValue ??
+                alert.foregroundContent?.interruptionLevel.storedValue ??
+                Alert.InterruptionLevel.timeSensitive.storedValue
             // Encode as JSON strings
             let encoder = StoredAlert.encoder
             sound = try encoder.encodeToStringIfPresent(alert.sound)
@@ -157,5 +159,32 @@ fileprivate extension JSONEncoder {
             throw JSONEncoderError.stringEncodingError
         }
         return result
+    }
+}
+
+public extension Alert.InterruptionLevel {
+    
+    init?(from: UInt16) {
+        switch from {
+        case 0:
+            self = .active
+        case 1:
+            self = .timeSensitive
+        case 2:
+            self = .critical
+        default:
+            return nil
+        }
+    }
+    
+    var storedValue: Int16 {
+        switch self {
+        case .active:
+            return 0
+        case .timeSensitive:
+            return 1
+        case .critical:
+            return 2
+        }
     }
 }

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -22,9 +22,6 @@ extension StoredAlert {
             managerIdentifier = alert.identifier.managerIdentifier
             triggerType = alert.trigger.storedType
             triggerInterval = alert.trigger.storedInterval
-            interruptionLevel = alert.backgroundContent?.interruptionLevel.storedValue ??
-                alert.foregroundContent?.interruptionLevel.storedValue ??
-                Alert.InterruptionLevel.timeSensitive.storedValue
             // Encode as JSON strings
             let encoder = StoredAlert.encoder
             sound = try encoder.encodeToStringIfPresent(alert.sound)
@@ -159,32 +156,5 @@ fileprivate extension JSONEncoder {
             throw JSONEncoderError.stringEncodingError
         }
         return result
-    }
-}
-
-public extension Alert.InterruptionLevel {
-    
-    init?(from: UInt16) {
-        switch from {
-        case 0:
-            self = .active
-        case 1:
-            self = .timeSensitive
-        case 2:
-            self = .critical
-        default:
-            return nil
-        }
-    }
-    
-    var storedValue: Int16 {
-        switch self {
-        case .active:
-            return 0
-        case .timeSensitive:
-            return 1
-        case .critical:
-            return 2
-        }
     }
 }

--- a/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
@@ -70,7 +70,7 @@ fileprivate extension Alert {
         userNotificationContent.body = content.body
         userNotificationContent.sound = userNotificationSound
         if #available(iOS 15.0, *) {
-            userNotificationContent.interruptionLevel = content.interruptionLevel.userNotificationInterruptLevel
+            userNotificationContent.interruptionLevel = interruptionLevel.userNotificationInterruptLevel
         }
         // TODO: Once we have a final design and approval for custom UserNotification buttons, we'll need to set categoryIdentifier
 //        userNotificationContent.categoryIdentifier = LoopNotificationCategory.alert.rawValue
@@ -97,12 +97,12 @@ fileprivate extension Alert {
             default:
                 if let actualFileName = AlertManager.soundURL(for: self)?.lastPathComponent {
                     let unname = UNNotificationSoundName(rawValue: actualFileName)
-                    return content.interruptionLevel == .critical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
+                    return interruptionLevel == .critical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
                 }
             }
         }
 
-        return content.interruptionLevel == .critical ? .defaultCritical : .default
+        return interruptionLevel == .critical ? .defaultCritical : .default
     }
 }
 

--- a/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
@@ -70,7 +70,7 @@ fileprivate extension Alert {
         userNotificationContent.body = content.body
         userNotificationContent.sound = userNotificationSound
         if #available(iOS 15.0, *) {
-            userNotificationContent.interruptionLevel = backgroundContent?.isCritical == true ? .critical : .timeSensitive
+            userNotificationContent.interruptionLevel = content.interruptionLevel.userNotificationInterruptLevel
         }
         // TODO: Once we have a final design and approval for custom UserNotification buttons, we'll need to set categoryIdentifier
 //        userNotificationContent.categoryIdentifier = LoopNotificationCategory.alert.rawValue
@@ -97,12 +97,26 @@ fileprivate extension Alert {
             default:
                 if let actualFileName = AlertManager.soundURL(for: self)?.lastPathComponent {
                     let unname = UNNotificationSoundName(rawValue: actualFileName)
-                    return content.isCritical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
+                    return content.interruptionLevel == .critical ? UNNotificationSound.criticalSoundNamed(unname) : UNNotificationSound(named: unname)
                 }
             }
         }
 
-        return content.isCritical ? .defaultCritical : .default
+        return content.interruptionLevel == .critical ? .defaultCritical : .default
+    }
+}
+
+fileprivate extension Alert.InterruptionLevel {
+    @available(iOS 15.0, *)
+    var userNotificationInterruptLevel: UNNotificationInterruptionLevel {
+        switch self {
+        case .critical:
+            return .critical
+        case .timeSensitive:
+            return .timeSensitive
+        case .active:
+            return .active
+        }
     }
 }
 

--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -45,14 +45,13 @@ public class LoopAlertsManager {
         let bgBody = NSLocalizedString("Loop will not work successfully until Bluetooth is enabled. You will not receive glucose readings, or be able to bolus.", comment: "Bluetooth off background alert body.")
         let bgcontent = Alert.Content(title: title,
                                       body: bgBody,
-                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"),
-                                      interruptionLevel: .critical)
+                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))
         let fgBody = NSLocalizedString("Turn on Bluetooth to receive alerts, alarms or sensor glucose readings.", comment: "Bluetooth off foreground alert body")
         let fgcontent = Alert.Content(title: title,
                                       body: fgBody,
-                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"),
-                                      interruptionLevel: .critical)
-        alertManager?.issueAlert(Alert(identifier: bluetoothPoweredOffIdentifier, foregroundContent: fgcontent, backgroundContent: bgcontent, trigger: .immediate))
+                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))
+        alertManager?.issueAlert(Alert(identifier: bluetoothPoweredOffIdentifier, foregroundContent: fgcontent, backgroundContent: bgcontent, trigger: .immediate,
+                                       interruptionLevel: .critical))
     }
 
 }

--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -45,11 +45,13 @@ public class LoopAlertsManager {
         let bgBody = NSLocalizedString("Loop will not work successfully until Bluetooth is enabled. You will not receive glucose readings, or be able to bolus.", comment: "Bluetooth off background alert body.")
         let bgcontent = Alert.Content(title: title,
                                       body: bgBody,
-                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))
+                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"),
+                                      interruptionLevel: .critical)
         let fgBody = NSLocalizedString("Turn on Bluetooth to receive alerts, alarms or sensor glucose readings.", comment: "Bluetooth off foreground alert body")
         let fgcontent = Alert.Content(title: title,
                                       body: fgBody,
-                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))
+                                      acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"),
+                                      interruptionLevel: .critical)
         alertManager?.issueAlert(Alert(identifier: bluetoothPoweredOffIdentifier, foregroundContent: fgcontent, backgroundContent: bgcontent, trigger: .immediate))
     }
 

--- a/Loop/Managers/LoopAlertsManager.swift
+++ b/Loop/Managers/LoopAlertsManager.swift
@@ -50,7 +50,10 @@ public class LoopAlertsManager {
         let fgcontent = Alert.Content(title: title,
                                       body: fgBody,
                                       acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))
-        alertManager?.issueAlert(Alert(identifier: bluetoothPoweredOffIdentifier, foregroundContent: fgcontent, backgroundContent: bgcontent, trigger: .immediate,
+        alertManager?.issueAlert(Alert(identifier: bluetoothPoweredOffIdentifier,
+                                       foregroundContent: fgcontent,
+                                       backgroundContent: bgcontent,
+                                       trigger: .immediate,
                                        interruptionLevel: .critical))
     }
 

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -414,12 +414,8 @@ extension LoopAppManager: UNUserNotificationCenterDelegate {
              LoopNotificationCategory.pumpFault.rawValue:
             completionHandler([.badge, .sound, .list, .banner])
         default:
-            if #available(iOS 15.0, *), notification.request.content.interruptionLevel == .critical {
-                completionHandler([.badge, .sound, .list, .banner])
-            } else {
-                // All other userNotifications are not to be displayed while in the foreground
-                completionHandler([])
-            }
+            // All other userNotifications are not to be displayed while in the foreground
+            completionHandler([])
         }
     }
 

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -414,8 +414,12 @@ extension LoopAppManager: UNUserNotificationCenterDelegate {
              LoopNotificationCategory.pumpFault.rawValue:
             completionHandler([.badge, .sound, .list, .banner])
         default:
-            // All other userNotifications are not to be displayed while in the foreground
-            completionHandler([])
+            if #available(iOS 15.0, *), notification.request.content.interruptionLevel == .critical {
+                completionHandler([.badge, .sound, .list, .banner])
+            } else {
+                // All other userNotifications are not to be displayed while in the foreground
+                completionHandler([])
+            }
         }
     }
 

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -22,7 +22,7 @@ class AlertStoreTests: XCTestCase {
     static let identifier1 = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
     let alert1 = Alert(identifier: identifier1, foregroundContent: nil, backgroundContent: nil, trigger: .immediate, sound: nil)
     static let identifier2 = Alert.Identifier(managerIdentifier: "managerIdentifier2", alertIdentifier: "alertIdentifier2")
-    static let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label", isCritical: true)
+    static let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label", interruptionLevel: .critical)
     let alert2 = Alert(identifier: identifier2, foregroundContent: content, backgroundContent: content, trigger: .immediate, sound: .sound(name: "soundName"))
     static let delayedAlertDelay = 30.0 // seconds
     static let delayedAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier3", alertIdentifier: "alertIdentifier3")
@@ -71,10 +71,10 @@ class AlertStoreTests: XCTestCase {
             let object = StoredAlert(from: alert2, context: alertStore.managedObjectContext, issuedDate: Self.historicDate)
             XCTAssertNil(object.acknowledgedDate)
             XCTAssertNil(object.retractedDate)
-            XCTAssertEqual("{\"body\":\"body\",\"isCritical\":true,\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\"}", object.backgroundContent)
-            XCTAssertEqual("{\"body\":\"body\",\"isCritical\":true,\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\"}", object.foregroundContent)
+            XCTAssertEqual("{\"body\":\"body\",\"acknowledgeActionButtonLabel\":\"label\",\"title\":\"title\",\"interruptionLevel\":\"critical\"}", object.backgroundContent)
+            XCTAssertEqual("{\"body\":\"body\",\"acknowledgeActionButtonLabel\":\"label\",\"title\":\"title\",\"interruptionLevel\":\"critical\"}", object.foregroundContent)
             XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier.value)
-            XCTAssertEqual(true, object.isCritical)
+            XCTAssertEqual(2, object.interruptionLevel)
             XCTAssertEqual(Self.historicDate, object.issuedDate)
             XCTAssertEqual(1, object.modificationCounter)
             XCTAssertEqual("{\"sound\":{\"name\":\"soundName\"}}", object.sound)
@@ -760,9 +760,9 @@ class AlertStoreLogCriticalEventLogTests: XCTestCase {
                                        progress: progress))
         XCTAssertEqual(outputStream.string, """
 [
-{"acknowledgedDate":"2100-01-02T03:08:00.000Z","alertIdentifier":"a1","isCritical":false,"issuedDate":"2100-01-02T03:08:00.000Z","managerIdentifier":"m1","modificationCounter":1,"triggerType":0},
-{"acknowledgedDate":"2100-01-02T03:04:00.000Z","alertIdentifier":"a3","isCritical":false,"issuedDate":"2100-01-02T03:04:00.000Z","managerIdentifier":"m3","modificationCounter":3,"triggerType":0},
-{"acknowledgedDate":"2100-01-02T03:06:00.000Z","alertIdentifier":"a4","isCritical":false,"issuedDate":"2100-01-02T03:06:00.000Z","managerIdentifier":"m4","modificationCounter":4,"triggerType":0}
+{"acknowledgedDate":"2100-01-02T03:08:00.000Z","alertIdentifier":"a1","interruptionLevel":1,"issuedDate":"2100-01-02T03:08:00.000Z","managerIdentifier":"m1","modificationCounter":1,"triggerType":0},
+{"acknowledgedDate":"2100-01-02T03:04:00.000Z","alertIdentifier":"a3","interruptionLevel":1,"issuedDate":"2100-01-02T03:04:00.000Z","managerIdentifier":"m3","modificationCounter":3,"triggerType":0},
+{"acknowledgedDate":"2100-01-02T03:06:00.000Z","alertIdentifier":"a4","interruptionLevel":1,"issuedDate":"2100-01-02T03:06:00.000Z","managerIdentifier":"m4","modificationCounter":4,"triggerType":0}
 ]
 """
         )

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -74,7 +74,6 @@ class AlertStoreTests: XCTestCase {
             XCTAssertEqual("{\"body\":\"body\",\"acknowledgeActionButtonLabel\":\"label\",\"title\":\"title\",\"interruptionLevel\":\"critical\"}", object.backgroundContent)
             XCTAssertEqual("{\"body\":\"body\",\"acknowledgeActionButtonLabel\":\"label\",\"title\":\"title\",\"interruptionLevel\":\"critical\"}", object.foregroundContent)
             XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier.value)
-            XCTAssertEqual(2, object.interruptionLevel)
             XCTAssertEqual(Self.historicDate, object.issuedDate)
             XCTAssertEqual(1, object.modificationCounter)
             XCTAssertEqual("{\"sound\":{\"name\":\"soundName\"}}", object.sound)
@@ -760,9 +759,9 @@ class AlertStoreLogCriticalEventLogTests: XCTestCase {
                                        progress: progress))
         XCTAssertEqual(outputStream.string, """
 [
-{"acknowledgedDate":"2100-01-02T03:08:00.000Z","alertIdentifier":"a1","interruptionLevel":1,"issuedDate":"2100-01-02T03:08:00.000Z","managerIdentifier":"m1","modificationCounter":1,"triggerType":0},
-{"acknowledgedDate":"2100-01-02T03:04:00.000Z","alertIdentifier":"a3","interruptionLevel":1,"issuedDate":"2100-01-02T03:04:00.000Z","managerIdentifier":"m3","modificationCounter":3,"triggerType":0},
-{"acknowledgedDate":"2100-01-02T03:06:00.000Z","alertIdentifier":"a4","interruptionLevel":1,"issuedDate":"2100-01-02T03:06:00.000Z","managerIdentifier":"m4","modificationCounter":4,"triggerType":0}
+{"acknowledgedDate":"2100-01-02T03:08:00.000Z","alertIdentifier":"a1","issuedDate":"2100-01-02T03:08:00.000Z","managerIdentifier":"m1","modificationCounter":1,"triggerType":0},
+{"acknowledgedDate":"2100-01-02T03:04:00.000Z","alertIdentifier":"a3","issuedDate":"2100-01-02T03:04:00.000Z","managerIdentifier":"m3","modificationCounter":3,"triggerType":0},
+{"acknowledgedDate":"2100-01-02T03:06:00.000Z","alertIdentifier":"a4","issuedDate":"2100-01-02T03:06:00.000Z","managerIdentifier":"m4","modificationCounter":4,"triggerType":0}
 ]
 """
         )

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -22,8 +22,8 @@ class AlertStoreTests: XCTestCase {
     static let identifier1 = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
     let alert1 = Alert(identifier: identifier1, foregroundContent: nil, backgroundContent: nil, trigger: .immediate, sound: nil)
     static let identifier2 = Alert.Identifier(managerIdentifier: "managerIdentifier2", alertIdentifier: "alertIdentifier2")
-    static let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label", interruptionLevel: .critical)
-    let alert2 = Alert(identifier: identifier2, foregroundContent: content, backgroundContent: content, trigger: .immediate, sound: .sound(name: "soundName"))
+    static let content = Alert.Content(title: "title", body: "body", acknowledgeActionButtonLabel: "label")
+    let alert2 = Alert(identifier: identifier2, foregroundContent: content, backgroundContent: content, trigger: .immediate, interruptionLevel: .critical, sound: .sound(name: "soundName"))
     static let delayedAlertDelay = 30.0 // seconds
     static let delayedAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier3", alertIdentifier: "alertIdentifier3")
     let delayedAlert = Alert(identifier: delayedAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .delayed(interval: delayedAlertDelay), sound: nil)
@@ -71,13 +71,14 @@ class AlertStoreTests: XCTestCase {
             let object = StoredAlert(from: alert2, context: alertStore.managedObjectContext, issuedDate: Self.historicDate)
             XCTAssertNil(object.acknowledgedDate)
             XCTAssertNil(object.retractedDate)
-            XCTAssertEqual("{\"body\":\"body\",\"acknowledgeActionButtonLabel\":\"label\",\"title\":\"title\",\"interruptionLevel\":\"critical\"}", object.backgroundContent)
-            XCTAssertEqual("{\"body\":\"body\",\"acknowledgeActionButtonLabel\":\"label\",\"title\":\"title\",\"interruptionLevel\":\"critical\"}", object.foregroundContent)
+            XCTAssertEqual("{\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\",\"body\":\"body\"}", object.backgroundContent)
+                XCTAssertEqual("{\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\",\"body\":\"body\"}", object.foregroundContent)
             XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier.value)
             XCTAssertEqual(Self.historicDate, object.issuedDate)
             XCTAssertEqual(1, object.modificationCounter)
             XCTAssertEqual("{\"sound\":{\"name\":\"soundName\"}}", object.sound)
             XCTAssertEqual(Alert.Trigger.immediate, object.trigger)
+            XCTAssertEqual(Alert.InterruptionLevel.critical, object.interruptionLevel)
         }
     }
     
@@ -759,9 +760,9 @@ class AlertStoreLogCriticalEventLogTests: XCTestCase {
                                        progress: progress))
         XCTAssertEqual(outputStream.string, """
 [
-{"acknowledgedDate":"2100-01-02T03:08:00.000Z","alertIdentifier":"a1","issuedDate":"2100-01-02T03:08:00.000Z","managerIdentifier":"m1","modificationCounter":1,"triggerType":0},
-{"acknowledgedDate":"2100-01-02T03:04:00.000Z","alertIdentifier":"a3","issuedDate":"2100-01-02T03:04:00.000Z","managerIdentifier":"m3","modificationCounter":3,"triggerType":0},
-{"acknowledgedDate":"2100-01-02T03:06:00.000Z","alertIdentifier":"a4","issuedDate":"2100-01-02T03:06:00.000Z","managerIdentifier":"m4","modificationCounter":4,"triggerType":0}
+{"acknowledgedDate":"2100-01-02T03:08:00.000Z","alertIdentifier":"a1","interruptionLevel":"timeSensitive","issuedDate":"2100-01-02T03:08:00.000Z","managerIdentifier":"m1","modificationCounter":1,"triggerType":0},
+{"acknowledgedDate":"2100-01-02T03:04:00.000Z","alertIdentifier":"a3","interruptionLevel":"timeSensitive","issuedDate":"2100-01-02T03:04:00.000Z","managerIdentifier":"m3","modificationCounter":3,"triggerType":0},
+{"acknowledgedDate":"2100-01-02T03:06:00.000Z","alertIdentifier":"a4","interruptionLevel":"timeSensitive","issuedDate":"2100-01-02T03:06:00.000Z","managerIdentifier":"m4","modificationCounter":4,"triggerType":0}
 ]
 """
         )

--- a/LoopTests/Managers/Alerts/StoredAlertTests.swift
+++ b/LoopTests/Managers/Alerts/StoredAlertTests.swift
@@ -38,6 +38,40 @@ class StoredAlertEncodableTests: XCTestCase {
         super.tearDown()
     }
 
+    func testInterruptionLevel() throws {
+        managedObjectContext.performAndWait {
+            let alert = Alert(identifier: Alert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar"), foregroundContent: nil, backgroundContent: nil, trigger: .immediate, interruptionLevel: .active)
+            let storedAlert = StoredAlert(from: alert, context: managedObjectContext)
+            XCTAssertEqual(.active, storedAlert.interruptionLevel)
+            storedAlert.issuedDate = dateFormatter.date(from: "2020-05-14T21:00:12Z")!
+            try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
+            {
+              "alertIdentifier" : "bar",
+              "interruptionLevel" : "active",
+              "issuedDate" : "2020-05-14T21:00:12Z",
+              "managerIdentifier" : "foo",
+              "modificationCounter" : 1,
+              "triggerType" : 0
+            }
+            """
+            )
+
+            storedAlert.interruptionLevel = .critical
+            XCTAssertEqual(.critical, storedAlert.interruptionLevel)
+            try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
+            {
+              "alertIdentifier" : "bar",
+              "interruptionLevel" : "critical",
+              "issuedDate" : "2020-05-14T21:00:12Z",
+              "managerIdentifier" : "foo",
+              "modificationCounter" : 1,
+              "triggerType" : 0
+            }
+            """
+            )
+        }
+    }
+    
     func testEncodable() throws {
         managedObjectContext.performAndWait {
             let storedAlert = StoredAlert(context: managedObjectContext)
@@ -53,21 +87,21 @@ class StoredAlertEncodableTests: XCTestCase {
             storedAlert.triggerInterval = 900
             storedAlert.triggerType = Alert.Trigger.delayed(interval: .minutes(15)).storedType
             try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
-{
-  "acknowledgedDate" : "2020-05-14T22:38:14Z",
-  "alertIdentifier" : "Alert Identifier 1",
-  "backgroundContent" : "Background Content 1",
-  "foregroundContent" : "Foreground Content 1",
-  "interruptionLevel" : "timeSensitive",
-  "issuedDate" : "2020-05-14T21:00:12Z",
-  "managerIdentifier" : "Manager Identifier 1",
-  "modificationCounter" : 123,
-  "retractedDate" : "2020-05-14T23:34:07Z",
-  "sound" : "Sound 1",
-  "triggerInterval" : 900,
-  "triggerType" : 1
-}
-"""
+            {
+              "acknowledgedDate" : "2020-05-14T22:38:14Z",
+              "alertIdentifier" : "Alert Identifier 1",
+              "backgroundContent" : "Background Content 1",
+              "foregroundContent" : "Foreground Content 1",
+              "interruptionLevel" : "timeSensitive",
+              "issuedDate" : "2020-05-14T21:00:12Z",
+              "managerIdentifier" : "Manager Identifier 1",
+              "modificationCounter" : 123,
+              "retractedDate" : "2020-05-14T23:34:07Z",
+              "sound" : "Sound 1",
+              "triggerInterval" : 900,
+              "triggerType" : 1
+            }
+            """
             )
         }
     }
@@ -81,15 +115,15 @@ class StoredAlertEncodableTests: XCTestCase {
             storedAlert.modificationCounter = 234
             storedAlert.triggerType = Alert.Trigger.immediate.storedType
             try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
-{
-  "alertIdentifier" : "Alert Identifier 2",
-  "interruptionLevel" : "timeSensitive",
-  "issuedDate" : "2020-05-14T21:00:12Z",
-  "managerIdentifier" : "Manager Identifier 2",
-  "modificationCounter" : 234,
-  "triggerType" : 0
-}
-"""
+            {
+              "alertIdentifier" : "Alert Identifier 2",
+              "interruptionLevel" : "timeSensitive",
+              "issuedDate" : "2020-05-14T21:00:12Z",
+              "managerIdentifier" : "Manager Identifier 2",
+              "modificationCounter" : 234,
+              "triggerType" : 0
+            }
+            """
             )
         }
     }

--- a/LoopTests/Managers/Alerts/StoredAlertTests.swift
+++ b/LoopTests/Managers/Alerts/StoredAlertTests.swift
@@ -58,6 +58,7 @@ class StoredAlertEncodableTests: XCTestCase {
   "alertIdentifier" : "Alert Identifier 1",
   "backgroundContent" : "Background Content 1",
   "foregroundContent" : "Foreground Content 1",
+  "interruptionLevel" : "timeSensitive",
   "issuedDate" : "2020-05-14T21:00:12Z",
   "managerIdentifier" : "Manager Identifier 1",
   "modificationCounter" : 123,
@@ -82,6 +83,7 @@ class StoredAlertEncodableTests: XCTestCase {
             try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
 {
   "alertIdentifier" : "Alert Identifier 2",
+  "interruptionLevel" : "timeSensitive",
   "issuedDate" : "2020-05-14T21:00:12Z",
   "managerIdentifier" : "Manager Identifier 2",
   "modificationCounter" : 234,

--- a/LoopTests/Managers/Alerts/StoredAlertTests.swift
+++ b/LoopTests/Managers/Alerts/StoredAlertTests.swift
@@ -45,7 +45,6 @@ class StoredAlertEncodableTests: XCTestCase {
             storedAlert.alertIdentifier = "Alert Identifier 1"
             storedAlert.backgroundContent = "Background Content 1"
             storedAlert.foregroundContent = "Foreground Content 1"
-            storedAlert.interruptionLevel = 1
             storedAlert.issuedDate = dateFormatter.date(from: "2020-05-14T21:00:12Z")!
             storedAlert.managerIdentifier = "Manager Identifier 1"
             storedAlert.modificationCounter = 123
@@ -59,7 +58,6 @@ class StoredAlertEncodableTests: XCTestCase {
   "alertIdentifier" : "Alert Identifier 1",
   "backgroundContent" : "Background Content 1",
   "foregroundContent" : "Foreground Content 1",
-  "interruptionLevel" : 1,
   "issuedDate" : "2020-05-14T21:00:12Z",
   "managerIdentifier" : "Manager Identifier 1",
   "modificationCounter" : 123,
@@ -77,7 +75,6 @@ class StoredAlertEncodableTests: XCTestCase {
         managedObjectContext.performAndWait {
             let storedAlert = StoredAlert(context: managedObjectContext)
             storedAlert.alertIdentifier = "Alert Identifier 2"
-            storedAlert.interruptionLevel = Alert.InterruptionLevel.timeSensitive.storedValue
             storedAlert.issuedDate = dateFormatter.date(from: "2020-05-14T21:00:12Z")!
             storedAlert.managerIdentifier = "Manager Identifier 2"
             storedAlert.modificationCounter = 234
@@ -85,7 +82,6 @@ class StoredAlertEncodableTests: XCTestCase {
             try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
 {
   "alertIdentifier" : "Alert Identifier 2",
-  "interruptionLevel" : 1,
   "issuedDate" : "2020-05-14T21:00:12Z",
   "managerIdentifier" : "Manager Identifier 2",
   "modificationCounter" : 234,

--- a/LoopTests/Managers/Alerts/StoredAlertTests.swift
+++ b/LoopTests/Managers/Alerts/StoredAlertTests.swift
@@ -45,7 +45,7 @@ class StoredAlertEncodableTests: XCTestCase {
             storedAlert.alertIdentifier = "Alert Identifier 1"
             storedAlert.backgroundContent = "Background Content 1"
             storedAlert.foregroundContent = "Foreground Content 1"
-            storedAlert.isCritical = false
+            storedAlert.interruptionLevel = 1
             storedAlert.issuedDate = dateFormatter.date(from: "2020-05-14T21:00:12Z")!
             storedAlert.managerIdentifier = "Manager Identifier 1"
             storedAlert.modificationCounter = 123
@@ -59,7 +59,7 @@ class StoredAlertEncodableTests: XCTestCase {
   "alertIdentifier" : "Alert Identifier 1",
   "backgroundContent" : "Background Content 1",
   "foregroundContent" : "Foreground Content 1",
-  "isCritical" : false,
+  "interruptionLevel" : 1,
   "issuedDate" : "2020-05-14T21:00:12Z",
   "managerIdentifier" : "Manager Identifier 1",
   "modificationCounter" : 123,
@@ -77,7 +77,7 @@ class StoredAlertEncodableTests: XCTestCase {
         managedObjectContext.performAndWait {
             let storedAlert = StoredAlert(context: managedObjectContext)
             storedAlert.alertIdentifier = "Alert Identifier 2"
-            storedAlert.isCritical = false
+            storedAlert.interruptionLevel = Alert.InterruptionLevel.timeSensitive.storedValue
             storedAlert.issuedDate = dateFormatter.date(from: "2020-05-14T21:00:12Z")!
             storedAlert.managerIdentifier = "Manager Identifier 2"
             storedAlert.modificationCounter = 234
@@ -85,7 +85,7 @@ class StoredAlertEncodableTests: XCTestCase {
             try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
 {
   "alertIdentifier" : "Alert Identifier 2",
-  "isCritical" : false,
+  "interruptionLevel" : 1,
   "issuedDate" : "2020-05-14T21:00:12Z",
   "managerIdentifier" : "Manager Identifier 2",
   "modificationCounter" : 234,
@@ -96,9 +96,9 @@ class StoredAlertEncodableTests: XCTestCase {
         }
     }
 
-    private func assertStoredAlertEncodable(_ original: StoredAlert, encodesJSON string: String) throws {
+    private func assertStoredAlertEncodable(_ original: StoredAlert, encodesJSON string: String, file: StaticString = #file, line: UInt = #line) throws {
         let data = try encoder.encode(original)
-        XCTAssertEqual(String(data: data, encoding: .utf8), string)
+        XCTAssertEqual(String(data: data, encoding: .utf8), string, file: file, line: line)
     }
 
     private let dateFormatter = ISO8601DateFormatter()

--- a/LoopTests/Managers/Alerts/UserNotificationAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/UserNotificationAlertIssuerTests.swift
@@ -47,8 +47,8 @@ class UserNotificationAlertIssuerTests: XCTestCase {
     }
     
     func testIssueImmediateCriticalAlert() {
-        let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", interruptionLevel: .critical)
-        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
+        let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate, interruptionLevel: .critical)
         userNotificationAlertIssuer.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()

--- a/LoopTests/Managers/Alerts/UserNotificationAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/UserNotificationAlertIssuerTests.swift
@@ -47,7 +47,7 @@ class UserNotificationAlertIssuerTests: XCTestCase {
     }
     
     func testIssueImmediateCriticalAlert() {
-        let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", isCritical: true)
+        let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "", interruptionLevel: .critical)
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .immediate)
         userNotificationAlertIssuer.issueAlert(alert, timestamp: Date.distantPast)
 

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -431,10 +431,12 @@ class LoopDataManagerDosingTests: XCTestCase {
         let expectedAutomaticDoseRecommendation = AutomaticDoseRecommendation(basalAdjustment: TempBasalRecommendation(unitsPerHour: 4.577747629410191, duration: .minutes(30)))
         XCTAssertEqual(delegate.recommendation, expectedAutomaticDoseRecommendation)
         XCTAssertEqual(dosingDecisionStore.dosingDecisions.count, 1)
-        XCTAssertEqual(dosingDecisionStore.dosingDecisions[0].reason, "loop")
-        XCTAssertEqual(dosingDecisionStore.dosingDecisions[0].automaticDoseRecommendation, expectedAutomaticDoseRecommendation)
-        XCTAssertNil(dosingDecisionStore.dosingDecisions[0].manualBolusRecommendation)
-        XCTAssertNil(dosingDecisionStore.dosingDecisions[0].manualBolusRequested)
+        if dosingDecisionStore.dosingDecisions.count == 1 {
+            XCTAssertEqual(dosingDecisionStore.dosingDecisions[0].reason, "loop")
+            XCTAssertEqual(dosingDecisionStore.dosingDecisions[0].automaticDoseRecommendation, expectedAutomaticDoseRecommendation)
+            XCTAssertNil(dosingDecisionStore.dosingDecisions[0].manualBolusRecommendation)
+            XCTAssertNil(dosingDecisionStore.dosingDecisions[0].manualBolusRequested)
+        }
         NotificationCenter.default.removeObserver(observer)
     }
 


### PR DESCRIPTION
This introduces the notion of three Alert "interruption levels" similar to iOS's
UNNotificationInterruptionLevel (https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel)
as a replacement of the `isCritical` flag.

https://tidepool.atlassian.net/browse/LOOP-3973

LWPR: https://github.com/tidepool-org/LoopWorkspace/pull/734