### PR TITLE
QAE-484 Simple Meal Calculator Test Automation

### DIFF
--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -263,6 +263,7 @@ struct BolusEntryView: View {
                 )
                 bolusUnitsLabel
             }
+            .accessibilityIdentifier("textField_Bolus")
         }
     }
 

--- a/Loop/Views/ManualEntryDoseView.swift
+++ b/Loop/Views/ManualEntryDoseView.swift
@@ -204,6 +204,7 @@ struct ManualEntryDoseView: View {
             }
         }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("textField_Bolus")
     }
 
     private var bolusUnitsLabel: some View {

--- a/Loop/Views/SimpleBolusView.swift
+++ b/Loop/Views/SimpleBolusView.swift
@@ -133,7 +133,7 @@ struct SimpleBolusView: View {
             .padding([.top, .bottom], 5)
             .fixedSize()
             .modifier(LabelBackground())
-            .accessibilityIdentifier("Carbohydrates Field")
+            .accessibilityIdentifier("textField_Carbohydrates")
         }
     }
 
@@ -155,7 +155,7 @@ struct SimpleBolusView: View {
                 .onAppear {
                     shouldGlucoseEntryBecomeFirstResponder = true
                 }
-                .accessibilityIdentifier("Current Glucose Field")
+                .accessibilityIdentifier("textField_CurrentGlucose")
 
                 glucoseUnitsLabel
             }
@@ -174,7 +174,7 @@ struct SimpleBolusView: View {
                         .font(.title)
                         .foregroundColor(Color(.label))
                         .padding([.top, .bottom], 4)
-                        .accessibilityIdentifier("Recommended Bolus Amount")
+                        .accessibilityIdentifier("staticText_RecommendedBolus")
                     bolusUnitsLabel
                 }
             }
@@ -219,7 +219,7 @@ struct SimpleBolusView: View {
             }
             .fixedSize()
             .modifier(LabelBackground())
-            .accessibilityIdentifier("Bolus Field")
+            .accessibilityIdentifier("textField_Bolus")
         }
     }
 
@@ -280,6 +280,7 @@ struct SimpleBolusView: View {
         .disabled(viewModel.actionButtonDisabled)
         .buttonStyle(ActionButtonStyle(.primary))
         .padding()
+        .accessibilityIdentifier("button_bolusAction")
     }
     
     private func alert(for alert: SimpleBolusViewModel.Alert) -> SwiftUI.Alert {


### PR DESCRIPTION
- Updated accessibility identifiers added in QAE-456 to naming convention consistent with other identifiers
- Added identifiers to bolus field on other bolus screens. 
- Needed for Bolus/Carb Entry test automation

https://tidepool.atlassian.net/browse/QAE-484 