### PR TITLE
LOOP-4803 Fix host identifier

### DIFF
--- a/Loop/Managers/ServicesManager.swift
+++ b/Loop/Managers/ServicesManager.swift
@@ -263,7 +263,13 @@ extension ServicesManager: StatefulPluggableDelegate {
 
 extension ServicesManager: ServiceDelegate {
     var hostIdentifier: String {
-        return "com.loopkit.Loop"
+        var identifier = Bundle.main.bundleIdentifier ?? "com.loopkit.Loop"
+        let components = identifier.components(separatedBy: ".")
+        // DIY Loop has bundle identifiers like com.UY653SP37Q.loopkit.Loop
+        if components[2] == "loopkit" && components[3] == "Loop" {
+            identifier = "com.loopkit.Looo"
+        }
+        return identifier
     }
 
     var hostVersion: String {


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4803

Host identifier is used by the TidepoolService plugin for a dataset name.