### PR TITLE
LOOP-4067: Remove the battery low alert from DeviceDataManager

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -773,7 +773,7 @@ extension DeviceDataManager: DeviceManagerDelegate {
     }
 }
 
-// MARK: - UserAlertHandler
+// MARK: - AlertIssuer
 extension DeviceDataManager: AlertIssuer {
     static let managerIdentifier = "DeviceDataManager"
 
@@ -783,22 +783,6 @@ extension DeviceDataManager: AlertIssuer {
 
     func retractAlert(identifier: Alert.Identifier) {
         alertManager?.retractAlert(identifier: identifier)
-    }
-
-    static var pumpBatteryLowAlertIdentifier: Alert.Identifier {
-        return Alert.Identifier(managerIdentifier: managerIdentifier, alertIdentifier: "PumpBatteryLow")
-    }
-
-    public var pumpBatteryLowAlert: Alert {
-        let title = NSLocalizedString("Pump Battery Low", comment: "The notification title for a low pump battery")
-        let body = NSLocalizedString("Change the pump battery immediately", comment: "The notification alert describing a low pump battery")
-        let content = Alert.Content(title: title,
-                                    body: body,
-                                    acknowledgeActionButtonLabel: NSLocalizedString("Dismiss", comment: "Default alert dismissal"))
-        return Alert(identifier: DeviceDataManager.pumpBatteryLowAlertIdentifier,
-                     foregroundContent: content,
-                     backgroundContent: content,
-                     trigger: .immediate)
     }
 }
 
@@ -961,19 +945,11 @@ extension DeviceDataManager: PumpManagerDelegate {
         log.default("PumpManager:%{public}@ did update status: %{public}@", String(describing: type(of: pumpManager)), String(describing: status))
 
         doseStore.device = status.device
-
-        if let newBatteryValue = status.pumpBatteryChargeRemaining {
-
-            if newBatteryValue != oldStatus.pumpBatteryChargeRemaining,
-               newBatteryValue == 0
-            {
-                issueAlert(pumpBatteryLowAlert)
-            }
-
-            if let oldBatteryValue = oldStatus.pumpBatteryChargeRemaining, newBatteryValue - oldBatteryValue >= LoopConstants.batteryReplacementDetectionThreshold {
-                retractAlert(identifier: DeviceDataManager.pumpBatteryLowAlertIdentifier)
-                analyticsServicesManager.pumpBatteryWasReplaced()
-            }
+        
+        if let newBatteryValue = status.pumpBatteryChargeRemaining,
+           let oldBatteryValue = oldStatus.pumpBatteryChargeRemaining,
+           newBatteryValue - oldBatteryValue >= LoopConstants.batteryReplacementDetectionThreshold {
+            analyticsServicesManager.pumpBatteryWasReplaced()
         }
 
         if status.basalDeliveryState != oldStatus.basalDeliveryState {


### PR DESCRIPTION
This responsibility belongs to the PumpManagers.

https://tidepool.atlassian.net/browse/LOOP-4067

Also see https://github.com/tidepool-org/rileylink_ios/pull/60 for the behavior that moved into that pump plugin.