### PR TITLE
[LOOP-5693] Cover carb history range in sensitivity/override queries

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -389,8 +389,15 @@ final class LoopDataManager: ObservableObject {
             recommendationEffectInterval: recommendationEffectInterval
         )
 
+        // Sensitivity and override timelines must also cover the carb history range so that
+        // any carb entry within that window (including a synthetic `potentialCarbEntry` later
+        // appended for a manual bolus recommendation) maps to an ISF and any active override.
+        // Otherwise `closestPrior(to: entry.startDate)` returns nil downstream and the algorithm
+        // traps in `CarbStatusBuilder` construction.
+        let scheduleQueryStart = min(neededSensitivityTimeline.start, carbsStart)
+
         let sensitivity = try await settingsProvider.getInsulinSensitivityHistory(
-            startDate: neededSensitivityTimeline.start,
+            startDate: scheduleQueryStart,
             endDate: neededSensitivityTimeline.end
         )
 
@@ -404,7 +411,7 @@ final class LoopDataManager: ObservableObject {
             throw LoopError.configurationError(.maximumBasalRatePerHour)
         }
 
-        var overrides = temporaryPresetsManager.presetHistory.getOverrideHistory(startDate: neededSensitivityTimeline.start, endDate: forecastEndTime)
+        var overrides = temporaryPresetsManager.presetHistory.getOverrideHistory(startDate: scheduleQueryStart, endDate: forecastEndTime)
 
         // For recommendation, we should consider preMeal override to be ending at time of dose
         if presumePresetEndingNow,

--- a/LoopTests/Managers/LoopDataManagerTests.swift
+++ b/LoopTests/Managers/LoopDataManagerTests.swift
@@ -459,6 +459,39 @@ class LoopDataManagerTests: XCTestCase {
 
     }
 
+    func testFetchDataSensitivityCoversCarbHistoryStart() async throws {
+        // A bolus recommendation may append a `potentialCarbEntry` with a startDate up to
+        // ~12h in the past. The sensitivity and override timelines must extend at least that
+        // far back; otherwise `closestPrior` on those timelines returns nil for the appended
+        // entry and `CarbStatusBuilder` construction traps. See LOOP-5693.
+        let input = try await loopDataManager.fetchData(for: now)
+        let carbsStart = now.addingTimeInterval(CarbMath.dateAdjustmentPast + .minutes(-1))
+
+        XCTAssertFalse(input.sensitivity.isEmpty)
+        XCTAssertLessThanOrEqual(input.sensitivity.first!.startDate, carbsStart)
+    }
+
+    func testRecommendManualBolusWithPastPotentialCarbEntryDoesNotCrash() async throws {
+        // Regression for LOOP-5693: a potential carb entry with a startDate older than the
+        // dose/glucose-derived sensitivity timeline used to trap inside LoopAlgorithm because
+        // the sensitivity schedule didn't cover the carb entry's startDate.
+        glucoseStore.storedGlucose = [
+            StoredGlucoseSample(startDate: d(.minutes(-13)), quantity: .glucose(value: 130)),
+            StoredGlucoseSample(startDate: d(.minutes(-8)), quantity: .glucose(value: 140)),
+            StoredGlucoseSample(startDate: d(.minutes(-3)), quantity: .glucose(value: 150)),
+        ]
+
+        let pastEntry = NewCarbEntry(
+            quantity: .carbs(value: 30),
+            startDate: d(.hours(-11)),
+            foodType: nil,
+            absorptionTime: .hours(3)
+        )
+
+        let recommendation = try await loopDataManager.recommendManualBolus(potentialCarbEntry: pastEntry)
+        XCTAssertNotNil(recommendation)
+    }
+
     func testFetchDataWithHighInsulinNeedsPresetMitigation() async throws {
         var input = try await loopDataManager.fetchData(for: now)
         XCTAssertEqual(input.target.count, 1)


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5693

## Summary
- `recommendManualBolus(potentialCarbEntry:)` appends a synthetic carb entry whose `startDate` can be up to ~12h in the past (the UI's allowed range). The sensitivity and override timelines, derived only from doses / glucose history / recommendation effect interval, often do not extend that far back.
- Once the synthetic entry is fed into the algorithm, `Collection<CarbEntry>.map(to:carbRatio:insulinSensitivity:…)` calls `closestPrior(to: entry.startDate)` on the sensitivity timeline, gets `nil`, and trips `preconditionFailure` inside `CarbStatusBuilder` construction — a hard crash on the main thread (Crashlytics reports point at `LoopAlgorithm/CarbMath.swift:717`).
- Widen the sensitivity and override queries in `fetchData` to also cover `carbsStart` (= `baseTime - 12h - 1min`), which already bounds the carb history.

## Test plan
- [x] New `testRecommendManualBolusWithPastPotentialCarbEntryDoesNotCrash` reproduces the crash on `dev` (verified to trap with `LoopAlgorithm/CarbMath.swift:717: Fatal error: Insulin sensitivity and carb ratio timelines must cover carb entry start dates`) and passes with this PR's fix applied.
- [x] New `testFetchDataSensitivityCoversCarbHistoryStart` asserts `input.sensitivity.first.startDate <= carbsStart`.
- [x] Full `LoopDataManagerTests` suite passes (14/14) on Xcode 26.5 iOS Simulator.