### PR TITLE
[LOOP-4349] corrected loop not looping rescheduling

### DIFF
--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -203,7 +203,7 @@ public final class AlertManager {
             )
 
             let request = UNNotificationRequest(
-                identifier: "\(LoopNotificationCategory.loopNotRunning.rawValue)\(failureInterval)",
+                identifier: "\(LoopNotificationCategory.loopNotRunning.rawValue)\(minutes)",
                 content: notificationContent,
                 trigger: trigger
             )


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4349

That test case failed for DIY, since critical alerts were not enabled. Updated to support both DIY and Tidepool