### PR TITLE
[LOOP-4349] Temp mute alert fix

### DIFF
--- a/Loop/Managers/AlertMuter.swift
+++ b/Loop/Managers/AlertMuter.swift
@@ -54,12 +54,12 @@ public class AlertMuter: ObservableObject {
         }
 
         func shouldMuteAlert(scheduledAt timeFromNow: TimeInterval = 0, now: Date = Date()) -> Bool {
-            guard timeFromNow >= 0 else { return false }
-
             guard let mutingEndTime = mutingEndTime else { return false }
 
             let alertTriggerTime = now.advanced(by: timeFromNow)
-            guard alertTriggerTime < mutingEndTime
+            guard let startTime = startTime,
+                  alertTriggerTime >= startTime,
+                  alertTriggerTime < mutingEndTime
             else { return false }
 
             return true


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4349

It does not matter if the alert trigger is in the past, just matters if the trigger happened between the start time and end time