### PR TITLE
COASTAL-460: Adds Alert.Trigger.nextDate and .nextDateRepeating functionality

### DIFF
--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -119,7 +119,7 @@ public class AlertStore {
                                 if let delay = $0.trigger.interval, $0.issuedDate + delay >= date {
                                     return .delete
                                 } else if let matching = $0.trigger.matching,
-                                          let nextDate = Calendar.current.nextDate(after: $0.issuedDate, matching: matching, matchingPolicy: .nextTime),
+                                          let nextDate = Calendar.current.nextDate(after: $0.issuedDate, matching: matching.dateComponents, matchingPolicy: .nextTime),
                                           nextDate >= date {
                                     return .delete
                                 } else {
@@ -442,7 +442,7 @@ extension Alert.Trigger {
         case .immediate, .nextDate, .nextDateRepeating: return nil
         }
     }
-    var matching: DateComponents? {
+    var matching: TimeSpec? {
         switch self {
         case .delayed, .repeating, .immediate: return nil
         case .nextDate(let matching), .nextDateRepeating(let matching): return matching

--- a/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
+++ b/Loop/Managers/Alerts/AlertStore.xcdatamodeld/AlertStore.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21D49" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21D62" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="StoredAlert" representedClassName=".StoredAlert" syncable="YES">
         <attribute name="acknowledgedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="alertIdentifier" attributeType="String"/>
@@ -13,6 +13,7 @@
         <attribute name="retractedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="sound" optional="YES" attributeType="String"/>
         <attribute name="syncIdentifier" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="triggerDateMatching" optional="YES" attributeType="Binary"/>
         <attribute name="triggerInterval" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
         <attribute name="triggerType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <fetchIndex name="byModificationCounter">
@@ -20,6 +21,6 @@
         </fetchIndex>
     </entity>
     <elements>
-        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="239"/>
+        <element name="StoredAlert" positionX="-63" positionY="-18" width="128" height="254"/>
     </elements>
 </model>

--- a/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
+++ b/Loop/Managers/Alerts/InAppModalAlertIssuer.swift
@@ -77,12 +77,12 @@ public class InAppModalAlertIssuer: AlertIssuer {
             }
         case .nextDate(let matching):
             schedule(alert: alert, repeats: false) { [weak self] in
-                self?.newTimerAtNextDateMatchingFunc(matching, $0, $1)
+                self?.newTimerAtNextDateMatchingFunc(matching.dateComponents, $0, $1)
             }
             break
         case .nextDateRepeating(let matching):
             schedule(alert: alert, repeats: true) { [weak self] in
-                self?.newTimerAtNextDateMatchingFunc(matching, $0, $1)
+                self?.newTimerAtNextDateMatchingFunc(matching.dateComponents, $0, $1)
             }
             break
         }

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
@@ -25,6 +25,19 @@ public class StoredAlert: NSManagedObject {
             primitiveInterruptionLevel = newValue.storedValue
         }
     }
+      
+    var triggerDateMatching: DateComponents? {
+        get {
+            willAccessValue(forKey: "triggerDateMatching")
+            defer { didAccessValue(forKey: "triggerDateMatching") }
+            return primitiveTriggerDateMatching.map { try! Self.decoder.decode(DateComponents.self, from: $0) }
+        }
+        set {
+            willChangeValue(forKey: "triggerDateMatching")
+            defer { didChangeValue(forKey: "triggerDateMatching") }
+            primitiveTriggerDateMatching = newValue.map { try! Self.encoder.encode($0) }
+        }
+    }
     
     var hasUpdatedModificationCounter: Bool { changedValues().keys.contains("modificationCounter") }
 
@@ -40,5 +53,44 @@ public class StoredAlert: NSManagedObject {
             updateModificationCounter()
         }
         super.willSave()
+    }
+}
+
+extension StoredAlert: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(acknowledgedDate, forKey: .acknowledgedDate)
+        try container.encode(alertIdentifier, forKey: .alertIdentifier)
+        try container.encodeIfPresent(backgroundContent, forKey: .backgroundContent)
+        try container.encodeIfPresent(foregroundContent, forKey: .foregroundContent)
+        try container.encode(interruptionLevel, forKey: .interruptionLevel)
+        try container.encode(issuedDate, forKey: .issuedDate)
+        try container.encode(managerIdentifier, forKey: .managerIdentifier)
+        try container.encodeIfPresent(metadata, forKey: .metadata)
+        try container.encode(modificationCounter, forKey: .modificationCounter)
+        try container.encodeIfPresent(retractedDate, forKey: .retractedDate)
+        try container.encodeIfPresent(sound, forKey: .sound)
+        try container.encodeIfPresent(syncIdentifier, forKey: .syncIdentifier)
+        try container.encodeIfPresent(triggerInterval?.doubleValue, forKey: .triggerInterval)
+        try container.encodeIfPresent(triggerDateMatching, forKey: .triggerDateMatching)
+        try container.encode(triggerType, forKey: .triggerType)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case acknowledgedDate
+        case alertIdentifier
+        case backgroundContent
+        case foregroundContent
+        case interruptionLevel
+        case issuedDate
+        case managerIdentifier
+        case metadata
+        case modificationCounter
+        case retractedDate
+        case sound
+        case syncIdentifier
+        case triggerInterval
+        case triggerDateMatching
+        case triggerType
     }
 }

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataClass.swift
@@ -26,11 +26,11 @@ public class StoredAlert: NSManagedObject {
         }
     }
       
