### PR TITLE
COASTAL-625: Relax requirement that HUDProvider needs to provide LevelHUDView

### DIFF
--- a/Common/Models/PumpManagerUI.swift
+++ b/Common/Models/PumpManagerUI.swift
@@ -12,7 +12,7 @@ import LoopKitUI
 
 typealias PumpManagerHUDViewRawValue = [String: Any]
 
-func PumpManagerHUDViewFromRawValue(_ rawValue: PumpManagerHUDViewRawValue, pluginManager: PluginManager) -> LevelHUDView? {
+func PumpManagerHUDViewFromRawValue(_ rawValue: PumpManagerHUDViewRawValue, pluginManager: PluginManager) -> BaseHUDView? {
     guard
         let identifier = rawValue["managerIdentifier"] as? String,
         let rawState = rawValue["hudProviderView"] as? HUDProvider.HUDViewRawState,

--- a/Loop Status Extension/StatusViewController.swift
+++ b/Loop Status Extension/StatusViewController.swift
@@ -223,7 +223,7 @@ class StatusViewController: UIViewController, NCWidgetProviding {
             }
 
             // Pump Status
-            let pumpManagerHUDView: LevelHUDView
+            let pumpManagerHUDView: BaseHUDView
             if let hudViewContext = context.pumpManagerHUDViewContext,
                 let contextHUDView = PumpManagerHUDViewFromRawValue(hudViewContext.pumpManagerHUDViewRawValue, pluginManager: self.pluginManager)
             {

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1509,7 +1509,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
         }
     }
 
-    private func addPumpManagerViewToHUD(_ view: LevelHUDView) {
+    private func addPumpManagerViewToHUD(_ view: BaseHUDView) {
         if let hudView = hudView {
             view.stateColors = .pumpStatus
             hudView.addPumpManagerProvidedHUDView(view)

--- a/LoopUI/Views/PumpStatusHUDView.swift
+++ b/LoopUI/Views/PumpStatusHUDView.swift
@@ -15,7 +15,7 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
     
     @IBOutlet public weak var basalRateHUD: BasalRateHUDView!
     
-    @IBOutlet public weak var pumpManagerProvidedHUD: LevelHUDView!
+    @IBOutlet public weak var pumpManagerProvidedHUD: BaseHUDView!
         
     override public var orderPriority: HUDViewOrderPriority {
         return 3
@@ -84,7 +84,7 @@ public final class PumpStatusHUDView: DeviceStatusHUDView, NibLoadable {
         pumpManagerProvidedHUD.removeFromSuperview()
     }
     
-    public func addPumpManagerProvidedHUDView(_ pumpManagerProvidedHUD: LevelHUDView) {
+    public func addPumpManagerProvidedHUDView(_ pumpManagerProvidedHUD: BaseHUDView) {
         self.pumpManagerProvidedHUD = pumpManagerProvidedHUD
         statusStackView.addArrangedSubview(self.pumpManagerProvidedHUD)
     }

--- a/LoopUI/Views/StatusBarHUDView.swift
+++ b/LoopUI/Views/StatusBarHUDView.swift
@@ -66,7 +66,7 @@ public class StatusBarHUDView: UIView, NibLoadable {
         pumpStatusHUD.removePumpManagerProvidedHUD()
     }
     
-    public func addPumpManagerProvidedHUDView(_ pumpManagerProvidedHUD: LevelHUDView) {
+    public func addPumpManagerProvidedHUDView(_ pumpManagerProvidedHUD: BaseHUDView) {
         pumpStatusHUD.addPumpManagerProvidedHUDView(pumpManagerProvidedHUD)
     }
 }


### PR DESCRIPTION
LevelHUDView is for providing a view that displays a thermometer level, which not all Pumps may provide.  This relaxes the requirement and just requires returning a BaseHUDView.

https://tidepool.atlassian.net/browse/COASTAL-625