### PR TITLE
[LOOP-5533] corrected display of in-app alert for critical alert disabled

### DIFF
--- a/Loop/Managers/AlertPermissionsChecker.swift
+++ b/Loop/Managers/AlertPermissionsChecker.swift
@@ -235,7 +235,7 @@ extension AlertPermissionsChecker {
     }
 
     @MainActor
-    static func constructUnsafeNotificationPermissionsInAppAlert(alert: UnsafeNotificationPermissionAlert) async -> UIAlertController {
+    static func constructUnsafeNotificationPermissionsInAppAlert(alert: UnsafeNotificationPermissionAlert, acknowledgementCompletion: @escaping (UnsafeNotificationPermissionAlert) -> Void) -> UIAlertController {
         let alertController = UIAlertController(title: alert.alertTitle,
                                                 message: alert.alertBody,
                                                 preferredStyle: .alert)
@@ -247,19 +247,16 @@ extension AlertPermissionsChecker {
         titleWithImage.append(NSMutableAttributedString(string: alert.alertTitle, attributes: [.font: UIFont.preferredFont(forTextStyle: .headline)]))
         alertController.setValue(titleWithImage, forKey: "attributedTitle")
 
-        await withCheckedContinuation { continuation in
-            alertController.addAction(UIAlertAction(title: NSLocalizedString("Settings", comment: "Label of button that navigation user to iOS Settings"),
-                                                    style: .default,
-                                                    handler: { _ in
-                AlertPermissionsChecker.gotoSettings()
-                continuation.resume()
-            }))
-            alertController.addAction(UIAlertAction(title: NSLocalizedString("Close", comment: "The button label of the action used to dismiss the unsafe notification permission alert"),
-                                                    style: .cancel,
-                                                    handler: { _ in
-                continuation.resume()
-            }))
-        }
+        alertController.addAction(UIAlertAction(title: NSLocalizedString("Settings", comment: "Label of button that navigation user to iOS Settings"),
+                                                style: .default,
+                                                handler: { _ in
+            AlertPermissionsChecker.gotoSettings()
+            acknowledgementCompletion(alert)
+        }))
+        alertController.addAction(UIAlertAction(title: NSLocalizedString("Close", comment: "The button label of the action used to dismiss the unsafe notification permission alert"),
+                                                style: .cancel,
+                                                handler: { _ in acknowledgementCompletion(alert) })
+        )
 
         return alertController
     }

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -743,16 +743,15 @@ extension AlertManager: AlertPermissionsCheckerDelegate {
 
     private func presentUnsafeNotificationPermissionsInAppAlert(_ alert: AlertPermissionsChecker.UnsafeNotificationPermissionAlert) {
         Task { @MainActor in
-            let alertController = await AlertPermissionsChecker.constructUnsafeNotificationPermissionsInAppAlert(alert: alert)
-            for alert in AlertPermissionsChecker.UnsafeNotificationPermissionAlert.allCases {
+            let alertController = AlertPermissionsChecker.constructUnsafeNotificationPermissionsInAppAlert(alert: alert) { [weak self] alert in
                 UserDefaults.standard.hasIssuedNotificationPermissionsAlert = false
-                try await self.acknowledgeAlert(
-                    identifier: alert.alertIdentifier
-                )
+                Task {
+                    try await self?.acknowledgeAlert(identifier: alert.alertIdentifier)
+                }
             }
 
             await self.alertPresenter.present(alertController, animated: true)
-            // the completion is called after the alert is presented
+            // this is called after the alert is presented
             unsafeNotificationPermissionsAlertController = alertController
         }
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5533