### PR TITLE
[LOOP-1114] Wire MockSupport loading via SupportProviding

### DIFF
--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -443,6 +443,7 @@ class LoopAppManager: NSObject {
                                         deviceSupportDelegate: deviceDataManager,
                                         servicesManager: servicesManager,
                                         alertIssuer: alertManager)
+        servicesManager.supportManager = supportManager
         
         setWhitelistedDevices()
 

--- a/Loop/Managers/ServicesManager.swift
+++ b/Loop/Managers/ServicesManager.swift
@@ -29,6 +29,7 @@ class ServicesManager {
     
     weak var servicesManagerDelegate: ServicesManagerDelegate?
     weak var servicesManagerDosingDelegate: ServicesManagerDosingDelegate?
+    weak var supportManager: SupportManager?
     
     private var services = [Service]()
 
@@ -142,6 +143,9 @@ class ServicesManager {
             if let remoteDataService = service as? RemoteDataService {
                 remoteDataServicesManager.addService(remoteDataService)
             }
+            if let provider = service as? SupportProviding {
+                supportManager?.addSupport(provider.createSupport())
+            }
 
             saveState()
         }
@@ -149,6 +153,9 @@ class ServicesManager {
 
     public func removeActiveService(_ service: Service) {
         servicesLock.withLock {
+            if let provider = service as? SupportProviding {
+                supportManager?.removeSupport(provider.createSupport())
+            }
             if let remoteDataService = service as? RemoteDataService {
                 remoteDataServicesManager.removeService(remoteDataService)
             }
@@ -400,7 +407,9 @@ extension ServicesManager: ServiceOnboardingDelegate {
 }
 
 extension ServicesManager {
-    var availableSupports: [SupportUI] { activeServices.compactMap { $0 as? SupportUI } }
+    var availableSupports: [SupportUI] {
+        activeServices.compactMap { ($0 as? SupportUI) ?? ($0 as? SupportProviding)?.createSupport() }
+    }
 }
 
 // Service extension for rawValue

--- a/Loop/View Models/VersionUpdateViewModel.swift
+++ b/Loop/View Models/VersionUpdateViewModel.swift
@@ -34,7 +34,9 @@ public class VersionUpdateViewModel: ObservableObject {
     
     func footer(appName: String) -> String {
         switch versionUpdate {
-        case .required, .recommended:
+        case .required:
+            return NSLocalizedString("A critical update is available. Your app may not function correctly until you update to the latest version.", comment: "Software update description for required update")
+        case .recommended:
             return String(format: NSLocalizedString("A new version of %@ is available and is recommended to continue using the app.", comment: "Software update available section footer (1: app name)"), appName)
         case .available:
             return String(format: NSLocalizedString("A new version of %@ is available.", comment: "Required software update section footer (1: app name)"), appName)

--- a/Loop/Views/SettingsView.swift
+++ b/Loop/Views/SettingsView.swift
@@ -97,7 +97,7 @@ struct SettingsView: View {
                         servicesSection
                     }
 
-                    ForEach(pluginMenuItems) { item in
+                    ForEach(pluginMenuItems.filter({ $0.section != .support })) { item in
                         item.view
                     }
 
@@ -265,9 +265,8 @@ extension SettingsView {
     private var softwareUpdateSection: some View {
         Section(footer: Text(viewModel.versionUpdateViewModel.footer(appName: appName))) {
             NavigationLink(destination: viewModel.versionUpdateViewModel.softwareUpdateView) {
-                Text(NSLocalizedString("Software Update", comment: "Software update button link text"))
-                Spacer()
                 viewModel.versionUpdateViewModel.icon
+                Text(NSLocalizedString("Software Update", comment: "Software update button link text"))
             }
         }
     }


### PR DESCRIPTION
Add supportManager reference to ServicesManager so it can add/remove supports when SupportProviding services are added/removed. Update availableSupports to include SupportProviding services.

Filter plugin menu items in SettingsView to avoid duplicate support section entries. Update VersionUpdateViewModel footer for required updates and reorder software update icon placement.