### PR TITLE
LOOP-4769 Premeal Storage

### DIFF
--- a/LoopTests/Managers/TemporaryPresetsManagerTests.swift
+++ b/LoopTests/Managers/TemporaryPresetsManagerTests.swift
@@ -34,7 +34,6 @@ class TemporaryPresetsManagerTests: XCTestCase {
     }
 
     func testPreMealOverride() {
-        var settings = self.settings
         let preMealStart = Date()
         manager.enablePreMealOverride(at: preMealStart, for: 1 /* hour */ * 60 * 60)
         let actualPreMealRange = manager.effectiveGlucoseTargetRangeSchedule()?.quantityRange(at: preMealStart.addingTimeInterval(30 /* minutes */ * 60))
@@ -42,7 +41,6 @@ class TemporaryPresetsManagerTests: XCTestCase {
     }
 
     func testPreMealOverrideWithPotentialCarbEntry() {
-        var settings = self.settings
         let preMealStart = Date()
         manager.enablePreMealOverride(at: preMealStart, for: 1 /* hour */ * 60 * 60)
         let actualRange = manager.effectiveGlucoseTargetRangeSchedule(presumingMealEntry: true)?.value(at: preMealStart.addingTimeInterval(30 /* minutes */ * 60))
@@ -50,7 +48,6 @@ class TemporaryPresetsManagerTests: XCTestCase {
     }
 
     func testScheduleOverride() {
-        var settings = self.settings
         let overrideStart = Date()
         let overrideTargetRange = DoubleRange(minValue: 130, maxValue: 150)
         let override = TemporaryScheduleOverride(
@@ -69,36 +66,7 @@ class TemporaryPresetsManagerTests: XCTestCase {
         XCTAssertEqual(actualOverrideRange, overrideTargetRange)
     }
 
-    func testBothPreMealAndScheduleOverride() {
-        var settings = self.settings
-        let preMealStart = Date()
-        manager.enablePreMealOverride(at: preMealStart, for: 1 /* hour */ * 60 * 60)
-
-        let overrideStart = Date()
-        let overrideTargetRange = DoubleRange(minValue: 130, maxValue: 150)
-        let override = TemporaryScheduleOverride(
-            context: .custom,
-            settings: TemporaryScheduleOverrideSettings(
-                unit: .milligramsPerDeciliter,
-                targetRange: overrideTargetRange
-            ),
-            startDate: overrideStart,
-            duration: .finite(3 /* hours */ * 60 * 60),
-            enactTrigger: .local,
-            syncIdentifier: UUID()
-        )
-        manager.scheduleOverride = override
-
-        let actualPreMealRange = manager.effectiveGlucoseTargetRangeSchedule()?.quantityRange(at: preMealStart.addingTimeInterval(30 /* minutes */ * 60))
-        XCTAssertEqual(actualPreMealRange, preMealRange)
-
-        // The pre-meal range should be projected into the future, despite the simultaneous schedule override
-        let preMealRangeDuringOverride = manager.effectiveGlucoseTargetRangeSchedule()?.quantityRange(at: preMealStart.addingTimeInterval(2 /* hours */ * 60 * 60))
-        XCTAssertEqual(preMealRangeDuringOverride, preMealRange)
-    }
-
     func testScheduleOverrideWithExpiredPreMealOverride() {
-        var settings = self.settings
         manager.preMealOverride = TemporaryScheduleOverride(
             context: .preMeal,
             settings: TemporaryScheduleOverrideSettings(targetRange: preMealRange),


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-4769

This fixes storage of premeal preset activations, so they can be uploaded, and persist across Loop restarts.