### PR TITLE
[LOOP-1114] Add blocking modal and open loop enforcement for required updates.

### DIFF
--- a/Loop.xcodeproj/project.pbxproj
+++ b/Loop.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 		C138C6F82C1B8A2C00F08F1A /* GlucoseCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C138C6F72C1B8A2C00F08F1A /* GlucoseCondition.swift */; };
 		C13DA2B024F6C7690098BB29 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13DA2AF24F6C7690098BB29 /* UIViewController.swift */; };
 		C148CEE724FD91BD00711B3B /* DeliveryUncertaintyAlertManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C148CEE624FD91BD00711B3B /* DeliveryUncertaintyAlertManager.swift */; };
+		C151634E2FA2C9C800FEECE8 /* RequiredVersionUpdateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C151634D2FA2C9C800FEECE8 /* RequiredVersionUpdateView.swift */; };
 		C152B9F52C9C7D4A00ACBC06 /* AutomationHistoryEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C152B9F42C9C7D4A00ACBC06 /* AutomationHistoryEntry.swift */; };
 		C152B9F72C9C7EF100ACBC06 /* AutomationHistoryEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C152B9F62C9C7EF100ACBC06 /* AutomationHistoryEntryTests.swift */; };
 		C1550B0C2E6F249A009369DC /* LoopCircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1550B0B2E6F249A009369DC /* LoopCircleView.swift */; };
@@ -1409,6 +1410,7 @@
 		C13DA2AF24F6C7690098BB29 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		C148CEE624FD91BD00711B3B /* DeliveryUncertaintyAlertManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeliveryUncertaintyAlertManager.swift; sourceTree = "<group>"; };
 		C14952142995822A0095AA84 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		C151634D2FA2C9C800FEECE8 /* RequiredVersionUpdateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequiredVersionUpdateView.swift; sourceTree = "<group>"; };
 		C152B9F42C9C7D4A00ACBC06 /* AutomationHistoryEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationHistoryEntry.swift; sourceTree = "<group>"; };
 		C152B9F62C9C7EF100ACBC06 /* AutomationHistoryEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationHistoryEntryTests.swift; sourceTree = "<group>"; };
 		C1550B0B2E6F249A009369DC /* LoopCircleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopCircleView.swift; sourceTree = "<group>"; };
@@ -2215,6 +2217,7 @@
 				84E8BBAF2CC979300078E6CF /* Presets */,
 				B43B5C552EAFBF170096A6AE /* RecentGlucoseTableViewCell.swift */,
 				B43B5C532EAFBF110096A6AE /* RecentGlucoseTableViewCell.xib */,
+				C151634D2FA2C9C800FEECE8 /* RequiredVersionUpdateView.swift */,
 				1DE09BA824A3E23F009EE9F9 /* SettingsView.swift */,
 				DDC389FB2A2BC6670066E2E8 /* SettingsView+algorithmExperimentsSection.swift */,
 				C1DE5D22251BFC4D00439E49 /* SimpleBolusView.swift */,
@@ -3689,6 +3692,7 @@
 				433EA4C41D9F71C800CD78FB /* CommandResponseViewController.swift in Sources */,
 				E9B3552229358C440076AB04 /* MealDetectionManager.swift in Sources */,
 				C16DA84222E8E112008624C2 /* PluginManager.swift in Sources */,
+				C151634E2FA2C9C800FEECE8 /* RequiredVersionUpdateView.swift in Sources */,
 				43785E932120A01B0057DED1 /* NewCarbEntryIntent+Loop.swift in Sources */,
 				439A7944211FE22F0041B75F /* NSUserActivity.swift in Sources */,
 				4328E0331CFC091100E199AA /* WatchContext+LoopKit.swift in Sources */,

--- a/Loop/Managers/AlertPermissionsChecker.swift
+++ b/Loop/Managers/AlertPermissionsChecker.swift
@@ -74,10 +74,8 @@ public class AlertPermissionsChecker: ObservableObject {
                 if FeatureFlags.criticalAlertsEnabled {
                     newSettings.criticalAlertsDisabled = settings.criticalAlertSetting == .disabled
                 }
-                if #available(iOS 15.0, *) {
-                    newSettings.scheduledDeliveryEnabled = settings.scheduledDeliverySetting == .enabled
-                    newSettings.timeSensitiveDisabled = settings.alertSetting != .disabled && settings.timeSensitiveSetting == .disabled
-                }
+                newSettings.scheduledDeliveryEnabled = settings.scheduledDeliverySetting == .enabled
+                newSettings.timeSensitiveDisabled = settings.alertSetting != .disabled && settings.timeSensitiveSetting == .disabled
                 self.notificationCenterSettings = newSettings
                 completion?()
             }

