### PR TITLE
[PAL-478] Uncertain delivery modal

### DIFF
--- a/Loop/Managers/DeliveryUncertaintyAlertManager.swift
+++ b/Loop/Managers/DeliveryUncertaintyAlertManager.swift
@@ -23,6 +23,7 @@ class DeliveryUncertaintyAlertManager {
     private func showUncertainDeliveryRecoveryView() {
         var controller = pumpManager.deliveryUncertaintyRecoveryViewController(colorPalette: .default, allowDebugFeatures: FeatureFlags.allowDebugFeatures)
         controller.completionDelegate = self
+        controller.modalPresentationStyle = .fullScreen
         self.alertPresenter.present(controller, animated: true)
     }
     


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/PAL-478

needed to trigger `viewDidAppear` to present the modal after dismissing the pump manager view, but it changes the presentation style. 