### PR TITLE
[QAE-486] Add No Recent Glucose and Fingerstick Glucose IDs

### DIFF
--- a/Loop/View Controllers/StatusTableViewController.swift
+++ b/Loop/View Controllers/StatusTableViewController.swift
@@ -1163,6 +1163,7 @@ final class StatusTableViewController: LoopChartsTableViewController {
                     let imageView = UIImageView(image: UIImage(named: "drop.circle"))
                     imageView.tintColor = .glucoseTintColor
                     cell.accessoryView = imageView
+                    cell.titleLabel.accessibilityIdentifier = "text_NoRecentGlucose"
                     return cell
                 }
             }

--- a/Loop/Views/BolusEntryView.swift
+++ b/Loop/Views/BolusEntryView.swift
@@ -344,6 +344,7 @@ struct BolusEntryView: View {
         )
         .buttonStyle(ActionButtonStyle(viewModel.primaryButton == .manualGlucoseEntry ? .primary : .secondary))
         .padding([.top, .horizontal])
+        .accessibilityIdentifier("button_EnterFingerstickGlucose")
     }
 
     private var actionButton: some View {

--- a/Loop/Views/ManualGlucoseEntryRow.swift
+++ b/Loop/Views/ManualGlucoseEntryRow.swift
@@ -50,7 +50,7 @@ struct ManualGlucoseEntryRow: View {
                 .onChange(of: displayGlucosePreference.unit, perform: { value in
                     unitsChanged()
                 })
-
+                .accessibilityIdentifier("textField_FingerstickGlucose")
                 Text(displayGlucosePreference.formatter.localizedUnitStringWithPlurality())
                     .foregroundColor(Color(.secondaryLabel))
             }


### PR DESCRIPTION

Adding these IDs for Closed Loop Bolus test automation. Needed for associated QAE ticket.