-    var triggerDateMatching: DateComponents? {
+    var triggerDateMatching: Alert.Trigger.TimeSpec? {
         get {
             willAccessValue(forKey: "triggerDateMatching")
             defer { didAccessValue(forKey: "triggerDateMatching") }
-            return primitiveTriggerDateMatching.map { try! Self.decoder.decode(DateComponents.self, from: $0) }
+            return primitiveTriggerDateMatching.map { try! Self.decoder.decode( Alert.Trigger.TimeSpec.self, from: $0) }
         }
         set {
             willChangeValue(forKey: "triggerDateMatching")

--- a/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
+++ b/Loop/Managers/Alerts/StoredAlert+CoreDataProperties.swift
@@ -21,7 +21,7 @@ extension StoredAlert {
     @NSManaged public var alertIdentifier: String
     @NSManaged public var backgroundContent: String?
     @NSManaged public var foregroundContent: String?
-    @NSManaged public var primitiveInterruptionLevel: NSNumber
+    @NSManaged var primitiveInterruptionLevel: NSNumber
     @NSManaged public var issuedDate: Date
     @NSManaged public var managerIdentifier: String
     @NSManaged public var metadata: String?
@@ -30,43 +30,7 @@ extension StoredAlert {
     @NSManaged public var sound: String?
     @NSManaged public var syncIdentifier: UUID?
     @NSManaged public var triggerInterval: NSNumber?
+    @NSManaged var primitiveTriggerDateMatching: Data?
     @NSManaged public var triggerType: Int16
     
-}
-
-extension StoredAlert: Encodable {
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(acknowledgedDate, forKey: .acknowledgedDate)
-        try container.encode(alertIdentifier, forKey: .alertIdentifier)
-        try container.encodeIfPresent(backgroundContent, forKey: .backgroundContent)
-        try container.encodeIfPresent(foregroundContent, forKey: .foregroundContent)
-        try container.encode(interruptionLevel, forKey: .interruptionLevel)
-        try container.encode(issuedDate, forKey: .issuedDate)
-        try container.encode(managerIdentifier, forKey: .managerIdentifier)
-        try container.encodeIfPresent(metadata, forKey: .metadata)
-        try container.encode(modificationCounter, forKey: .modificationCounter)
-        try container.encodeIfPresent(retractedDate, forKey: .retractedDate)
-        try container.encodeIfPresent(sound, forKey: .sound)
-        try container.encodeIfPresent(syncIdentifier, forKey: .syncIdentifier)
-        try container.encodeIfPresent(triggerInterval?.doubleValue, forKey: .triggerInterval)
-        try container.encode(triggerType, forKey: .triggerType)
-    }
-
-    private enum CodingKeys: String, CodingKey {
-        case acknowledgedDate
-        case alertIdentifier
-        case backgroundContent
-        case foregroundContent
-        case interruptionLevel
-        case issuedDate
-        case managerIdentifier
-        case metadata
-        case modificationCounter
-        case retractedDate
-        case sound
-        case syncIdentifier
-        case triggerInterval
-        case triggerType
-    }
 }

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -139,7 +139,7 @@ extension Alert.Trigger {
         }
     }
     
-    var storedDateMatching: DateComponents? {
+    var storedDateMatching: TimeSpec? {
         switch self {
         case .immediate, .delayed, .repeating: return nil
         case .nextDate(let matching): return matching
@@ -147,7 +147,7 @@ extension Alert.Trigger {
         }
     }
 
-    init(storedType: Int16, storedInterval: NSNumber?, storedDateMatching: DateComponents?, storageDate: Date? = nil, now: Date = Date()) throws {
+    init(storedType: Int16, storedInterval: NSNumber?, storedDateMatching: TimeSpec?, storageDate: Date? = nil, now: Date = Date()) throws {
         switch storedType {
         case 0: self = .immediate
         case 1:
@@ -177,7 +177,7 @@ extension Alert.Trigger {
         case 3:
             if let storedDateMatching = storedDateMatching {
                 if let storageDate = storageDate,
-                   let nextDate = Calendar.current.nextDate(after: storageDate, matching: storedDateMatching, matchingPolicy: .nextTime),
+                   let nextDate = Calendar.current.nextDate(after: storageDate, matching: storedDateMatching.dateComponents, matchingPolicy: .nextTime),
                    // Interesting case here, and I'm not exactly sure what to do.
                    // If the "next matching date" after storage date is in the past, that means we've past the time when the alert should have shown
                     // So... make it .immediate?? (TODO: Or, maybe we should throw an error?  Not clear...)

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -178,9 +178,6 @@ extension Alert.Trigger {
             if let storedDateMatching = storedDateMatching {
                 if let storageDate = storageDate,
                    let nextDate = Calendar.current.nextDate(after: storageDate, matching: storedDateMatching.dateComponents, matchingPolicy: .nextTime),
-                   // Interesting case here, and I'm not exactly sure what to do.
-                   // If the "next matching date" after storage date is in the past, that means we've past the time when the alert should have shown
-                    // So... make it .immediate?? (TODO: Or, maybe we should throw an error?  Not clear...)
                    now > nextDate
                 {
                     self = .immediate

--- a/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
@@ -83,7 +83,7 @@ fileprivate extension Alert {
     }
     
     private var userNotificationSound: UNNotificationSound? {
-        guard let content = backgroundContent else {
+        guard backgroundContent != nil else {
             return nil
         }
         if let sound = sound {
@@ -125,19 +125,23 @@ fileprivate extension UNNotificationRequest {
         let content = try alert.getUserNotificationContent(timestamp: timestamp)
         self.init(identifier: alert.identifier.value,
                   content: content,
-                  trigger: UNTimeIntervalNotificationTrigger(from: alert.trigger))
+                  trigger: UNNotificationTrigger.create(from: alert.trigger))
     }
 }
 
-fileprivate extension UNTimeIntervalNotificationTrigger {
-    convenience init?(from alertTrigger: Alert.Trigger) {
+fileprivate extension UNNotificationTrigger {
+    static func create(from alertTrigger: Alert.Trigger) -> UNNotificationTrigger? {
         switch alertTrigger {
         case .immediate:
             return nil
         case .delayed(let timeInterval):
-            self.init(timeInterval: timeInterval, repeats: false)
+            return UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
         case .repeating(let repeatInterval):
-            self.init(timeInterval: repeatInterval, repeats: true)
+            return UNTimeIntervalNotificationTrigger(timeInterval: repeatInterval, repeats: true)
+        case .nextDate(let matching):
+            return UNCalendarNotificationTrigger(dateMatching: matching, repeats: false)
+        case .nextDateRepeating(let matching):
+            return UNCalendarNotificationTrigger(dateMatching: matching, repeats: true)
         }
     }
 }

--- a/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertIssuer.swift
@@ -139,9 +139,9 @@ fileprivate extension UNNotificationTrigger {
         case .repeating(let repeatInterval):
             return UNTimeIntervalNotificationTrigger(timeInterval: repeatInterval, repeats: true)
         case .nextDate(let matching):
-            return UNCalendarNotificationTrigger(dateMatching: matching, repeats: false)
+            return UNCalendarNotificationTrigger(dateMatching: matching.dateComponents, repeats: false)
         case .nextDateRepeating(let matching):
-            return UNCalendarNotificationTrigger(dateMatching: matching, repeats: true)
+            return UNCalendarNotificationTrigger(dateMatching: matching.dateComponents, repeats: true)
         }
     }
 }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -30,6 +30,12 @@ class AlertStoreTests: XCTestCase {
     static let repeatingAlertDelay = 30.0 // seconds
     static let repeatingAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier4", alertIdentifier: "alertIdentifier4")
     let repeatingAlert = Alert(identifier: repeatingAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .repeating(repeatInterval: repeatingAlertDelay), sound: nil)
+    static let matching = DateComponents(hour: 1, minute: 2)
+    static let dateMatchingAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier5", alertIdentifier: "alertIdentifier5")
+    let dateMatchingAlert = Alert(identifier: dateMatchingAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .nextDate(matching: matching), sound: nil)
+    static let repeatMatching = DateComponents(hour: 3, minute: 4)
+    static let dateMatchingAlertRepeatingIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier6", alertIdentifier: "alertIdentifier6")
+    let dateMatchingAlertRepeating = Alert(identifier: dateMatchingAlertRepeatingIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .nextDateRepeating(matching: repeatMatching), sound: nil)
 
     override func setUp() {
         alertStore = AlertStore(expireAfter: Self.expiryInterval)
@@ -43,9 +49,13 @@ class AlertStoreTests: XCTestCase {
         let immediate = Alert.Trigger.immediate
         let delayed = Alert.Trigger.delayed(interval: 1.0)
         let repeating = Alert.Trigger.repeating(repeatInterval: 2.0)
-        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval))
-        XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval))
-        XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval))
+        let matching = Alert.Trigger.nextDate(matching: DateComponents(hour: 1, minute: 2))
+        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: DateComponents(hour: 3, minute: 4))
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching))
+        XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching))
+        XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval, storedDateMatching: repeating.storedDateMatching))
+        XCTAssertEqual(matching, try? Alert.Trigger(storedType: matching.storedType, storedInterval: matching.storedInterval, storedDateMatching: matching.storedDateMatching))
+        XCTAssertEqual(matchingRepeating, try? Alert.Trigger(storedType: matchingRepeating.storedType, storedInterval: matchingRepeating.storedInterval, storedDateMatching: matchingRepeating.storedDateMatching))
         XCTAssertNil(immediate.storedInterval)
     }
     
@@ -53,17 +63,28 @@ class AlertStoreTests: XCTestCase {
         let immediate = Alert.Trigger.immediate
         let delayed = Alert.Trigger.delayed(interval: 10.0)
         let repeating = Alert.Trigger.repeating(repeatInterval: 20.0)
-        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storageDate: Self.historicDate))
-        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storageDate: Self.historicDate))
-        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storageDate: Date(timeIntervalSinceNow: -10.0.nextUp)))
-        XCTAssertEqual(Alert.Trigger.delayed(interval: 10.0), try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storageDate: Date(timeIntervalSinceNow: 5.0)))
-        let adjustedTrigger = try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storageDate: Date(timeIntervalSinceNow: -5.0))
+        let matching = Alert.Trigger.nextDate(matching: DateComponents(hour: 1, minute: 2))
+        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: DateComponents(hour: 3, minute: 4))
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching))
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching, storageDate: Self.historicDate))
+        XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching))
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching, storageDate: Self.historicDate))
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching, storageDate: Date(timeIntervalSinceNow: -10.0.nextUp)))
+        XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching, storageDate: Date(timeIntervalSinceNow: 5.0)))
+        let adjustedTrigger = try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching, storageDate: Date(timeIntervalSinceNow: -5.0))
         switch adjustedTrigger {
         case .delayed(let interval): XCTAssertLessThanOrEqual(interval, 5.0) // The new delay interval value may be close to, but no more than 5, but not exact
         default: XCTFail("Wrong trigger")
         }
