### PR TITLE
LOOP-5351 Preset guardrail fixes.

### DIFF
--- a/Loop/Managers/SettingsManager.swift
+++ b/Loop/Managers/SettingsManager.swift
@@ -345,7 +345,7 @@ extension SettingsManager {
         case .legacyWorkout:
             return legacyWorkoutPresetGuardrail
         default:
-            return customPresetGuardRail
+            return Guardrail.temporaryPresetCorrectionRange
         }
     }
 
@@ -371,10 +371,6 @@ extension SettingsManager {
         } else {
             return Guardrail.correctionRange
         }
-    }
-
-    public var customPresetGuardRail: Guardrail<LoopQuantity> {
-        return Guardrail.temporaryPresetCorrectionRange(suspendThreshold: settings.suspendThreshold)
     }
 
     func savePreset(_ preset: SelectablePreset) {

--- a/Loop/Views/Presets/CreatePresetView.swift
+++ b/Loop/Views/Presets/CreatePresetView.swift
@@ -101,7 +101,7 @@ struct CreatePresetView: View {
                             NewPresetRangeEdit(
                                 preset: $preset,
                                 path: $path,
-                                guardrail: Guardrail.temporaryPresetCorrectionRange(suspendThreshold: suspendThreshold),
+                                guardrail: Guardrail.temporaryPresetCorrectionRange,
                                 scheduledRange: scheduledRange,
                                 onCancel: { dismiss() }
                             )

--- a/Loop/Views/Presets/PresetRangeEditor.swift
+++ b/Loop/Views/Presets/PresetRangeEditor.swift
@@ -14,6 +14,8 @@ struct PresetRangeEditor: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.guidanceColors) private var guidanceColors
     @EnvironmentObject private var displayGlucosePreference: DisplayGlucosePreference
+    @Environment(\.settingsManager) private var settingsManager
+
 
     @State private var presentInfoView: Bool = false
     @Binding var range: ClosedRange<LoopQuantity>?
@@ -125,7 +127,7 @@ struct PresetRangeEditor: View {
                     get: { displayedRange },
                     set: { range = $0 }),
                                    unit: displayGlucosePreference.unit,
-                                   minValue: nil,
+                                   minValue: settingsManager.settings.suspendThreshold?.quantity,
                                    guardrail: guardrail)
                 .padding(.vertical, -20)
             }

--- a/Loop/Views/Presets/ReviewNewPresetView.swift
+++ b/Loop/Views/Presets/ReviewNewPresetView.swift
@@ -57,7 +57,11 @@ struct ReviewNewPresetView: View {
             sensitivitySection
 
             CardSection {
-                CorrectionRangePreview(range: preset.correctionRange, guardrail: Guardrail.correctionRange, scheduledRange: scheduledRange)
+                CorrectionRangePreview(
+                    range: preset.correctionRange,
+                    guardrail: Guardrail.temporaryPresetCorrectionRange,
+                    scheduledRange: scheduledRange
+                )
             }
 
             // Name Field


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5351

Preset correction guardrail for lower bound stays the same regardless of suspend threshold; we prevent selection of lower values with the minValue param