### PR TITLE
COASTAL-651: Adds PersistedAlertStore for looking up outstanding alerts

### DIFF
--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -251,6 +251,28 @@ extension AlertManager {
     }
 }
 
+// MARK: AlertSearcher
+extension AlertManager: AlertSearcher {
+    public func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[Alert], Error>) -> Void) {
+        alertStore.lookupAllUnacknowledged(managerIdentifier: managerIdentifier) {
+            switch $0 {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let alerts):
+                do {
+                    let result = try alerts.map {
+                        try Alert(from: $0, adjustedForStorageTime: false)
+                    }
+                    completion(.success(result))
+                } catch {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+}
+
 // MARK: Extensions
 
 fileprivate extension SyncAlertObject {

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -253,7 +253,7 @@ extension AlertManager {
 
 // MARK: PersistedAlertStore
 extension AlertManager: PersistedAlertStore {
-    public func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
+    public func lookupAllUnretracted(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
         alertStore.lookupAllUnretracted(managerIdentifier: managerIdentifier) {
             switch $0 {
             case .failure(let error):
@@ -276,6 +276,28 @@ extension AlertManager: PersistedAlertStore {
         }
     }
 
+    public func lookupAllUnacknowledgedUnretracted(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
+        alertStore.lookupAllUnacknowledgedUnretracted(managerIdentifier: managerIdentifier) {
+            switch $0 {
+            case .failure(let error):
+                completion(.failure(error))
+            case .success(let alerts):
+                do {
+                    let result = try alerts.map {
+                        PersistedAlert(
+                            alert: try Alert(from: $0, adjustedForStorageTime: false),
+                            issuedDate: $0.issuedDate,
+                            retractedDate: $0.retractedDate,
+                            acknowledgedDate: $0.acknowledgedDate
+                        )
+                    }
+                    completion(.success(result))
+                } catch {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
 }
 
 // MARK: Extensions

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -186,7 +186,7 @@ extension AlertManager {
     }
 
     private func playbackAlertsFromAlertStore() {
-        alertStore.lookupAllUnacknowledged {
+        alertStore.lookupAllUnacknowledgedUnretracted {
             switch $0 {
             case .failure(let error):
                 self.log.error("Could not fetch unacknowledged alerts: %@", error.localizedDescription)
@@ -251,17 +251,22 @@ extension AlertManager {
     }
 }
 
-// MARK: AlertQuerier
-extension AlertManager: AlertQuerier {
-    public func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[Alert], Error>) -> Void) {
-        alertStore.lookupAllUnacknowledged(managerIdentifier: managerIdentifier) {
+// MARK: PersistedAlertStore
+extension AlertManager: PersistedAlertStore {
+    public func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
+        alertStore.lookupAllUnretracted(managerIdentifier: managerIdentifier) {
             switch $0 {
             case .failure(let error):
                 completion(.failure(error))
             case .success(let alerts):
                 do {
                     let result = try alerts.map {
-                        try Alert(from: $0, adjustedForStorageTime: false)
+                        PersistedAlert(
+                            alert: try Alert(from: $0, adjustedForStorageTime: false),
+                            issuedDate: $0.issuedDate,
+                            retractedDate: $0.retractedDate,
+                            acknowledgedDate: $0.acknowledgedDate
+                        )
                     }
                     completion(.success(result))
                 } catch {

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -251,8 +251,8 @@ extension AlertManager {
     }
 }
 
-// MARK: AlertSearcher
-extension AlertManager: AlertSearcher {
+// MARK: AlertQuerier
+extension AlertManager: AlertQuerier {
     public func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[Alert], Error>) -> Void) {
         alertStore.lookupAllUnacknowledged(managerIdentifier: managerIdentifier) {
             switch $0 {

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -128,16 +128,12 @@ extension AlertManager: AlertIssuer {
 
     public func issueAlert(_ alert: Alert) {
         handlers.forEach { $0.issueAlert(alert) }
-        let sema = DispatchSemaphore(value: 0)
-        alertStore.recordIssued(alert: alert) { _ in sema.signal() }
-        _ = sema.wait(timeout: DispatchTime.now() + 1)
+        alertStore.recordIssued(alert: alert)
     }
 
     public func retractAlert(identifier: Alert.Identifier) {
         handlers.forEach { $0.retractAlert(identifier: identifier) }
-        let sema = DispatchSemaphore(value: 0)
-        alertStore.recordRetraction(of: identifier) { _ in sema.signal() }
-        _ = sema.wait(timeout: DispatchTime.now() + 1)
+        alertStore.recordRetraction(of: identifier)
     }
 
     private func replayAlert(_ alert: Alert) {

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -128,12 +128,16 @@ extension AlertManager: AlertIssuer {
 
     public func issueAlert(_ alert: Alert) {
         handlers.forEach { $0.issueAlert(alert) }
-        alertStore.recordIssued(alert: alert)
+        let sema = DispatchSemaphore(value: 0)
+        alertStore.recordIssued(alert: alert) { _ in sema.signal() }
+        _ = sema.wait(timeout: DispatchTime.now() + 1)
     }
 
     public func retractAlert(identifier: Alert.Identifier) {
         handlers.forEach { $0.retractAlert(identifier: identifier) }
-        alertStore.recordRetraction(of: identifier)
+        let sema = DispatchSemaphore(value: 0)
+        alertStore.recordRetraction(of: identifier) { _ in sema.signal() }
+        _ = sema.wait(timeout: DispatchTime.now() + 1)
     }
 
     private func replayAlert(_ alert: Alert) {

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -126,14 +126,18 @@ public class AlertStore {
                              completion: completion)
     }
     
-    public func lookupAllUnacknowledged(completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+    public func lookupAllUnacknowledged(managerIdentifier: String? = nil, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
         managedObjectContext.perform {
             do {
                 let fetchRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
-                fetchRequest.predicate =  NSCompoundPredicate(andPredicateWithSubpredicates: [
+                var predicates = [
                     NSPredicate(format: "acknowledgedDate == nil"),
                     NSPredicate(format: "retractedDate == nil"),
-                ])
+                ]
+                if let managerIdentifier = managerIdentifier {
+                    predicates.insert(NSPredicate(format: "managerIdentifier = %@", managerIdentifier), at: 0)
+                }
+                fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
                 fetchRequest.sortDescriptors = [ NSSortDescriptor(key: "modificationCounter", ascending: true) ]
                 let result = try self.managedObjectContext.fetch(fetchRequest)
                 completion(.success(result))

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -126,7 +126,27 @@ public class AlertStore {
                              completion: completion)
     }
     
-    public func lookupAllUnacknowledged(managerIdentifier: String? = nil, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+    public func lookupAllUnretracted(managerIdentifier: String? = nil, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+        managedObjectContext.perform {
+            do {
+                let fetchRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()
+                var predicates = [
+                    NSPredicate(format: "retractedDate == nil"),
+                ]
+                if let managerIdentifier = managerIdentifier {
+                    predicates.insert(NSPredicate(format: "managerIdentifier = %@", managerIdentifier), at: 0)
+                }
+                fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+                fetchRequest.sortDescriptors = [ NSSortDescriptor(key: "modificationCounter", ascending: true) ]
+                let result = try self.managedObjectContext.fetch(fetchRequest)
+                completion(.success(result))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func lookupAllUnacknowledgedUnretracted(managerIdentifier: String? = nil, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
         managedObjectContext.perform {
             do {
                 let fetchRequest: NSFetchRequest<StoredAlert> = StoredAlert.fetchRequest()

--- a/Loop/Managers/Alerts/AlertStore.swift
+++ b/Loop/Managers/Alerts/AlertStore.swift
@@ -83,7 +83,7 @@ public class AlertStore {
     }
 
     public func recordIssued(alert: Alert, at date: Date = Date(), completion: ((Result<Void, Error>) -> Void)? = nil) {
-        self.managedObjectContext.perform {
+        self.managedObjectContext.performAndWait {
             _ = StoredAlert(from: alert, context: self.managedObjectContext, issuedDate: date)
             do {
                 try self.managedObjectContext.save()
@@ -196,7 +196,7 @@ extension AlertStore {
                                    addingPredicate predicate: NSPredicate,
                                    with updateBlock: @escaping ManagedObjectUpdateBlock,
                                    completion: ((Result<Void, Error>) -> Void)?) {
-        managedObjectContext.perform {
+        managedObjectContext.performAndWait {
             self.lookupAll(identifier: identifier, predicate: predicate) {
                 switch $0 {
                 case .success(let objects):
@@ -218,7 +218,7 @@ extension AlertStore {
                                       addingPredicate predicate: NSPredicate,
                                       with updateBlock: @escaping ManagedObjectUpdateBlock,
                                       completion: ((Result<Void, Error>) -> Void)?) {
-        managedObjectContext.perform {
+        managedObjectContext.performAndWait {
             self.lookupLatest(identifier: identifier, predicate: predicate) {
                 switch $0 {
                 case .success(let object):

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -792,8 +792,14 @@ extension DeviceDataManager: AlertIssuer {
 
 // MARK: - PersistedAlertStore
 extension DeviceDataManager: PersistedAlertStore {
-    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void) {
-        alertManager?.lookupOutstandingAlerts(managerIdentifier: managerIdentifier, completion: completion)
+    func lookupAllUnretracted(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void) {
+        precondition(alertManager != nil)
+        alertManager.lookupAllUnretracted(managerIdentifier: managerIdentifier, completion: completion)
+    }
+    
+    func lookupAllUnacknowledgedUnretracted(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void) {
+        precondition(alertManager != nil)
+        alertManager.lookupAllUnacknowledgedUnretracted(managerIdentifier: managerIdentifier, completion: completion)
     }
 }
 

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -790,6 +790,13 @@ extension DeviceDataManager: AlertIssuer {
     }
 }
 
+// MARK: - AlertQuerier
+extension DeviceDataManager: AlertQuerier {
+    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Swift.Result<[Alert], Error>) -> Void) {
+        alertManager?.lookupOutstandingAlerts(managerIdentifier: managerIdentifier, completion: completion)
+    }
+}
+
 // MARK: - CGMManagerDelegate
 extension DeviceDataManager: CGMManagerDelegate {
     func cgmManagerWantsDeletion(_ manager: CGMManager) {

--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -790,9 +790,9 @@ extension DeviceDataManager: AlertIssuer {
     }
 }
 
-// MARK: - AlertQuerier
-extension DeviceDataManager: AlertQuerier {
-    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Swift.Result<[Alert], Error>) -> Void) {
+// MARK: - PersistedAlertStore
+extension DeviceDataManager: PersistedAlertStore {
+    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Swift.Result<[PersistedAlert], Error>) -> Void) {
         alertManager?.lookupOutstandingAlerts(managerIdentifier: managerIdentifier, completion: completion)
     }
 }

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -108,7 +108,7 @@ class AlertManagerTests: XCTestCase {
         }
 
         var storedAlerts = [StoredAlert]()
-        override public func lookupAllUnacknowledged(managerIdentifier: String?, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+        override public func lookupAllUnacknowledgedUnretracted(managerIdentifier: String?, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
             completion(.success(storedAlerts))
         }
     }

--- a/LoopTests/Managers/Alerts/AlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/AlertManagerTests.swift
@@ -108,7 +108,7 @@ class AlertManagerTests: XCTestCase {
         }
 
         var storedAlerts = [StoredAlert]()
-        override public func lookupAllUnacknowledged(completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
+        override public func lookupAllUnacknowledged(managerIdentifier: String?, completion: @escaping (Result<[StoredAlert], Error>) -> Void) {
             completion(.success(storedAlerts))
         }
     }

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -552,7 +552,7 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
-    func testLookupAllUnacknowledgedEmpty() {
+    func testLookupAllUnacknowledgedUnretractedEmpty() {
         let expect = self.expectation(description: #function)
         alertStore.lookupAllUnacknowledgedUnretracted(completion: expectSuccess { alerts in
             XCTAssertTrue(alerts.isEmpty)
@@ -561,7 +561,7 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
-    func testLookupAllUnacknowledgedOne() {
+    func testLookupAllUnacknowledgedUnretractedOne() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [(alert1, false, false)]) {
             self.alertStore.lookupAllUnacknowledgedUnretracted(completion: self.expectSuccess { alerts in
@@ -573,7 +573,7 @@ class AlertStoreTests: XCTestCase {
     }
     
     
-    func testLookupAllUnacknowledgedOneAcknowledged() {
+    func testLookupAllUnacknowledgedUnretractedOneAcknowledged() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [(alert1, true, false)]) {
             self.alertStore.lookupAllUnacknowledgedUnretracted(completion: self.expectSuccess { alerts in
@@ -584,7 +584,7 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
-    func testLookupAllUnacknowledgedSomeNot() {
+    func testLookupAllUnacknowledgedUnretractedSomeNot() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [
             (alert1, true, false),
@@ -599,7 +599,7 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
-    func testLookupAllUnacknowledgedSomeRetracted() {
+    func testLookupAllUnacknowledgedUnretractedSomeRetracted() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [
             (alert1, false, true),
@@ -614,6 +614,68 @@ class AlertStoreTests: XCTestCase {
         wait(for: [expect], timeout: Self.defaultTimeout)
     }
     
+    func testLookupAllUnretractedEmpty() {
+        let expect = self.expectation(description: #function)
+        alertStore.lookupAllUnretracted(completion: expectSuccess { alerts in
+            XCTAssertTrue(alerts.isEmpty)
+            expect.fulfill()
+        })
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    func testLookupAllUnretractedOne() {
+        let expect = self.expectation(description: #function)
+        fillWith(startDate: Self.historicDate, data: [(alert1, false, false)]) {
+            self.alertStore.lookupAllUnretracted(completion: self.expectSuccess { alerts in
+                self.assertEqual([self.alert1], alerts)
+                expect.fulfill()
+            })
+        }
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    
+    func testLookupAllUnretractedOneAcknowledged() {
+        let expect = self.expectation(description: #function)
+        fillWith(startDate: Self.historicDate, data: [(alert1, true, false)]) {
+            self.alertStore.lookupAllUnretracted(completion: self.expectSuccess { alerts in
+                self.assertEqual([self.alert1], alerts)
+                expect.fulfill()
+            })
+        }
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    func testLookupAllUnretractedSomeAcknowledgedSomeNot() {
+        let expect = self.expectation(description: #function)
+        fillWith(startDate: Self.historicDate, data: [
+            (alert1, true, false),
+            (alert2, false, false),
+            (alert1, false, false),
+        ]) {
+            self.alertStore.lookupAllUnretracted(completion: self.expectSuccess { alerts in
+                self.assertEqual([self.alert1, self.alert2, self.alert1], alerts)
+                expect.fulfill()
+            })
+        }
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+    
+    func testLookupAllUnretractedSomeRetracted() {
+        let expect = self.expectation(description: #function)
+        fillWith(startDate: Self.historicDate, data: [
+            (alert1, false, true),
+            (alert2, false, false),
+            (alert1, false, true)
+        ]) {
+            self.alertStore.lookupAllUnretracted(completion: self.expectSuccess { alerts in
+                self.assertEqual([self.alert2], alerts)
+                expect.fulfill()
+            })
+        }
+        wait(for: [expect], timeout: Self.defaultTimeout)
+    }
+
     func testLookupAllAcknowledgedUnretractedRepeatingAlertsAll() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [

--- a/LoopTests/Managers/Alerts/AlertStoreTests.swift
+++ b/LoopTests/Managers/Alerts/AlertStoreTests.swift
@@ -554,7 +554,7 @@ class AlertStoreTests: XCTestCase {
     
     func testLookupAllUnacknowledgedEmpty() {
         let expect = self.expectation(description: #function)
-        alertStore.lookupAllUnacknowledged(completion: expectSuccess { alerts in
+        alertStore.lookupAllUnacknowledgedUnretracted(completion: expectSuccess { alerts in
             XCTAssertTrue(alerts.isEmpty)
             expect.fulfill()
         })
@@ -564,7 +564,7 @@ class AlertStoreTests: XCTestCase {
     func testLookupAllUnacknowledgedOne() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [(alert1, false, false)]) {
-            self.alertStore.lookupAllUnacknowledged(completion: self.expectSuccess { alerts in
+            self.alertStore.lookupAllUnacknowledgedUnretracted(completion: self.expectSuccess { alerts in
                 self.assertEqual([self.alert1], alerts)
                 expect.fulfill()
             })
@@ -576,7 +576,7 @@ class AlertStoreTests: XCTestCase {
     func testLookupAllUnacknowledgedOneAcknowledged() {
         let expect = self.expectation(description: #function)
         fillWith(startDate: Self.historicDate, data: [(alert1, true, false)]) {
-            self.alertStore.lookupAllUnacknowledged(completion: self.expectSuccess { alerts in
+            self.alertStore.lookupAllUnacknowledgedUnretracted(completion: self.expectSuccess { alerts in
                 self.assertEqual([], alerts)
                 expect.fulfill()
             })
@@ -591,7 +591,7 @@ class AlertStoreTests: XCTestCase {
             (alert2, false, false),
             (alert1, false, false),
         ]) {
-            self.alertStore.lookupAllUnacknowledged(completion: self.expectSuccess { alerts in
+            self.alertStore.lookupAllUnacknowledgedUnretracted(completion: self.expectSuccess { alerts in
                 self.assertEqual([self.alert2, self.alert1], alerts)
                 expect.fulfill()
             })
@@ -606,7 +606,7 @@ class AlertStoreTests: XCTestCase {
             (alert2, false, false),
             (alert1, false, true)
         ]) {
-            self.alertStore.lookupAllUnacknowledged(completion: self.expectSuccess { alerts in
+            self.alertStore.lookupAllUnacknowledgedUnretracted(completion: self.expectSuccess { alerts in
                 self.assertEqual([self.alert2], alerts)
                 expect.fulfill()
             })


### PR DESCRIPTION
Adds ability to query CoreData for all outstanding (i.e. "unretracted") alerts from a given `managerIdentifier`.

https://tidepool.atlassian.net/browse/COASTAL-651

LWPR: https://github.com/tidepool-org/LoopWorkspace/pull/780