-        XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval, storageDate: Self.historicDate))
+        XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval, storedDateMatching: repeating.storedDateMatching))
+        XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval, storedDateMatching: repeating.storedDateMatching, storageDate: Self.historicDate))
         XCTAssertNil(immediate.storedInterval)
+        XCTAssertEqual(matchingRepeating, try? Alert.Trigger(storedType: matchingRepeating.storedType, storedInterval: matchingRepeating.storedInterval, storedDateMatching: matchingRepeating.storedDateMatching))
+        XCTAssertEqual(matchingRepeating, try? Alert.Trigger(storedType: matchingRepeating.storedType, storedInterval: matchingRepeating.storedInterval, storedDateMatching: matchingRepeating.storedDateMatching, storageDate: Self.historicDate))
+        // An "expired" next matching alert become "immediate"
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: matching.storedType, storedInterval: matching.storedInterval, storedDateMatching: matching.storedDateMatching, storageDate: Self.historicDate))
+        // An "unexpired" next matching alert is "preserved"
+        XCTAssertEqual(matching, try? Alert.Trigger(storedType: matching.storedType, storedInterval: matching.storedInterval, storedDateMatching: matching.storedDateMatching, storageDate: Date(timeIntervalSinceNow: -5.0)))
     }
     
     func testStoredAlertSerialization() {
@@ -72,7 +93,7 @@ class AlertStoreTests: XCTestCase {
             XCTAssertNil(object.acknowledgedDate)
             XCTAssertNil(object.retractedDate)
             XCTAssertEqual("{\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\",\"body\":\"body\"}", object.backgroundContent)
-                XCTAssertEqual("{\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\",\"body\":\"body\"}", object.foregroundContent)
+            XCTAssertEqual("{\"title\":\"title\",\"acknowledgeActionButtonLabel\":\"label\",\"body\":\"body\"}", object.foregroundContent)
             XCTAssertEqual("managerIdentifier2.alertIdentifier2", object.identifier.value)
             XCTAssertEqual(Self.historicDate, object.issuedDate)
             XCTAssertEqual(1, object.modificationCounter)
@@ -223,6 +244,36 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
+    func testRecordRetractedBeforeDateMatchingShouldDelete() throws {
+        let expect = self.expectation(description: #function)
+        let issuedDate = Self.historicDate
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(-(.minutes(1))))
+        alertStore.recordIssued(alert: dateMatchingAlert, at: issuedDate, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.dateMatchingAlertIdentifier, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.dateMatchingAlertIdentifier, completion: self.expectSuccess { storedAlerts in
+                    XCTAssertEqual(0, storedAlerts.count)
+                    expect.fulfill()
+                })
+            })
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    func testRecordRetractedBeforeRepeatDateMatchingShouldDelete() throws {
+        let expect = self.expectation(description: #function)
+        let issuedDate = Self.historicDate
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(-(.minutes(1))))
+        alertStore.recordIssued(alert: dateMatchingAlertRepeating, at: issuedDate, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.dateMatchingAlertRepeatingIdentifier, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.dateMatchingAlertRepeatingIdentifier, completion: self.expectSuccess { storedAlerts in
+                    XCTAssertEqual(0, storedAlerts.count)
+                    expect.fulfill()
+                })
+            })
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
     func testRecordRetractedExactlyAtDelayShouldDelete() {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
@@ -253,7 +304,36 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
-
+    func testRecordRetractedExactlyAtDateMatchingShouldDelete() throws {
+        let expect = self.expectation(description: #function)
+        let issuedDate = Self.historicDate
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching), matchingPolicy: .nextTime))
+        alertStore.recordIssued(alert: dateMatchingAlert, at: issuedDate, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.dateMatchingAlertIdentifier, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.dateMatchingAlertIdentifier, completion: self.expectSuccess { storedAlerts in
+                    XCTAssertEqual(0, storedAlerts.count)
+                    expect.fulfill()
+                })
+            })
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    func testRecordRetractedExactlyAtRepeatDateMatchingShouldDelete() throws {
+        let expect = self.expectation(description: #function)
+        let issuedDate = Self.historicDate
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching), matchingPolicy: .nextTime))
+        alertStore.recordIssued(alert: dateMatchingAlertRepeating, at: issuedDate, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.dateMatchingAlertRepeatingIdentifier, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.dateMatchingAlertRepeatingIdentifier, completion: self.expectSuccess { storedAlerts in
+                    XCTAssertEqual(0, storedAlerts.count)
+                    expect.fulfill()
+                })
+            })
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
     func testRecordRetractedAfterDelayShouldRetract() {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
@@ -273,6 +353,45 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
+    func testRecordRetractedAfterDateMatchingShouldRetract() throws {
+        let expect = self.expectation(description: #function)
+        let issuedDate = Self.historicDate
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(.minutes(1)))
+        alertStore.recordIssued(alert: dateMatchingAlert, at: issuedDate, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.dateMatchingAlertIdentifier, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.dateMatchingAlertIdentifier, completion: self.expectSuccess { storedAlerts in
+                    XCTAssertEqual(1, storedAlerts.count)
+                    XCTAssertEqual(Self.dateMatchingAlertIdentifier, storedAlerts.first?.identifier)
+                    XCTAssertEqual(issuedDate, storedAlerts.first?.issuedDate)
+                    XCTAssertEqual(retractedDate, storedAlerts.first?.retractedDate)
+                    XCTAssertNil(storedAlerts.first?.acknowledgedDate)
+                    expect.fulfill()
+                })
+            })
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    func testRecordRetractedAfterRepeatDateMatchingShouldRetract() throws {
+        let expect = self.expectation(description: #function)
+        let issuedDate = Self.historicDate
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(.minutes(1)))
+        alertStore.recordIssued(alert: dateMatchingAlertRepeating, at: issuedDate, completion: self.expectSuccess {
+            self.alertStore.recordRetraction(of: Self.dateMatchingAlertRepeatingIdentifier, at: retractedDate, completion: self.expectSuccess {
+                self.alertStore.fetch(identifier: Self.dateMatchingAlertRepeatingIdentifier, completion: self.expectSuccess { storedAlerts in
+                    XCTAssertEqual(1, storedAlerts.count)
+                    XCTAssertEqual(Self.dateMatchingAlertRepeatingIdentifier, storedAlerts.first?.identifier)
+                    XCTAssertEqual(issuedDate, storedAlerts.first?.issuedDate)
+                    XCTAssertEqual(retractedDate, storedAlerts.first?.retractedDate)
+                    XCTAssertNil(storedAlerts.first?.acknowledgedDate)
+                    expect.fulfill()
+                })
+            })
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+
     func testRecordRetractedAfterRepeatDelayShouldRetract() {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
@@ -291,6 +410,7 @@ class AlertStoreTests: XCTestCase {
         })
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
+    
     
     // These next two tests are admittedly weird corner cases, but theoretically they might be race conditions,
     // and so are allowed

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -18,6 +18,7 @@ class AlertStoreTests: XCTestCase {
     static let defaultTimeout: TimeInterval = 1.5
     static let expiryInterval: TimeInterval = 24 /* hours */ * 60 /* minutes */ * 60 /* seconds */
     static let historicDate = Date(timeIntervalSinceNow: -expiryInterval + TimeInterval.hours(4))  // Within default 24 hour expiration
+    static let longTimeAgo = Date().addingTimeInterval(.days(-30))
     
     static let identifier1 = Alert.Identifier(managerIdentifier: "managerIdentifier1", alertIdentifier: "alertIdentifier1")
     let alert1 = Alert(identifier: identifier1, foregroundContent: nil, backgroundContent: nil, trigger: .immediate, sound: nil)
@@ -82,7 +83,7 @@ class AlertStoreTests: XCTestCase {
         XCTAssertEqual(matchingRepeating, try? Alert.Trigger(storedType: matchingRepeating.storedType, storedInterval: matchingRepeating.storedInterval, storedDateMatching: matchingRepeating.storedDateMatching))
         XCTAssertEqual(matchingRepeating, try? Alert.Trigger(storedType: matchingRepeating.storedType, storedInterval: matchingRepeating.storedInterval, storedDateMatching: matchingRepeating.storedDateMatching, storageDate: Self.historicDate))
         // An "expired" next matching alert become "immediate"
-        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: matching.storedType, storedInterval: matching.storedInterval, storedDateMatching: matching.storedDateMatching, storageDate: Self.historicDate))
+        XCTAssertEqual(immediate, try? Alert.Trigger(storedType: matching.storedType, storedInterval: matching.storedInterval, storedDateMatching: matching.storedDateMatching, storageDate: Self.longTimeAgo))
         // An "unexpired" next matching alert is "preserved"
         XCTAssertEqual(matching, try? Alert.Trigger(storedType: matching.storedType, storedInterval: matching.storedInterval, storedDateMatching: matching.storedDateMatching, storageDate: Date(timeIntervalSinceNow: -5.0)))
     }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -31,10 +31,10 @@ class AlertStoreTests: XCTestCase {
     static let repeatingAlertDelay = 30.0 // seconds
     static let repeatingAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier4", alertIdentifier: "alertIdentifier4")
     let repeatingAlert = Alert(identifier: repeatingAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .repeating(repeatInterval: repeatingAlertDelay), sound: nil)
-    static let matching = Alert.Trigger.TimeSpec(hourOfDay: 1, minuteOfHour: 2)
+    static let matching = Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 1, minuteOfHour: 2)
     static let dateMatchingAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier5", alertIdentifier: "alertIdentifier5")
     let dateMatchingAlert = Alert(identifier: dateMatchingAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .nextDate(matching: matching), sound: nil)
-    static let repeatMatching = Alert.Trigger.TimeSpec(hourOfDay: 3, minuteOfHour: 4)
+    static let repeatMatching = Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 3, minuteOfHour: 4)
     static let dateMatchingAlertRepeatingIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier6", alertIdentifier: "alertIdentifier6")
     let dateMatchingAlertRepeating = Alert(identifier: dateMatchingAlertRepeatingIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .nextDateRepeating(matching: repeatMatching), sound: nil)
 
@@ -50,8 +50,8 @@ class AlertStoreTests: XCTestCase {
         let immediate = Alert.Trigger.immediate
         let delayed = Alert.Trigger.delayed(interval: 1.0)
         let repeating = Alert.Trigger.repeating(repeatInterval: 2.0)
-        let matching = Alert.Trigger.nextDate(matching: Alert.Trigger.TimeSpec(hourOfDay: 1, minuteOfHour: 2))
-        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: Alert.Trigger.TimeSpec(hourOfDay: 3, minuteOfHour: 4))
+        let matching = Alert.Trigger.nextDate(matching: Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 1, minuteOfHour: 2))
+        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 3, minuteOfHour: 4))
         XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching))
         XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching))
         XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval, storedDateMatching: repeating.storedDateMatching))
