### PR TITLE
LOOP-5693 Fix CarbMath preconditionFailure when a carb entry predates the ISF window

### DIFF
--- a/Loop/Managers/LoopDataManager.swift
+++ b/Loop/Managers/LoopDataManager.swift
@@ -389,8 +389,15 @@ final class LoopDataManager: ObservableObject {
             recommendationEffectInterval: recommendationEffectInterval
         )
 
+        // Carb entries (and a backdated manual-bolus entry) can extend back to carbsStart, and
+        // CarbMath.map(to:) preconditionFailures if the ISF/carb-ratio timelines don't cover every
+        // carb entry's start date. timelineIntervalForSensitivity derives its window from dose and
+        // glucose history only — which can be more recent than carbsStart (e.g. after a CGM gap) —
+        // so extend the ISF (and override) window back to cover the carb window, matching carbRatio.
+        let sensitivityStart = min(neededSensitivityTimeline.start, carbsStart)
+
         let sensitivity = try await settingsProvider.getInsulinSensitivityHistory(
-            startDate: neededSensitivityTimeline.start,
+            startDate: sensitivityStart,
             endDate: neededSensitivityTimeline.end
         )
 
@@ -404,7 +411,7 @@ final class LoopDataManager: ObservableObject {
             throw LoopError.configurationError(.maximumBasalRatePerHour)
         }
 
-        var overrides = temporaryPresetsManager.presetHistory.getOverrideHistory(startDate: neededSensitivityTimeline.start, endDate: forecastEndTime)
+        var overrides = temporaryPresetsManager.presetHistory.getOverrideHistory(startDate: sensitivityStart, endDate: forecastEndTime)
 
         // For recommendation, we should consider preMeal override to be ending at time of dose
         if presumePresetEndingNow,


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-5693

## Crash

`preconditionFailure` in LoopAlgorithm `CarbMath.map(to:carbRatio:insulinSensitivity:…)`:

> Insulin sensitivity and carb ratio timelines must cover carb entry start dates

It fires when a carb entry's `startDate` is earlier than the earliest value in the insulin-sensitivity (or carb-ratio) history — `closestPrior(to: entry.startDate)` returns `nil`. Observed via `recommendManualBolus(…potentialCarbEntry:…)` → `LoopAlgorithm.run` → `generatePrediction` → `carbStatus.map(to:)`.

## Root cause

In `fetchData`, the two schedule windows are computed independently:

- **carbRatio** and the fetched **carb entries** go back to `carbsStart = baseTime − dateAdjustmentPast`.
- **insulinSensitivity** goes back to `neededSensitivityTimeline.start`, from `timelineIntervalForSensitivity(doses:glucoseHistoryStart:recommendationEffectInterval:)` — derived from **dose + glucose history only**, never the carb entries.

When dose/glucose history is more recent than `carbsStart` (a CGM gap, a fresh setup, or a carb entry backdated on the manual-bolus screen further than glucose reaches), an older carb entry has carb-ratio coverage but **no ISF coverage** → `insulinSensitivity.closestPrior == nil` → crash. `recommendManualBolus` is the common trigger because it appends the user's (possibly backdated) `potentialCarbEntry` on top of `fetchData`.

## Fix

Extend the ISF and override history back to `min(neededSensitivityTimeline.start, carbsStart)`, so it covers the same carb window as carbRatio. Small, contained change in `fetchData` (shared by the loop and `recommendManualBolus`).

## Follow-up (not in this PR)

The durable fix is upstream in LoopAlgorithm: `map(to:)` should clamp `closestPrior` to the earliest available schedule value (or drop uncoverable entries) rather than `preconditionFailure` — a data-driven path shouldn't hard-crash on a coverage gap.
