### PR TITLE
[COASTAL-872] Improve performance of generating simulated data

### DIFF
--- a/Loop/Extensions/DoseStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/DoseStore+SimulatedCoreData.swift
@@ -18,7 +18,7 @@ extension DoseStore {
     private var simulatedBolusPerDay: Int { 8 }
     private var simulatedBasalStartDateInterval: TimeInterval { .minutes(5) }
     private var simulatedOtherPerDay: Int { 1 }
-    private var simulatedLimit: Int { 10000 }
+    private var simulatedLimit: Int { 100 }
 
     func generateSimulatedHistoricalPumpEvents(completion: @escaping (Error?) -> Void) {
         generatedSimulatedHistoricalBasalPumpEvents() { error in

--- a/Loop/Extensions/DosingDecisionStore+SimulatedCoreData.swift
+++ b/Loop/Extensions/DosingDecisionStore+SimulatedCoreData.swift
@@ -16,7 +16,7 @@ extension DosingDecisionStore {
     private var historicalEndDate: Date { Date(timeIntervalSinceNow: -.hours(24)) }
 
     private var simulatedStartDateInterval: TimeInterval { .minutes(5) }
-    private var simulatedLimit: Int { 10000 }
+    private var simulatedLimit: Int { 100 }
 
     func generateSimulatedHistoricalDosingDecisionObjects(completion: @escaping (Error?) -> Void) {
         var startDate = Calendar.current.startOfDay(for: expireDate)

--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1763,7 +1763,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
             fatalError("\(#function) should be invoked only when simulated core data is enabled")
         }
 
-        presentActivityIndicator(title: "Simulated Core Data", message: "Generating simulated historical...") { dismissActivityIndicator in
+        presentActivityIndicator(title: "Simulated Core Data", message: "Generating simulated historical...\n\n The app must stay in the foreground. If the app enters the background before this action completes, a crash will occur. This action will take 15-30 mins.") { dismissActivityIndicator in
             self.deviceManager.purgeHistoricalCoreData() { error in
                 DispatchQueue.main.async {
                     if let error = error {


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/COASTAL-872

When profiling, I noticed that reducing the limit of simulated data for dosing decisions and doses improved performance as follows:

| simulatedLimit | iPhone Simulator | iPhone XR |
| --- | --- | --- |
| 10000 | ~26 mins | ~80 mins |
| 1000 | ~13 mins | ~35 mins |
| 100 | ~11 mins | ~28 mins |
