### PR TITLE
LOOP-4796 Green Loop fix

### DIFF
--- a/Loop/Managers/ExtensionDataManager.swift
+++ b/Loop/Managers/ExtensionDataManager.swift
@@ -115,13 +115,9 @@ final class ExtensionDataManager {
                 unit: HKUnit.milligramsPerDeciliter,
                 startDate: Date(),
                 interval: TimeInterval(minutes: 5))
-
-            let lastLoopCompleted = Date(timeIntervalSinceNow: -TimeInterval(minutes: 0))
-        #else
-            let lastLoopCompleted = loopDataManager.lastLoopCompleted
         #endif
 
-        context.lastLoopCompleted = lastLoopCompleted
+        context.lastLoopCompleted = loopDataManager.lastLoopCompleted
 
         context.isClosedLoop = self.automaticDosingStatus.automaticDosingEnabled
 

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -468,6 +468,10 @@ final class LoopDataManager {
                 throw LoopError.invalidFutureGlucose(date: latestGlucose.startDate)
             }
 
+            guard startDate.timeIntervalSince(doseStore.lastAddedPumpData) <= LoopAlgorithm.inputDataRecencyInterval else {
+                throw LoopError.pumpDataTooOld(date: doseStore.lastAddedPumpData)
+            }
+
             var output = LoopAlgorithm.run(input: input)
 
             switch output.recommendationResult {

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -111,6 +111,8 @@ class LoopDataManagerTests: XCTestCase {
 
         now = dateFormatter.date(from: "2023-07-29T19:21:00Z")!
 
+        doseStore.lastAddedPumpData = now
+
         dosingDecisionStore = MockDosingDecisionStore()
         automaticDosingStatus = AutomaticDosingStatus(automaticDosingEnabled: true, isAutomaticDosingAllowed: true)
 


### PR DESCRIPTION
This fixes an erroneous return to green loop status when pump data is stale, but dosing calcs indicate in-range bg.

https://tidepool.atlassian.net/browse/LOOP-4796