### PR TITLE
LOOP-4025 Add note to bolus view.

### DIFF
--- a/Loop/View Controllers/CarbEntryViewController.swift
+++ b/Loop/View Controllers/CarbEntryViewController.swift
@@ -500,6 +500,7 @@ final class CarbEntryViewController: LoopChartsTableViewController, Identifiable
             potentialCarbEntry: updatedEntry,
             selectedCarbAbsorptionTimeEmoji: selectedDefaultAbsorptionTimeEmoji
         )
+        viewModel.generateRecommendationAndStartObserving()
 
         let bolusEntryView = BolusEntryView(viewModel: viewModel).environmentObject(deviceManager.displayGlucoseUnitObservable)
 

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1247,6 +1247,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             hostingController = DismissibleHostingController(rootView: bolusEntryView, isModalInPresentation: false)
         } else {
             let viewModel = BolusEntryViewModel(delegate: deviceManager, isManualGlucoseEntryEnabled: enableManualGlucoseEntry)
+            viewModel.generateRecommendationAndStartObserving()
             let bolusEntryView = BolusEntryView(viewModel: viewModel).environmentObject(deviceManager.displayGlucoseUnitObservable)
             hostingController = DismissibleHostingController(rootView: bolusEntryView, isModalInPresentation: false)
         }


### PR DESCRIPTION
* Adds an informative modal explaining why the suggested bolus might still leave the post-bolus forecast above range.
* Fixes an issue with tapping just outside the bolus amount textedit will clear the bolus, but not bring up the keyboard.
* Fix flashing of forecast graph as initial presentation was previously generating 7 forecast predictions, showing forecast before recommendation, and then after.
* Fixes an issue where the bolus view may continuously loop by triggering pump refresh, which is not needed.