### PR TITLE
LOOP-4960 Upload settings on restart

### DIFF
--- a/Loop/Managers/DeviceDataManager.swift
+++ b/Loop/Managers/DeviceDataManager.swift
@@ -1263,11 +1263,11 @@ struct CancelTempBasalFailedMaximumBasalRateChangedError: LocalizedError {
 //MARK: - RemoteDataServicesManagerDelegate protocol conformance
 
 extension DeviceDataManager : RemoteDataServicesManagerDelegate {
-    var shouldSyncToRemoteService: Bool {
+    var shouldSyncGlucoseToRemoteService: Bool {
         guard let cgmManager = cgmManager else {
-            return onboardingManager?.isComplete == true
+            return true
         }
-        return cgmManager.shouldSyncToRemoteService && (onboardingManager?.isComplete == true)
+        return cgmManager.shouldSyncToRemoteService
     }
 }
 

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -341,6 +341,8 @@ class LoopAppManager: NSObject {
 
         settingsManager.remoteDataServicesManager = remoteDataServicesManager
 
+        remoteDataServicesManager.triggerAllUploads()
+
         servicesManager = ServicesManager(
             pluginManager: pluginManager,
             alertManager: alertManager,

--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -455,7 +455,8 @@ final class LoopDataManager: ObservableObject {
 
         var dosingDecision = StoredDosingDecision(
             date: loopBaseTime,
-            reason: "loop"
+            reason: "loop",
+            settings: StoredDosingDecision.Settings(settingsProvider.settings)
         )
 
         do {

--- a/Loop/Managers/RemoteDataServicesManager.swift
+++ b/Loop/Managers/RemoteDataServicesManager.swift
@@ -411,7 +411,7 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadGlucoseData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncGlucoseToRemoteService == true else { return }
+        guard delegate?.shouldSyncGlucoseToRemoteService != false else { return }
 
         uploadGroup.enter()
 

--- a/Loop/Managers/RemoteDataServicesManager.swift
+++ b/Loop/Managers/RemoteDataServicesManager.swift
@@ -187,7 +187,15 @@ final class RemoteDataServicesManager {
             }
         }
     }
-    
+
+    func triggerAllUploads() {
+        Task {
+            for type in RemoteDataType.allCases {
+                await performUpload(for: type)
+            }
+        }
+    }
+
     func triggerUpload(for triggeringType: RemoteDataType) {
         Task {
             await performUpload(for: triggeringType)
@@ -241,8 +249,6 @@ final class RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadAlertData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
-
         uploadGroup.enter()
 
         let key = UploadTaskKey(serviceIdentifier: remoteDataService.pluginIdentifier, remoteDataType: .alert)
@@ -278,8 +284,6 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadCarbData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
-
         uploadGroup.enter()
 
         let key = UploadTaskKey(serviceIdentifier: remoteDataService.pluginIdentifier, remoteDataType: .carb)
@@ -322,8 +326,6 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadDoseData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
-
         uploadGroup.enter()
 
         let key = UploadTaskKey(serviceIdentifier: remoteDataService.pluginIdentifier, remoteDataType: .dose)
@@ -366,8 +368,6 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadDosingDecisionData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
-
         uploadGroup.enter()
 
         let key = UploadTaskKey(serviceIdentifier: remoteDataService.pluginIdentifier, remoteDataType: .dosingDecision)
@@ -411,7 +411,7 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadGlucoseData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
+        guard delegate?.shouldSyncGlucoseToRemoteService == true else { return }
 
         uploadGroup.enter()
 
@@ -455,8 +455,6 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadPumpEventData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
-
         uploadGroup.enter()
 
         let key = UploadTaskKey(serviceIdentifier: remoteDataService.pluginIdentifier, remoteDataType: .pumpEvent)
@@ -499,8 +497,6 @@ extension RemoteDataServicesManager {
 
 extension RemoteDataServicesManager {
     private func uploadSettingsData(to remoteDataService: RemoteDataService) {
-        guard delegate?.shouldSyncToRemoteService == true else { return }
-
         uploadGroup.enter()
 
         let key = UploadTaskKey(serviceIdentifier: remoteDataService.pluginIdentifier, remoteDataType: .settings)
@@ -653,7 +649,7 @@ extension RemoteDataServicesManager {
 extension RemoteDataServicesManager: UploadEventListener { }
 
 protocol RemoteDataServicesManagerDelegate: AnyObject {
-    var shouldSyncToRemoteService: Bool { get }
+    var shouldSyncGlucoseToRemoteService: Bool { get }
 }
 
 


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4960

Also fixes a bug where turning off CGM upload flag on the simulator prevents upload of other non-cgm data, and fixes a bug where `loop` dosing decisions do not have the settings associated with them properly for upload