@@ -64,8 +64,8 @@ class AlertStoreTests: XCTestCase {
         let immediate = Alert.Trigger.immediate
         let delayed = Alert.Trigger.delayed(interval: 10.0)
         let repeating = Alert.Trigger.repeating(repeatInterval: 20.0)
-        let matching = Alert.Trigger.nextDate(matching: Alert.Trigger.TimeSpec(hourOfDay: 1, minuteOfHour: 2))
-        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: Alert.Trigger.TimeSpec(hourOfDay: 3, minuteOfHour: 4))
+        let matching = Alert.Trigger.nextDate(matching: Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 1, minuteOfHour: 2))
+        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 3, minuteOfHour: 4))
         XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching))
         XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching, storageDate: Self.historicDate))
         XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching))

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -31,10 +31,10 @@ class AlertStoreTests: XCTestCase {
     static let repeatingAlertDelay = 30.0 // seconds
     static let repeatingAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier4", alertIdentifier: "alertIdentifier4")
     let repeatingAlert = Alert(identifier: repeatingAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .repeating(repeatInterval: repeatingAlertDelay), sound: nil)
-    static let matching = DateComponents(hour: 1, minute: 2)
+    static let matching = Alert.Trigger.TimeSpec(hourOfDay: 1, minuteOfHour: 2)
     static let dateMatchingAlertIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier5", alertIdentifier: "alertIdentifier5")
     let dateMatchingAlert = Alert(identifier: dateMatchingAlertIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .nextDate(matching: matching), sound: nil)
-    static let repeatMatching = DateComponents(hour: 3, minute: 4)
+    static let repeatMatching = Alert.Trigger.TimeSpec(hourOfDay: 3, minuteOfHour: 4)
     static let dateMatchingAlertRepeatingIdentifier = Alert.Identifier(managerIdentifier: "managerIdentifier6", alertIdentifier: "alertIdentifier6")
     let dateMatchingAlertRepeating = Alert(identifier: dateMatchingAlertRepeatingIdentifier, foregroundContent: nil, backgroundContent: nil, trigger: .nextDateRepeating(matching: repeatMatching), sound: nil)
 
@@ -50,8 +50,8 @@ class AlertStoreTests: XCTestCase {
         let immediate = Alert.Trigger.immediate
         let delayed = Alert.Trigger.delayed(interval: 1.0)
         let repeating = Alert.Trigger.repeating(repeatInterval: 2.0)
-        let matching = Alert.Trigger.nextDate(matching: DateComponents(hour: 1, minute: 2))
-        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: DateComponents(hour: 3, minute: 4))
+        let matching = Alert.Trigger.nextDate(matching: Alert.Trigger.TimeSpec(hourOfDay: 1, minuteOfHour: 2))
+        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: Alert.Trigger.TimeSpec(hourOfDay: 3, minuteOfHour: 4))
         XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching))
         XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching))
         XCTAssertEqual(repeating, try? Alert.Trigger(storedType: repeating.storedType, storedInterval: repeating.storedInterval, storedDateMatching: repeating.storedDateMatching))