--- a/Loop/Managers/Alerts/AlertManager.swift
+++ b/Loop/Managers/Alerts/AlertManager.swift
@@ -212,14 +212,10 @@ public final class AlertManager {
             notificationContent.title = NSLocalizedString("Loop Failure", comment: "The notification title for a loop failure")
             let shouldMuteAlert = alertMuter.shouldMuteAlert(scheduledAt: timeUntilNotification)
             if isCritical, FeatureFlags.criticalAlertsEnabled {
-                if #available(iOS 15.0, *) {
-                    notificationContent.interruptionLevel = .critical
-                }
+                notificationContent.interruptionLevel = .critical
                 notificationContent.sound = shouldMuteAlert ? .defaultCriticalSound(withAudioVolume: 0.0) : .defaultCritical
             } else {
-                if #available(iOS 15.0, *) {
-                    notificationContent.interruptionLevel = .timeSensitive
-                }
+                notificationContent.interruptionLevel = .timeSensitive
                 notificationContent.sound = shouldMuteAlert ? nil : .default
             }
             notificationContent.categoryIdentifier = LoopNotificationCategory.loopNotRunning.rawValue

--- a/Loop/Managers/Alerts/StoredAlert.swift
+++ b/Loop/Managers/Alerts/StoredAlert.swift
@@ -190,26 +190,11 @@ extension Alert.InterruptionLevel {
         // Since this is arbitrary anyway, might as well make it match iOS's values
         switch self {
         case .active:
-            if #available(iOS 15.0, *) {
-                return NSNumber(value: UNNotificationInterruptionLevel.active.rawValue)
-            } else {
-                // https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/active
-                return 1
-            }
+            return NSNumber(value: UNNotificationInterruptionLevel.active.rawValue)
         case .timeSensitive:
-            if #available(iOS 15.0, *) {
-                return NSNumber(value: UNNotificationInterruptionLevel.timeSensitive.rawValue)
-            } else {
-                // https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/timesensitive
-                return 2
-            }
+            return NSNumber(value: UNNotificationInterruptionLevel.timeSensitive.rawValue)
         case .critical:
-            if #available(iOS 15.0, *) {
-                return NSNumber(value: UNNotificationInterruptionLevel.critical.rawValue)
-            } else {
-                // https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/critical
-                return 3
-            }
+            return NSNumber(value: UNNotificationInterruptionLevel.critical.rawValue)
         }
     }
     

