### PR TITLE
[LOOP-4852] clamp to min...max

### DIFF
--- a/Common/Extensions/Comparable.swift
+++ b/Common/Extensions/Comparable.swift
@@ -1,6 +1,6 @@
 //
 //  Comparable.swift
-//  WatchApp Extension
+//  Loop
 //
 //  Created by Michael Pangburn on 3/27/20.
 //  Copyright © 2020 LoopKit Authors. All rights reserved.

--- a/Common/Models/WatchPredictedGlucose.swift
+++ b/Common/Models/WatchPredictedGlucose.swift
@@ -16,7 +16,7 @@ struct WatchPredictedGlucose: Equatable {
     let values: [PredictedGlucoseValue]
 
     init?(values: [PredictedGlucoseValue]) {
-        guard values.count > 1 else {
+        guard values.count > 2 else {
             return nil
         }
         self.values = values

--- a/Common/Models/WatchPredictedGlucose.swift
+++ b/Common/Models/WatchPredictedGlucose.swift
@@ -16,7 +16,7 @@ struct WatchPredictedGlucose: Equatable {
     let values: [PredictedGlucoseValue]
 
     init?(values: [PredictedGlucoseValue]) {
-        guard values.count > 2 else {
+        guard values.count > 1 else {
             return nil
         }
         self.values = values
@@ -30,7 +30,7 @@ extension WatchPredictedGlucose: RawRepresentable {
     var rawValue: RawValue {
 
         return [
-            "v": values.map { Int16($0.quantity.doubleValue(for: .milligramsPerDeciliter)) },
+            "v": values.map { Int16($0.quantity.doubleValue(for: .milligramsPerDeciliter).clamped(to: Double(Int16.min)...Double(Int16.max))) },
             "d": values[0].startDate,
             "i": values[1].startDate.timeIntervalSince(values[0].startDate)
         ]

--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -298,7 +298,6 @@
 		89E08FC6242E7506000D719B /* CarbAndDateInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E08FC5242E7506000D719B /* CarbAndDateInput.swift */; };
 		89E08FC8242E76E9000D719B /* AnyTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E08FC7242E76E9000D719B /* AnyTransition.swift */; };
 		89E08FCA242E7714000D719B /* UIFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E08FC9242E7714000D719B /* UIFont.swift */; };
-		89E08FCC242E790C000D719B /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E08FCB242E790C000D719B /* Comparable.swift */; };
 		89E08FD0242E8B2B000D719B /* BolusConfirmationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E08FCF242E8B2B000D719B /* BolusConfirmationView.swift */; };
 		89E267FC2292456700A3F2AF /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E267FB2292456700A3F2AF /* FeatureFlags.swift */; };
 		89E267FD2292456700A3F2AF /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89E267FB2292456700A3F2AF /* FeatureFlags.swift */; };
@@ -370,6 +369,8 @@
 		B42D124328D371C400E43D22 /* AlertMuter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42D124228D371C400E43D22 /* AlertMuter.swift */; };
 		B43CF07E29434EC4008A520B /* HowMuteAlertWorkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43CF07D29434EC4008A520B /* HowMuteAlertWorkView.swift */; };
 		B43DA44124D9C12100CAFF4E /* DismissibleHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43DA44024D9C12100CAFF4E /* DismissibleHostingController.swift */; };
+		B455C7332BD14E25002B847E /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B455C7322BD14E25002B847E /* Comparable.swift */; };
+		B455C7352BD14E30002B847E /* Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B455C7322BD14E25002B847E /* Comparable.swift */; };
 		B470F5842AB22B5100049695 /* StatefulPluggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B470F5832AB22B5100049695 /* StatefulPluggable.swift */; };
 		B48B0BAC24900093009A48DE /* PumpStatusHUDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48B0BAB24900093009A48DE /* PumpStatusHUDView.swift */; };
 		B490A03F24D0550F00F509FA /* GlucoseRangeCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B490A03E24D0550F00F509FA /* GlucoseRangeCategory.swift */; };
@@ -1214,7 +1215,6 @@
 		89E08FC5242E7506000D719B /* CarbAndDateInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbAndDateInput.swift; sourceTree = "<group>"; };
 		89E08FC7242E76E9000D719B /* AnyTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyTransition.swift; sourceTree = "<group>"; };
 		89E08FC9242E7714000D719B /* UIFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFont.swift; sourceTree = "<group>"; };
-		89E08FCB242E790C000D719B /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		89E08FCF242E8B2B000D719B /* BolusConfirmationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusConfirmationView.swift; sourceTree = "<group>"; };
 		89E267FB2292456700A3F2AF /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		89E267FE229267DF00A3F2AF /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
@@ -1279,6 +1279,7 @@
 		B42D124228D371C400E43D22 /* AlertMuter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertMuter.swift; sourceTree = "<group>"; };
 		B43CF07D29434EC4008A520B /* HowMuteAlertWorkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HowMuteAlertWorkView.swift; sourceTree = "<group>"; };
 		B43DA44024D9C12100CAFF4E /* DismissibleHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissibleHostingController.swift; sourceTree = "<group>"; };
+		B455C7322BD14E25002B847E /* Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comparable.swift; sourceTree = "<group>"; };
 		B470F5832AB22B5100049695 /* StatefulPluggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatefulPluggable.swift; sourceTree = "<group>"; };
 		B48B0BAB24900093009A48DE /* PumpStatusHUDView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PumpStatusHUDView.swift; sourceTree = "<group>"; };
 		B490A03C24D04F9400F509FA /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
@@ -1878,7 +1879,6 @@
 				898ECA64218ABD9A001E9D35 /* CGRect.swift */,
 				4328E0221CFBE2C500E199AA /* CLKComplicationTemplate.swift */,
 				89FE21AC24AC57E30033F501 /* Collection.swift */,