@@ -64,8 +64,8 @@ class AlertStoreTests: XCTestCase {
         let immediate = Alert.Trigger.immediate
         let delayed = Alert.Trigger.delayed(interval: 10.0)
         let repeating = Alert.Trigger.repeating(repeatInterval: 20.0)
-        let matching = Alert.Trigger.nextDate(matching: DateComponents(hour: 1, minute: 2))
-        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: DateComponents(hour: 3, minute: 4))
+        let matching = Alert.Trigger.nextDate(matching: Alert.Trigger.TimeSpec(hourOfDay: 1, minuteOfHour: 2))
+        let matchingRepeating = Alert.Trigger.nextDateRepeating(matching: Alert.Trigger.TimeSpec(hourOfDay: 3, minuteOfHour: 4))
         XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching))
         XCTAssertEqual(immediate, try? Alert.Trigger(storedType: immediate.storedType, storedInterval: immediate.storedInterval, storedDateMatching: immediate.storedDateMatching, storageDate: Self.historicDate))
         XCTAssertEqual(delayed, try? Alert.Trigger(storedType: delayed.storedType, storedInterval: delayed.storedInterval, storedDateMatching: delayed.storedDateMatching))
@@ -248,7 +248,7 @@ class AlertStoreTests: XCTestCase {
     func testRecordRetractedBeforeDateMatchingShouldDelete() throws {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
-        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(-(.minutes(1))))
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching).dateComponents, matchingPolicy: .nextTime)?.addingTimeInterval(-(.minutes(1))))
         alertStore.recordIssued(alert: dateMatchingAlert, at: issuedDate, completion: self.expectSuccess {
             self.alertStore.recordRetraction(of: Self.dateMatchingAlertIdentifier, at: retractedDate, completion: self.expectSuccess {
                 self.alertStore.fetch(identifier: Self.dateMatchingAlertIdentifier, completion: self.expectSuccess { storedAlerts in
@@ -263,7 +263,7 @@ class AlertStoreTests: XCTestCase {
     func testRecordRetractedBeforeRepeatDateMatchingShouldDelete() throws {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
-        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(-(.minutes(1))))
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching).dateComponents, matchingPolicy: .nextTime)?.addingTimeInterval(-(.minutes(1))))
         alertStore.recordIssued(alert: dateMatchingAlertRepeating, at: issuedDate, completion: self.expectSuccess {
             self.alertStore.recordRetraction(of: Self.dateMatchingAlertRepeatingIdentifier, at: retractedDate, completion: self.expectSuccess {
                 self.alertStore.fetch(identifier: Self.dateMatchingAlertRepeatingIdentifier, completion: self.expectSuccess { storedAlerts in
@@ -308,7 +308,7 @@ class AlertStoreTests: XCTestCase {
     func testRecordRetractedExactlyAtDateMatchingShouldDelete() throws {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
-        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching), matchingPolicy: .nextTime))
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching).dateComponents, matchingPolicy: .nextTime))
         alertStore.recordIssued(alert: dateMatchingAlert, at: issuedDate, completion: self.expectSuccess {
             self.alertStore.recordRetraction(of: Self.dateMatchingAlertIdentifier, at: retractedDate, completion: self.expectSuccess {
                 self.alertStore.fetch(identifier: Self.dateMatchingAlertIdentifier, completion: self.expectSuccess { storedAlerts in
@@ -323,7 +323,7 @@ class AlertStoreTests: XCTestCase {
     func testRecordRetractedExactlyAtRepeatDateMatchingShouldDelete() throws {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
-        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching), matchingPolicy: .nextTime))
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching).dateComponents, matchingPolicy: .nextTime))
         alertStore.recordIssued(alert: dateMatchingAlertRepeating, at: issuedDate, completion: self.expectSuccess {
             self.alertStore.recordRetraction(of: Self.dateMatchingAlertRepeatingIdentifier, at: retractedDate, completion: self.expectSuccess {
                 self.alertStore.fetch(identifier: Self.dateMatchingAlertRepeatingIdentifier, completion: self.expectSuccess { storedAlerts in
@@ -357,7 +357,7 @@ class AlertStoreTests: XCTestCase {
     func testRecordRetractedAfterDateMatchingShouldRetract() throws {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
-        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(.minutes(1)))
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlert.trigger.matching).dateComponents, matchingPolicy: .nextTime)?.addingTimeInterval(.minutes(1)))
         alertStore.recordIssued(alert: dateMatchingAlert, at: issuedDate, completion: self.expectSuccess {
             self.alertStore.recordRetraction(of: Self.dateMatchingAlertIdentifier, at: retractedDate, completion: self.expectSuccess {
                 self.alertStore.fetch(identifier: Self.dateMatchingAlertIdentifier, completion: self.expectSuccess { storedAlerts in
@@ -376,7 +376,7 @@ class AlertStoreTests: XCTestCase {
     func testRecordRetractedAfterRepeatDateMatchingShouldRetract() throws {
         let expect = self.expectation(description: #function)
         let issuedDate = Self.historicDate
-        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching), matchingPolicy: .nextTime)?.addingTimeInterval(.minutes(1)))
+        let retractedDate = try XCTUnwrap(Calendar.current.nextDate(after: issuedDate, matching: try XCTUnwrap(dateMatchingAlertRepeating.trigger.matching).dateComponents, matchingPolicy: .nextTime)?.addingTimeInterval(.minutes(1)))
         alertStore.recordIssued(alert: dateMatchingAlertRepeating, at: issuedDate, completion: self.expectSuccess {
             self.alertStore.recordRetraction(of: Self.dateMatchingAlertRepeatingIdentifier, at: retractedDate, completion: self.expectSuccess {
                 self.alertStore.fetch(identifier: Self.dateMatchingAlertRepeatingIdentifier, completion: self.expectSuccess { storedAlerts in

--- a/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
@@ -340,7 +340,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
     }
     
     func testIssueNextDateMatchingAlert() throws {
-        let noon = DateComponents(hour: 12, minute: 0)
+        let noon = Alert.Trigger.TimeSpec(hourOfDay: 12, minuteOfHour: 0)
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: noon))
         mockViewController.autoComplete = false
         inAppModalAlertIssuer.issueAlert(alert)
@@ -350,7 +350,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
         XCTAssertNil(mockViewController.viewControllerPresented)
         XCTAssertNil(mockTimer)
         XCTAssertNotNil(mockDateMatchingTimer)
-        XCTAssertEqual(noon, mockDateMatchingTimerComponents)
+        XCTAssertEqual(noon.dateComponents, mockDateMatchingTimerComponents)
         XCTAssertEqual(false, mockDateMatchingTimerRepeats)
         XCTAssertFalse(inAppModalAlertIssuer.getPendingAlerts().isEmpty)
         try XCTUnwrap(mockDateMatchingTimer).fire()
@@ -364,7 +364,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
     }
     
     func testIssueNextDateMatchingRepeatingAlert() throws {
-        let noon = DateComponents(hour: 12, minute: 0)
+        let noon = Alert.Trigger.TimeSpec(hourOfDay: 12, minuteOfHour: 0)
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: noon))
         mockViewController.autoComplete = false
         inAppModalAlertIssuer.issueAlert(alert)
@@ -374,7 +374,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
         XCTAssertNil(mockViewController.viewControllerPresented)
         XCTAssertNil(mockTimer)
         XCTAssertNotNil(mockDateMatchingTimer)
-        XCTAssertEqual(noon, mockDateMatchingTimerComponents)
+        XCTAssertEqual(noon.dateComponents, mockDateMatchingTimerComponents)
         XCTAssertEqual(true, mockDateMatchingTimerRepeats)
         XCTAssertFalse(inAppModalAlertIssuer.getPendingAlerts().isEmpty)
         try XCTUnwrap(mockDateMatchingTimer).fire()

--- a/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/InAppModalAlertIssuerTests.swift
@@ -340,7 +340,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
     }
     
     func testIssueNextDateMatchingAlert() throws {
-        let noon = Alert.Trigger.TimeSpec(hourOfDay: 12, minuteOfHour: 0)
+        let noon = Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 12, minuteOfHour: 0)
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: noon))
         mockViewController.autoComplete = false
         inAppModalAlertIssuer.issueAlert(alert)
@@ -364,7 +364,7 @@ class InAppModalAlertIssuerTests: XCTestCase {
     }
     
     func testIssueNextDateMatchingRepeatingAlert() throws {
-        let noon = Alert.Trigger.TimeSpec(hourOfDay: 12, minuteOfHour: 0)
+        let noon = Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 12, minuteOfHour: 0)
         let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: noon))
         mockViewController.autoComplete = false
         inAppModalAlertIssuer.issueAlert(alert)

--- a/LoopTests/Managers/Alerts/StoredAlertTests.swift
+++ b/LoopTests/Managers/Alerts/StoredAlertTests.swift
@@ -122,7 +122,7 @@ class StoredAlertEncodableTests: XCTestCase {
             storedAlert.modificationCounter = 123
             storedAlert.retractedDate = dateFormatter.date(from: "2020-05-14T23:34:07Z")!
             storedAlert.sound = "Sound 1"
-            let matching = DateComponents(day: 5, hour: 12, minute: 0)
+            let matching = Alert.Trigger.TimeSpec(dayOfMonth: 5, hourOfDay: 12, minuteOfHour: 0)
             storedAlert.triggerDateMatching = matching
             storedAlert.triggerType = Alert.Trigger.nextDate(matching: matching).storedType
             try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
@@ -137,7 +137,11 @@ class StoredAlertEncodableTests: XCTestCase {
               "modificationCounter" : 123,
               "retractedDate" : "2020-05-14T23:34:07Z",
               "sound" : "Sound 1",
-              "triggerDateMatching" : {\n    "day" : 5,\n    "hour" : 12,\n    "minute" : 0\n  },
+              "triggerDateMatching" : {
+                "dayOfMonth" : 5,
+                "hourOfDay" : 12,
+                "minuteOfHour" : 0
+              },
               "triggerType" : 3
             }
             """

--- a/LoopTests/Managers/Alerts/StoredAlertTests.swift
+++ b/LoopTests/Managers/Alerts/StoredAlertTests.swift
@@ -110,6 +110,41 @@ class StoredAlertEncodableTests: XCTestCase {
         }
     }
 
+    func testEncodableDateMatching() throws {
+        managedObjectContext.performAndWait {
+            let storedAlert = StoredAlert(context: managedObjectContext)
+            storedAlert.acknowledgedDate = dateFormatter.date(from: "2020-05-14T22:38:14Z")!
+            storedAlert.alertIdentifier = "Alert Identifier 1"
+            storedAlert.backgroundContent = "Background Content 1"
+            storedAlert.foregroundContent = "Foreground Content 1"
+            storedAlert.issuedDate = dateFormatter.date(from: "2020-05-14T21:00:12Z")!
+            storedAlert.managerIdentifier = "Manager Identifier 1"
+            storedAlert.modificationCounter = 123
+            storedAlert.retractedDate = dateFormatter.date(from: "2020-05-14T23:34:07Z")!
+            storedAlert.sound = "Sound 1"
+            let matching = DateComponents(day: 5, hour: 12, minute: 0)
+            storedAlert.triggerDateMatching = matching
+            storedAlert.triggerType = Alert.Trigger.nextDate(matching: matching).storedType
+            try! assertStoredAlertEncodable(storedAlert, encodesJSON: """
+            {
+              "acknowledgedDate" : "2020-05-14T22:38:14Z",
+              "alertIdentifier" : "Alert Identifier 1",
+              "backgroundContent" : "Background Content 1",
+              "foregroundContent" : "Foreground Content 1",
+              "interruptionLevel" : "timeSensitive",
+              "issuedDate" : "2020-05-14T21:00:12Z",
+              "managerIdentifier" : "Manager Identifier 1",
+              "modificationCounter" : 123,
+              "retractedDate" : "2020-05-14T23:34:07Z",
+              "sound" : "Sound 1",
+              "triggerDateMatching" : {\n    "day" : 5,\n    "hour" : 12,\n    "minute" : 0\n  },
+              "triggerType" : 3
+            }
+            """
+            )
+        }
+    }
+
     func testEncodableOptional() throws {
         managedObjectContext.performAndWait {
             let storedAlert = StoredAlert(context: managedObjectContext)

--- a/LoopTests/Managers/Alerts/UserNotificationAlertIssuerTests.swift
+++ b/LoopTests/Managers/Alerts/UserNotificationAlertIssuerTests.swift
@@ -17,7 +17,7 @@ class UserNotificationAlertIssuerTests: XCTestCase {
     let alertIdentifier = Alert.Identifier(managerIdentifier: "foo", alertIdentifier: "bar")
     let foregroundContent = Alert.Content(title: "FOREGROUND", body: "foreground", acknowledgeActionButtonLabel: "")
     let backgroundContent = Alert.Content(title: "BACKGROUND", body: "background", acknowledgeActionButtonLabel: "")
-    let dateComponents = DateComponents(day: 1, hour: 2, minute: 3)
+    let timeSpec = Alert.Trigger.TimeSpec(dayOfMonth: 1, hourOfDay: 2, minuteOfHour: 3)
     
     var mockUserNotificationCenter: MockUserNotificationCenter!
     
@@ -111,7 +111,7 @@ class UserNotificationAlertIssuerTests: XCTestCase {
     }
     
     func testIssueDateMatchingAlert() {
-        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: dateComponents))
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDate(matching: timeSpec))
         userNotificationAlertIssuer.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
@@ -126,13 +126,13 @@ class UserNotificationAlertIssuerTests: XCTestCase {
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
             ], request.content.userInfo as? [String: String])
-            XCTAssertEqual(dateComponents, (request.trigger as? UNCalendarNotificationTrigger)?.dateComponents)
+            XCTAssertEqual(timeSpec.dateComponents, (request.trigger as? UNCalendarNotificationTrigger)?.dateComponents)
             XCTAssertEqual(false, (request.trigger as? UNCalendarNotificationTrigger)?.repeats)
         }
     }
     
     func testIssueDateMatchingRepeatingAlert() {
-        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: dateComponents))
+        let alert = Alert(identifier: alertIdentifier, foregroundContent: foregroundContent, backgroundContent: backgroundContent, trigger: .nextDateRepeating(matching: timeSpec))
         userNotificationAlertIssuer.issueAlert(alert, timestamp: Date.distantPast)
 
         waitOnMain()
@@ -147,7 +147,7 @@ class UserNotificationAlertIssuerTests: XCTestCase {
                 LoopNotificationUserInfoKey.managerIDForAlert.rawValue: alertIdentifier.managerIdentifier,
                 LoopNotificationUserInfoKey.alertTypeID.rawValue: alertIdentifier.alertIdentifier,
             ], request.content.userInfo as? [String: String])
-            XCTAssertEqual(dateComponents, (request.trigger as? UNCalendarNotificationTrigger)?.dateComponents)
+            XCTAssertEqual(timeSpec.dateComponents, (request.trigger as? UNCalendarNotificationTrigger)?.dateComponents)
             XCTAssertEqual(true, (request.trigger as? UNCalendarNotificationTrigger)?.repeats)
         }
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/COASTAL-460
See also https://github.com/tidepool-org/LoopKit/pull/440
- AlertStore (CoreData) now stores DateComponents, as binary JSON data
- Special code to handle alert retraction for alerts not yet triggered
- InAppModalAlertIssuer now supports these new triggers
- UserNotificationAlertIssuer now supports these new triggers
- unit tests