--- a/Loop/Managers/Alerts/UserNotificationAlertScheduler.swift
+++ b/Loop/Managers/Alerts/UserNotificationAlertScheduler.swift
@@ -69,9 +69,7 @@ fileprivate extension Alert {
         userNotificationContent.title = backgroundContent.title
         userNotificationContent.body = backgroundContent.body
         userNotificationContent.sound = userNotificationSound(muted: muted)
-        if #available(iOS 15.0, *) {
-            userNotificationContent.interruptionLevel = interruptionLevel.userNotificationInterruptLevel
-        }
+        userNotificationContent.interruptionLevel = interruptionLevel.userNotificationInterruptLevel
         userNotificationContent.categoryIdentifier = categoryIdentifier ?? ""
         userNotificationContent.threadIdentifier = identifier.value // Used to match categoryIdentifier, but I /think/ we want multiple threads for multiple alert types, no?
         userNotificationContent.userInfo = [

--- a/Loop/Managers/LoopAppManager.swift
+++ b/Loop/Managers/LoopAppManager.swift
@@ -101,6 +101,7 @@ class LoopAppManager: NSObject {
     private var statefulPluginManager: StatefulPluginManager!
     private var criticalEventLogExportManager: CriticalEventLogExportManager!
     private var deviceLog: PersistentDeviceLog!
+    private var requiredUpdateModalPresented = false
 
     // HealthStorePreferredGlucoseUnitDidChange will be notified once the user completes the health access form. Set to .milligramsPerDeciliter until then
     public private(set) var displayGlucosePreference = DisplayGlucosePreference(displayGlucoseUnit: .milligramsPerDeciliter)
@@ -444,7 +445,11 @@ class LoopAppManager: NSObject {
                                         servicesManager: servicesManager,
                                         alertIssuer: alertManager)
         servicesManager.supportManager = supportManager
-        
+
+        supportManager.onRequiredUpdate = { [weak self] in
+            self?.handleRequiredVersionUpdate()
+        }
+
         setWhitelistedDevices()
 
         onboardingManager = OnboardingManager(pluginManager: pluginManager,
@@ -759,6 +764,30 @@ class LoopAppManager: NSObject {
         deviceDataManager.deviceWhitelist = DeviceWhitelist(cgmDevices: Array(whitelistedCGMs), pumpDevices: Array(whitelistedPumps))
     }
 
+    private func handleRequiredVersionUpdate() {
+        settingsManager.mutateLoopSettings { settings in
+            settings.dosingEnabled = false
+        }
+        settingsViewModel.closedLoopPreference = false
+
+        guard !requiredUpdateModalPresented else { return }
+        requiredUpdateModalPresented = true
+
+        let appName = Bundle.main.bundleDisplayName
+        NotificationManager.sendRequiredUpdateNotification(appName: appName)
+
+        let updateView = RequiredVersionUpdateView(appName: appName) { [weak self] in
+            self?.supportManager.openAppStore()
+        }
+        let hostingController = UIHostingController(rootView: updateView)
+        hostingController.modalPresentationStyle = .overFullScreen
+        hostingController.modalTransitionStyle = .crossDissolve
+        hostingController.isModalInPresentation = true
+        hostingController.view.backgroundColor = .clear
+
+        rootViewController?.topmostViewController.present(hostingController, animated: true)
+    }
+
     private func isProtectedDataAvailable() -> Bool {
         let fileManager = FileManager.default
         do {
@@ -870,7 +899,8 @@ extension LoopAppManager: UNUserNotificationCenterDelegate {
              LoopNotificationCategory.remoteBolusFailure.rawValue,
              LoopNotificationCategory.remoteCarbs.rawValue,
              LoopNotificationCategory.remoteCarbsFailure.rawValue,
-             LoopNotificationCategory.missedMeal.rawValue:
+             LoopNotificationCategory.missedMeal.rawValue,
+             LoopNotificationCategory.requiredUpdate.rawValue:
             completionHandler([.badge, .sound, .list, .banner])
         default:
             // For all others, banners are not to be displayed while in the foreground

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -282,6 +282,24 @@ extension NotificationManager {
         }
     }
     
+    static func sendRequiredUpdateNotification(appName: String) {
+        let notification = UNMutableNotificationContent()
+        notification.title = String(format: NSLocalizedString("Required %1$@ App Update", comment: "The notification title for a required app update (1: app name)"), appName)
+        notification.body = String(format: NSLocalizedString("To continue to use %1$@, go to the App Store to install the latest version.", comment: "The notification body for a required app update (1: app name)"), appName)
+        if #available(iOS 15.0, *) {
+            notification.interruptionLevel = .critical
+        }
+        notification.sound = .defaultCritical
+
+        let request = UNNotificationRequest(
+            identifier: LoopNotificationCategory.requiredUpdate.rawValue,
+            content: notification,
+            trigger: nil
+        )
+
+        UNUserNotificationCenter.current().add(request)
+    }
+
     private static func remoteCarbEntryNotificationBody(amountInGrams: Double) -> String {
         return String(format: NSLocalizedString("Remote Carbs Entry: %d grams", comment: "The carb amount message for a remote carbs entry notification. (1: Carb amount in grams)"), Int(amountInGrams))
     }

--- a/Loop/Managers/NotificationManager.swift
+++ b/Loop/Managers/NotificationManager.swift
@@ -286,9 +286,7 @@ extension NotificationManager {
         let notification = UNMutableNotificationContent()
         notification.title = String(format: NSLocalizedString("Required %1$@ App Update", comment: "The notification title for a required app update (1: app name)"), appName)
         notification.body = String(format: NSLocalizedString("To continue to use %1$@, go to the App Store to install the latest version.", comment: "The notification body for a required app update (1: app name)"), appName)
-        if #available(iOS 15.0, *) {
-            notification.interruptionLevel = .critical
-        }
+        notification.interruptionLevel = .critical
         notification.sound = .defaultCritical
 
         let request = UNNotificationRequest(

--- a/Loop/Managers/SettingsManager.swift
+++ b/Loop/Managers/SettingsManager.swift
@@ -444,13 +444,8 @@ private extension NotificationSettings {
         let timeSensitiveSetting: NotificationSettings.NotificationSetting
         let scheduledDeliverySetting: NotificationSettings.NotificationSetting
 
-        if #available(iOS 15.0, *) {
-            timeSensitiveSetting = NotificationSettings.NotificationSetting(notificationSettings.timeSensitiveSetting)
-            scheduledDeliverySetting = NotificationSettings.NotificationSetting(notificationSettings.scheduledDeliverySetting)
-        } else {
-            timeSensitiveSetting = .unknown
-            scheduledDeliverySetting = .unknown
-        }
+        timeSensitiveSetting = NotificationSettings.NotificationSetting(notificationSettings.timeSensitiveSetting)
+        scheduledDeliverySetting = NotificationSettings.NotificationSetting(notificationSettings.scheduledDeliverySetting)
 
         self.init(authorizationStatus: NotificationSettings.AuthorizationStatus(notificationSettings.authorizationStatus),
                   soundSetting: NotificationSettings.NotificationSetting(notificationSettings.soundSetting),

--- a/Loop/Managers/SupportManager.swift
+++ b/Loop/Managers/SupportManager.swift
@@ -37,6 +37,8 @@ public final class SupportManager {
         }
     }
     
+    var onRequiredUpdate: (() -> Void)?
+
     private let alertIssuer: AlertIssuer
     private let deviceSupportDelegate: DeviceSupportDelegate
     private let pluginManager: PluginManager
@@ -134,6 +136,9 @@ extension SupportManager {
         Task { @MainActor in
             let versionUpdate = await checkVersion()
             self.notify(versionUpdate)
+            if versionUpdate == .required {
+                self.onRequiredUpdate?()
+            }
         }
     }
     

--- a/Loop/Views/NotificationsCriticalAlertPermissionsView.swift
+++ b/Loop/Views/NotificationsCriticalAlertPermissionsView.swift
@@ -53,16 +53,12 @@ public struct NotificationsCriticalAlertPermissionsView: View {
             {
                 manageNotifications
                 notificationsEnabledStatus
-                if #available(iOS 15.0, *) {
-                    if !checker.notificationCenterSettings.notificationsDisabled {
-                        notificationDelivery
-                    }
+                if !checker.notificationCenterSettings.notificationsDisabled {
+                    notificationDelivery
                 }
                 criticalAlertsStatus
-                if #available(iOS 15.0, *) {
-                    if !checker.notificationCenterSettings.notificationsDisabled {
-                        timeSensitiveStatus
-                    }
+                if !checker.notificationCenterSettings.notificationsDisabled {
+                    timeSensitiveStatus
                 }
             }
             notificationAndCriticalAlertPermissionSupportSection

--- a/Loop/Views/RequiredVersionUpdateView.swift
+++ b/Loop/Views/RequiredVersionUpdateView.swift
@@ -1,0 +1,53 @@
+//
+//  RequiredVersionUpdateView.swift
+//  Loop
+//
+//  Copyright © 2026 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+struct RequiredVersionUpdateView: View {
+    let appName: String
+    let openAppStore: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .edgesIgnoringSafeArea(.all)
+
+            VStack(spacing: 16) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 40))
+                    .foregroundColor(.red)
+                    .padding(.top, 8)
+
+                Text(String(format: NSLocalizedString("Required %1$@ App Update", comment: "Title for required version update modal (1: app name)"), appName))
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+
+                VStack(spacing: 12) {
+                    Text(String(format: NSLocalizedString("A critical issue has been discovered in this version of %1$@.", comment: "Required update modal paragraph 1 (1: app name)"), appName))
+                    Text(String(format: NSLocalizedString("Until you update the app, you will not be able to use %1$@.", comment: "Required update modal paragraph 2 (1: app name)"), appName))
+                    Text(NSLocalizedString("Please go to the App Store to install the latest version.", comment: "Required update modal paragraph 3"))
+                }
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+
+                Divider()
+
+                Button(action: openAppStore) {
+                    Text(NSLocalizedString("App Store", comment: "Button title to open the App Store for a required update"))
+                        .fontWeight(.semibold)
+                }
+                .padding(.bottom, 8)
+            }
+            .padding(24)
+            .background(Color(.systemBackground))
+            .cornerRadius(14)
+            .shadow(radius: 10)
+            .padding(.horizontal, 40)
+        }
+    }
+}


### PR DESCRIPTION

When a support plugin returns .required from checkVersion, Loop now:
- Forces the app into open loop mode
- Sends a critical user notification
- Presents a non-dismissable modal with an App Store link

The modal and notification use the dynamic app name for white labeling.