-				89E08FCB242E790C000D719B /* Comparable.swift */,
 				4F7E8AC420E2AB9600AEA65E /* Date.swift */,
 				43785E952120E4010057DED1 /* INRelevantShortcutStore+Loop.swift */,
 				4328E0231CFBE2C500E199AA /* NSUserDefaults+WatchApp.swift */,
@@ -2445,9 +2445,10 @@
 		4FF4D0FC1E1834CC00846527 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B455C7322BD14E25002B847E /* Comparable.swift */,
 				4372E48A213CB5F00068E043 /* Double.swift */,
-				4F526D5E1DF2459000A04910 /* HKUnit.swift */,
 				43C513181E864C4E001547C7 /* GlucoseRangeSchedule.swift */,
+				4F526D5E1DF2459000A04910 /* HKUnit.swift */,
 				43785E922120A01B0057DED1 /* NewCarbEntryIntent+Loop.swift */,
 				430DA58D1D4AEC230097D1CA /* NSBundle.swift */,
 				439897341CD2F7DE00223065 /* NSTimeInterval.swift */,
@@ -3596,6 +3597,7 @@
 				89CA2B32226C18B8004D9350 /* TestingScenariosTableViewController.swift in Sources */,
 				43E93FB71E469A5100EAB8DB /* HKUnit.swift in Sources */,
 				43C05CAF21EB2C24006FB252 /* NSBundle.swift in Sources */,
+				B455C7332BD14E25002B847E /* Comparable.swift in Sources */,
 				A91D2A3F26CF0FF80023B075 /* IconTitleSubtitleTableViewCell.swift in Sources */,
 				A967D94C24F99B9300CDDF8A /* OutputStream.swift in Sources */,
 				1DB1065124467E18005542BD /* AlertManager.swift in Sources */,
@@ -3720,6 +3722,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				894F6DDD243C0A2300CCE676 /* CarbAmountLabel.swift in Sources */,
+				B455C7352BD14E30002B847E /* Comparable.swift in Sources */,
 				89A605E524327F45009C1096 /* DoseVolumeInput.swift in Sources */,
 				4372E488213C862B0068E043 /* SampleValue.swift in Sources */,
 				89A605EB243288E4009C1096 /* TopDownTriangle.swift in Sources */,
@@ -3772,7 +3775,6 @@
 				89E08FCA242E7714000D719B /* UIFont.swift in Sources */,
 				4328E0281CFBE2C500E199AA /* CLKComplicationTemplate.swift in Sources */,
 				4328E01E1CFBE25F00E199AA /* CarbAndBolusFlowController.swift in Sources */,
-				89E08FCC242E790C000D719B /* Comparable.swift in Sources */,
 				432CF87520D8AC950066B889 /* NSUserDefaults+WatchApp.swift in Sources */,
 				89A1B66F24ABFDF800117AC2 /* SupportedBolusVolumesUserInfo.swift in Sources */,
 				43027F0F1DFE0EC900C51989 /* HKUnit.swift in Sources */,


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4852
https://console.firebase.google.com/u/2/project/tidepool-loop-coastal/crashlytics/app/ios:org.tidepool.coastal.Loop/issues/055d96bab0d6e101d1e25dff54e36806?time=last-ninety-days&types=crash&sessionEventKey=312bd21d80634d92aaa4c0181b644116_1931698829658476015

[updated] stack from the crash
> Thread 0 Crashed:
0   Loop                          	0x000000010303ca68 Swift runtime failure: Double value cannot be converted to Int16 because the result would be less than Int16.min + 0 (<compiler-generated>:0)
1   Loop                          	0x000000010303ca68 closure #1 in WatchPredictedGlucose.rawValue.getter + 4 (WatchPredictedGlucose.swift:33)
2   Loop                          	0x000000010303ca68 specialized Collection.map<A>(_:) + 4 (<compiler-generated>:0)
3   Loop                          	0x000000010303ca68 WatchPredictedGlucose.rawValue.getter + 792 (WatchPredictedGlucose.swift:33)
4   Loop                          	0x000000010303c888 closure #1 in WatchPredictedGlucose.rawValue.getter + 32 (WatchPredictedGlucose.swift:33)