### PR TITLE
LOOP-4093 Infer delivered loop-not-looping notifications on app becoming active

### DIFF
--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -243,6 +243,7 @@ class LoopAppManager: NSObject {
             ProfileExpirationAlerter.alertIfNeeded(viewControllerToPresentFrom: rootViewController)
         }
         deviceDataManager?.didBecomeActive()
+        loopAlertsManager.inferDeliveredLoopNotRunningNotifications()
     }
 
     // MARK: - Remote Notification

--- a/LoopTests/Managers/Alerts/LoopAlertManagerTests.swift
+++ b/LoopTests/Managers/Alerts/LoopAlertManagerTests.swift
@@ -68,29 +68,29 @@ class LoopAlertManagerTests: XCTestCase {
         XCTAssertEqual(4, UserDefaults.appGroup?.loopNotRunningNotifications.count)
     }
 
-    func testLoopDidCompleteAfter10MinutesDoesNotRecordAlert() {
+    func testLoopFailureFor10MinutesDoesNotRecordAlert() {
         loopAlertsManager.loopDidComplete()
         XCTAssertNil(mockAlertStore.issuedAlert)
         loopAlertsManager.getCurrentDate = { return Date().addingTimeInterval(.minutes(10))}
-        loopAlertsManager.loopDidComplete()
+        loopAlertsManager.inferDeliveredLoopNotRunningNotifications()
         XCTAssertNil(mockAlertStore.issuedAlert)
     }
 
-    func testLoopDidCompleteAfter30MinutesRecordsTimeSensitiveAlert() {
+    func testLoopFailureFor30MinutesRecordsTimeSensitiveAlert() {
         loopAlertsManager.loopDidComplete()
         XCTAssertNil(mockAlertStore.issuedAlert)
         loopAlertsManager.getCurrentDate = { return Date().addingTimeInterval(.minutes(30))}
-        loopAlertsManager.loopDidComplete()
-        XCTAssertEqual(4, UserDefaults.appGroup?.loopNotRunningNotifications.count)
+        loopAlertsManager.inferDeliveredLoopNotRunningNotifications()
+        XCTAssertEqual(3, UserDefaults.appGroup?.loopNotRunningNotifications.count)
         XCTAssertNotNil(mockAlertStore.issuedAlert)
         XCTAssertEqual(.timeSensitive, mockAlertStore.issuedAlert!.interruptionLevel)
     }
 
-    func testLoopDidCompleteAfter30MinutesRecordsCriticalAlert() {
+    func testLoopFailureFor65MinutesRecordsCriticalAlert() {
         loopAlertsManager.loopDidComplete()
         loopAlertsManager.getCurrentDate = { return Date().addingTimeInterval(.minutes(65))}
-        loopAlertsManager.loopDidComplete()
-        XCTAssertEqual(4, UserDefaults.appGroup?.loopNotRunningNotifications.count)
+        loopAlertsManager.inferDeliveredLoopNotRunningNotifications()
+        XCTAssertEqual(1, UserDefaults.appGroup?.loopNotRunningNotifications.count)
         XCTAssertNotNil(mockAlertStore.issuedAlert)
         XCTAssertEqual(.critical, mockAlertStore.issuedAlert!.interruptionLevel)
     }


### PR DESCRIPTION
We need to detect and log these deliveries sooner, rather than waiting for the next loop cycle, as that may be a long time.

https://tidepool.atlassian.net/browse/LOOP-4093